### PR TITLE
feat(core): opt-in subagent usage breakdown (--subagents)

### DIFF
--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -249,6 +249,7 @@ async fn load_wrapped_data(options: &WrappedOptions) -> Result<WrappedData> {
         year: Some(year.clone()),
         group_by: GroupBy::default(),
         scanner_settings: crate::tui::settings::load_scanner_settings(),
+        include_subagents: false,
     })
     .await
     .map_err(anyhow::Error::msg)?;

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -210,6 +210,11 @@ enum Commands {
         benchmark: bool,
         #[arg(long, help = "Disable spinner")]
         no_spinner: bool,
+        #[arg(
+            long,
+            help = "Include a subagent usage breakdown in the JSON (additive; does not change totals)"
+        )]
+        subagents: bool,
     },
     #[command(about = "Launch interactive TUI with optional filters")]
     Tui {
@@ -621,6 +626,7 @@ fn main() -> Result<()> {
             date,
             benchmark,
             no_spinner,
+            subagents,
         }) => {
             let today = date.today;
             let week = date.week;
@@ -637,6 +643,7 @@ fn main() -> Result<()> {
                 year,
                 benchmark,
                 no_spinner,
+                subagents,
             )
         }
         Some(Commands::Tui { clients, date }) => {
@@ -1770,6 +1777,7 @@ fn run_models_report(
                 year: year.clone(),
                 group_by: group_by.clone(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
+                include_subagents: false,
             })
             .await
         })
@@ -2542,6 +2550,7 @@ fn run_monthly_report(
                 year,
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
+                include_subagents: false,
             })
             .await
         })
@@ -2841,6 +2850,7 @@ fn run_hourly_report(
                 year,
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
+                include_subagents: false,
             })
             .await
         })
@@ -4477,6 +4487,7 @@ fn run_time_metrics_report(
                 year,
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
+                include_subagents: false,
             })
             .await
         })
@@ -4561,6 +4572,7 @@ fn run_graph_command(
     year: Option<String>,
     benchmark: bool,
     no_spinner: bool,
+    subagents: bool,
 ) -> Result<()> {
     use colored::Colorize;
     use std::time::Instant;
@@ -4602,6 +4614,7 @@ fn run_graph_command(
                 year,
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
+                include_subagents: subagents,
             })
             .await
         })
@@ -4615,7 +4628,20 @@ fn run_graph_command(
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
     let output_data = to_ts_token_contribution_data(&graph_result, None);
-    let json_output = serde_json::to_string_pretty(&output_data)?;
+    let json_output = if subagents {
+        // Attach the opt-in subagent breakdown as a separate top-level key so the
+        // shared contribution-data shape (and therefore the submit payload) stays
+        // byte-for-byte identical to the default output.
+        let mut value = serde_json::to_value(&output_data)?;
+        if let (serde_json::Value::Object(map), Some(summary)) =
+            (&mut value, graph_result.subagents.as_ref())
+        {
+            map.insert("subagents".to_string(), serde_json::to_value(summary)?);
+        }
+        serde_json::to_string_pretty(&value)?
+    } else {
+        serde_json::to_string_pretty(&output_data)?
+    };
 
     if let Some(output_path) = output {
         std::fs::write(&output_path, json_output)?;
@@ -5045,6 +5071,9 @@ fn run_submit_command(
                 year,
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings(),
+                // Submit path: never compute subagents — the submit payload must
+                // be identical with or without this feature.
+                include_subagents: false,
             })
             .await
         })

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -100,6 +100,114 @@ pub fn aggregate_by_session(messages: Vec<UnifiedMessage>) -> Vec<SessionContrib
     contributions
 }
 
+/// Per-agent usage rollup for the opt-in subagent breakdown.
+///
+/// An "agent" message is any message carrying an `agent` attribution (Claude
+/// Agent-tool subagents / sidechains). This is a purely additive view computed
+/// only when explicitly requested — it never participates in the token/cost
+/// totals (`aggregate_by_date`) and never affects dedup. Token totals use the
+/// same all-bucket sum as the daily aggregation so the share is comparable to
+/// the grand total.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct SubagentSummary {
+    pub total_tokens: i64,
+    pub total_messages: i64,
+    /// Distinct parent sessions that contained any subagent activity.
+    pub session_count: i64,
+    /// Distinct subagent invocations, keyed by `agent_run_id` when available
+    /// (falls back to `session_id|agent` for messages parsed before the
+    /// `agent_run_id` field existed).
+    pub invocation_count: i64,
+    /// Per-agent-name breakdown, sorted by tokens descending.
+    pub agents: Vec<SubagentEntry>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SubagentEntry {
+    pub name: String,
+    pub tokens: i64,
+    pub messages: i64,
+    pub sessions: i64,
+    pub invocations: i64,
+}
+
+/// Roll up every message that carries an `agent` attribution, by agent name.
+///
+/// Read-only over `messages`; does not mutate or remove anything, so it cannot
+/// change the grand total.
+pub fn aggregate_subagents(messages: &[UnifiedMessage]) -> SubagentSummary {
+    use std::collections::HashSet;
+
+    struct Acc {
+        tokens: i64,
+        messages: i64,
+        sessions: HashSet<String>,
+        invocations: HashSet<String>,
+    }
+
+    let mut by_agent: HashMap<String, Acc> = HashMap::new();
+    let mut all_sessions: HashSet<String> = HashSet::new();
+    let mut all_invocations: HashSet<String> = HashSet::new();
+    let mut total_tokens: i64 = 0;
+    let mut total_messages: i64 = 0;
+
+    for msg in messages {
+        let Some(agent) = msg.agent.as_ref() else {
+            continue;
+        };
+        let tokens = msg
+            .tokens
+            .input
+            .saturating_add(msg.tokens.output)
+            .saturating_add(msg.tokens.cache_read)
+            .saturating_add(msg.tokens.cache_write)
+            .saturating_add(msg.tokens.reasoning);
+        let messages_count = msg.message_count.max(0) as i64;
+
+        total_tokens = total_tokens.saturating_add(tokens);
+        total_messages = total_messages.saturating_add(messages_count);
+        all_sessions.insert(msg.session_id.clone());
+        // Combine the parent session with the per-invocation key so file-stem
+        // collisions across different parents cannot merge two invocations.
+        let invocation_key = match msg.agent_run_id.as_deref() {
+            Some(run_id) => format!("{}|{}", msg.session_id, run_id),
+            None => format!("{}|{}", msg.session_id, agent),
+        };
+        all_invocations.insert(invocation_key.clone());
+
+        let entry = by_agent.entry(agent.clone()).or_insert_with(|| Acc {
+            tokens: 0,
+            messages: 0,
+            sessions: HashSet::new(),
+            invocations: HashSet::new(),
+        });
+        entry.tokens = entry.tokens.saturating_add(tokens);
+        entry.messages = entry.messages.saturating_add(messages_count);
+        entry.sessions.insert(msg.session_id.clone());
+        entry.invocations.insert(invocation_key);
+    }
+
+    let mut agents: Vec<SubagentEntry> = by_agent
+        .into_iter()
+        .map(|(name, acc)| SubagentEntry {
+            name,
+            tokens: acc.tokens,
+            messages: acc.messages,
+            sessions: acc.sessions.len() as i64,
+            invocations: acc.invocations.len() as i64,
+        })
+        .collect();
+    agents.sort_by(|a, b| b.tokens.cmp(&a.tokens).then_with(|| a.name.cmp(&b.name)));
+
+    SubagentSummary {
+        total_tokens,
+        total_messages,
+        session_count: all_sessions.len() as i64,
+        invocation_count: all_invocations.len() as i64,
+        agents,
+    }
+}
+
 /// Calculate summary statistics
 pub fn calculate_summary(contributions: &[DailyContribution]) -> DataSummary {
     let total_tokens: i64 = contributions.iter().map(|c| c.totals.tokens).sum();
@@ -212,6 +320,7 @@ pub fn generate_graph_result(
         years,
         contributions,
         time_metrics: None,
+        subagents: None,
     }
 }
 
@@ -763,6 +872,7 @@ mod tests {
             duration_ms: None,
             message_count: 1,
             agent: None,
+            agent_run_id: None,
             dedup_key: None,
             is_turn_start: false,
         }
@@ -773,6 +883,73 @@ mod tests {
         let messages = Vec::new();
         let result = aggregate_by_date(messages);
         assert_eq!(result.len(), 0);
+    }
+
+    #[test]
+    fn test_aggregate_subagents_ignores_non_agent_messages() {
+        // A plain main-session message (agent: None) must not appear in the
+        // subagent rollup at all.
+        let plain = mock_unified_message("2024-01-01", 1000, 0.05, "claude-sonnet-4-5", "claude");
+        let result = aggregate_subagents(&[plain]);
+        assert_eq!(result.total_tokens, 0);
+        assert_eq!(result.session_count, 0);
+        assert_eq!(result.invocation_count, 0);
+        assert!(result.agents.is_empty());
+    }
+
+    #[test]
+    fn test_aggregate_subagents_counts_distinct_invocations() {
+        // Two messages share one invocation (agent-run-a), a third is a separate
+        // invocation (agent-run-b) in the same parent session, and a legacy row
+        // has no agent_run_id (falls back to session|agent).
+        let mut a1 = mock_unified_message("2024-01-01", 1000, 0.05, "claude-sonnet-4-5", "claude");
+        a1.session_id = "shared-parent".to_string();
+        a1.agent = Some("Explore".to_string());
+        a1.agent_run_id = Some("agent-run-a".to_string());
+
+        let mut a2 = mock_unified_message("2024-01-01", 1200, 0.06, "claude-sonnet-4-5", "claude");
+        a2.session_id = "shared-parent".to_string();
+        a2.agent = Some("Explore".to_string());
+        a2.agent_run_id = Some("agent-run-a".to_string());
+
+        let mut b = mock_unified_message("2024-01-01", 800, 0.04, "claude-sonnet-4-5", "claude");
+        b.session_id = "shared-parent".to_string();
+        b.agent = Some("Explore".to_string());
+        b.agent_run_id = Some("agent-run-b".to_string());
+
+        let mut legacy = mock_unified_message("2024-01-01", 600, 0.03, "claude-sonnet-4-5", "claude");
+        legacy.session_id = "legacy-parent".to_string();
+        legacy.agent = Some("Explore".to_string());
+
+        let result = aggregate_subagents(&[a1, a2, b, legacy]);
+
+        assert_eq!(result.session_count, 2, "shared-parent + legacy-parent");
+        assert_eq!(result.invocation_count, 3, "run-a, run-b, legacy fallback");
+        assert_eq!(result.total_messages, 4);
+        assert_eq!(result.agents.len(), 1);
+        assert_eq!(result.agents[0].name, "Explore");
+        assert_eq!(result.agents[0].sessions, 2);
+        assert_eq!(result.agents[0].invocations, 3);
+        assert_eq!(result.agents[0].messages, 4);
+    }
+
+    #[test]
+    fn test_aggregate_subagents_same_run_id_distinct_parents_not_merged() {
+        // The same file stem under two different parents must count as two
+        // invocations (the key combines session_id with agent_run_id).
+        let mut p1 = mock_unified_message("2024-01-01", 100, 0.01, "claude-sonnet-4-5", "claude");
+        p1.session_id = "parent-1".to_string();
+        p1.agent = Some("Explore".to_string());
+        p1.agent_run_id = Some("agent-dup".to_string());
+
+        let mut p2 = mock_unified_message("2024-01-01", 100, 0.01, "claude-sonnet-4-5", "claude");
+        p2.session_id = "parent-2".to_string();
+        p2.agent = Some("Explore".to_string());
+        p2.agent_run_id = Some("agent-dup".to_string());
+
+        let result = aggregate_subagents(&[p1, p2]);
+        assert_eq!(result.session_count, 2);
+        assert_eq!(result.invocation_count, 2);
     }
 
     #[test]
@@ -1303,6 +1480,7 @@ mod tests {
             cost,
             message_count: 1,
             agent: None,
+            agent_run_id: None,
             dedup_key: None,
             is_turn_start: false,
             duration_ms: None,

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -386,6 +386,11 @@ pub struct GraphResult {
     pub contributions: Vec<DailyContribution>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub time_metrics: Option<sessionize::TimeMetrics>,
+    /// Opt-in subagent breakdown. Populated only when
+    /// [`ReportOptions::include_subagents`] is set; omitted from JSON otherwise,
+    /// so default output (and the submit payload) is unchanged.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subagents: Option<aggregator::SubagentSummary>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -400,6 +405,11 @@ pub struct ReportOptions {
     /// Persistent scanner config loaded from `~/.config/tokens/settings.json`.
     /// Defaults to empty when callers don't care about user-configured paths.
     pub scanner_settings: scanner::ScannerSettings,
+    /// When true, compute the additive subagent breakdown and attach it to
+    /// [`GraphResult::subagents`]. Defaults to false so the CLI's default
+    /// output, totals, and submit payload are completely unaffected. Intended
+    /// for the menu bar app, which opts in via `tokens graph --subagents`.
+    pub include_subagents: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -1802,11 +1812,20 @@ async fn generate_graph_with_loaded_pricing(
         sessionize::compute_time_metrics(&intervals, sessionize::DEFAULT_IDLE_GAP_MS);
 
     let daily_active_time = sessionize::compute_daily_active_time(&intervals);
+    // Opt-in only: compute the additive subagent breakdown before `filtered` is
+    // moved into the daily aggregation. This is read-only and never alters the
+    // totals; when not requested we do no extra work at all.
+    let subagents = if options.include_subagents {
+        Some(aggregator::aggregate_subagents(&filtered))
+    } else {
+        None
+    };
     let contributions = aggregator::aggregate_by_date(filtered);
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
     let mut result = aggregator::generate_graph_result(contributions, processing_time_ms);
     result.time_metrics = Some(time_metrics);
+    result.subagents = subagents;
 
     for contribution in &mut result.contributions {
         if let Some(&ms) = daily_active_time.get(&contribution.date) {
@@ -2581,6 +2600,7 @@ pub fn parsed_to_unified(msg: &ParsedMessage, cost: f64) -> UnifiedMessage {
         duration_ms: msg.duration_ms,
         message_count: msg.message_count,
         agent: msg.agent.clone(),
+        agent_run_id: None,
         dedup_key: None,
         is_turn_start: false,
     }

--- a/crates/tokscale-core/src/message_cache.rs
+++ b/crates/tokscale-core/src/message_cache.rs
@@ -10,7 +10,9 @@ use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::time::UNIX_EPOCH;
 
-const CACHE_SCHEMA_VERSION: u32 = 16;
+// Bumped to 17: UnifiedMessage gained `agent_run_id` (per-invocation key for the
+// opt-in subagent breakdown); re-scan so cached sidechain messages populate it.
+const CACHE_SCHEMA_VERSION: u32 = 17;
 const CACHE_FILENAME: &str = "source-message-cache.bin";
 const CACHE_LOCK_FILENAME: &str = "source-message-cache.lock";
 const MAX_CACHE_FILE_BYTES: u64 = 256 * 1024 * 1024;

--- a/crates/tokscale-core/src/sessionize.rs
+++ b/crates/tokscale-core/src/sessionize.rs
@@ -352,6 +352,7 @@ mod tests {
             cost: 0.01,
             message_count: 1,
             agent: None,
+            agent_run_id: None,
             dedup_key: None,
             is_turn_start: false,
             duration_ms: None,

--- a/crates/tokscale-core/src/sessions/claudecode.rs
+++ b/crates/tokscale-core/src/sessions/claudecode.rs
@@ -384,6 +384,7 @@ pub fn parse_claude_file_with_cache_and_home(
     let mut last_provider_hint: Option<String> = None;
     // Sidechain detection state (resolved lazily on first parseable entry)
     let mut sidechain_agent: Option<String> = None;
+    let mut sidechain_run_id: Option<String> = None;
     let mut sidechain_detected = false;
 
     for line in reader.lines() {
@@ -416,6 +417,14 @@ pub fn parse_claude_file_with_cache_and_home(
                         entry.agent_id.as_deref(),
                         parent_cache,
                     ));
+                    // Each subagent invocation is written to its own transcript
+                    // file, so the file stem uniquely identifies the invocation.
+                    // (session_id is rewritten to the parent above, which is why
+                    // we need a separate per-invocation key.)
+                    sidechain_run_id = path
+                        .file_stem()
+                        .and_then(|stem| stem.to_str())
+                        .map(str::to_string);
                 }
             }
 
@@ -431,6 +440,7 @@ pub fn parse_claude_file_with_cache_and_home(
                         workspace_key: workspace_key.clone(),
                         workspace_label: workspace_label.clone(),
                         sidechain_agent: sidechain_agent.clone(),
+                        sidechain_run_id: sidechain_run_id.clone(),
                     },
                 );
 
@@ -583,6 +593,7 @@ pub fn parse_claude_file_with_cache_and_home(
                 );
                 unified.duration_ms = duration_ms;
                 unified.agent = sidechain_agent.clone();
+                unified.agent_run_id = sidechain_run_id.clone();
                 unified.set_workspace(workspace_key.clone(), workspace_label.clone());
                 // Mark the first assistant response after a user message as a turn start
                 if pending_turn_start {
@@ -818,6 +829,7 @@ struct ClaudeToolResultContext<'a> {
     workspace_key: Option<String>,
     workspace_label: Option<String>,
     sidechain_agent: Option<String>,
+    sidechain_run_id: Option<String>,
 }
 
 fn extract_claude_tool_result_message(
@@ -874,6 +886,7 @@ fn extract_claude_tool_result_message(
     );
     message.message_count = 0;
     message.agent = context.sidechain_agent;
+    message.agent_run_id = context.sidechain_run_id;
     message.set_workspace(context.workspace_key, context.workspace_label);
     Some(message)
 }
@@ -2201,6 +2214,11 @@ mod tests {
             messages[0].session_id, "parent-uuid-001",
             "Should use parent session ID from transcript, not filename"
         );
+        assert_eq!(
+            messages[0].agent_run_id,
+            Some("agent-abc123".to_string()),
+            "Subagent invocation key is the transcript file stem"
+        );
         assert_eq!(messages[0].tokens.input, 200);
         assert_eq!(messages[0].tokens.output, 80);
         assert_eq!(messages[0].tokens.cache_read, 50);
@@ -2340,7 +2358,9 @@ mod tests {
             messages[0].agent, None,
             "Main session messages must not have an agent"
         );
+        assert_eq!(messages[0].agent_run_id, None);
         assert_eq!(messages[1].agent, None);
+        assert_eq!(messages[1].agent_run_id, None);
     }
 
     #[test]

--- a/crates/tokscale-core/src/sessions/mod.rs
+++ b/crates/tokscale-core/src/sessions/mod.rs
@@ -49,6 +49,12 @@ pub struct UnifiedMessage {
     #[serde(default = "default_message_count")]
     pub message_count: i32,
     pub agent: Option<String>,
+    /// Identifies a single subagent invocation (the sidechain transcript file
+    /// stem). `Some` only for subagent/sidechain messages; `None` for normal
+    /// main-session messages. Used purely for the opt-in subagent breakdown —
+    /// it never affects token/cost totals or dedup.
+    #[serde(default)]
+    pub agent_run_id: Option<String>,
     pub dedup_key: Option<String>,
     /// True if this message is the first assistant response after a user turn.
     /// Used to count user interaction turns (as opposed to API message count).
@@ -291,6 +297,7 @@ impl UnifiedMessage {
             duration_ms: None,
             message_count: default_message_count(),
             agent,
+            agent_run_id: None,
             dedup_key,
             is_turn_start: false,
         }


### PR DESCRIPTION
## Summary

Adds an **opt-in** subagent usage breakdown intended for the menu bar app, built cleanly on top of the latest `main`. This is the Rust-only slice extracted from #3 — it is fully independent of the SwiftUI app and keeps every accuracy fix already on `main` (tool-result input tokens #622, codex fork dedup #630, cc-mirror #618, etc.).

The hard requirement throughout: **it never affects token/cost totals, the CLI's default output, or the submit payload.**

## What it does

- Tracks a per-invocation `agent_run_id` (the sidechain transcript file stem) on `UnifiedMessage`, set on both the assistant and tool-result parser paths. `None` for normal main-session messages.
- Adds `aggregator::aggregate_subagents` — a read-only rollup reporting distinct parent **sessions**, distinct **invocations**, and a per-agent breakdown. Because the session_id of a sidechain is rewritten to its parent (to avoid inflated session counts), `agent_run_id` is what lets us count individual runs. The invocation key combines `session_id` with `agent_run_id` so file-stem collisions across different parents can't merge two runs.
- Gates the whole thing behind `ReportOptions::include_subagents` (default `false`), exposed via `tokens graph --subagents`. The breakdown is attached as a **separate top-level JSON key**, so the shared contribution-data shape (and therefore the submit payload) is unchanged.

## Why it can't affect totals

- `aggregate_subagents` only borrows `&[UnifiedMessage]`; it never mutates or filters, so `aggregate_by_date` runs on identical data.
- Dedup is keyed on `messageId:requestId` (session-independent) — `agent_run_id` plays no part.
- Submit and every non-graph report command hardcode `include_subagents: false`.

Verified locally: `tokens graph` vs `tokens graph --subagents` produce identical totals (integer tokens exact; cost identical modulo pre-existing float summation-order noise) and an identical contribution payload once the additive `subagents` key is stripped.

## Notes

- Bumps the message cache schema `16 → 17` so cached sidechain messages repopulate the new field (one-time re-scan; no output changes).
- `tokens graph` default output, `submit`, `serve`, `wrapped`, `models`, `monthly`, `hourly` are untouched.

## Tests

- New `aggregate_subagents` unit tests (distinct invocations, collision-safe key, legacy fallback, non-agent messages ignored).
- Parser assertions that `agent_run_id` is the file stem for sidechains and `None` for main sessions.
- `cargo test -p tokscale-core`: 818 + new tests pass. `cargo clippy`: clean.
