### PR TITLE
feat(graph): per-client today work time + today-only incremental scan

### DIFF
--- a/crates/tokscale-cli/src/commands/wrapped.rs
+++ b/crates/tokscale-cli/src/commands/wrapped.rs
@@ -250,6 +250,8 @@ async fn load_wrapped_data(options: &WrappedOptions) -> Result<WrappedData> {
         group_by: GroupBy::default(),
         scanner_settings: crate::tui::settings::load_scanner_settings(),
         include_subagents: false,
+        include_work_time: false,
+        today_only: false,
     })
     .await
     .map_err(anyhow::Error::msg)?;

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -216,6 +216,16 @@ enum Commands {
             help = "Include a subagent usage breakdown in the JSON (additive; does not change totals)"
         )]
         subagents: bool,
+        #[arg(
+            long,
+            help = "Include today's per-client active work time in the JSON (additive; does not change totals)"
+        )]
+        work_time: bool,
+        #[arg(
+            long,
+            help = "Only scan files modified today — fast refresh of today's usage (skips historical files)"
+        )]
+        today_only: bool,
     },
     #[command(about = "Launch interactive TUI with optional filters")]
     Tui {
@@ -628,6 +638,8 @@ fn main() -> Result<()> {
             benchmark,
             no_spinner,
             subagents,
+            work_time,
+            today_only,
         }) => {
             let today = date.today;
             let week = date.week;
@@ -645,6 +657,8 @@ fn main() -> Result<()> {
                 benchmark,
                 no_spinner,
                 subagents,
+                work_time,
+                today_only,
             )
         }
         Some(Commands::Tui { clients, date }) => {
@@ -1817,6 +1831,8 @@ fn run_models_report(
                 group_by: group_by.clone(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
                 include_subagents: false,
+                include_work_time: false,
+                today_only: false,
             })
             .await
         })
@@ -2610,6 +2626,8 @@ fn run_monthly_report(
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
                 include_subagents: false,
+                include_work_time: false,
+                today_only: false,
             })
             .await
         })
@@ -2910,6 +2928,8 @@ fn run_hourly_report(
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
                 include_subagents: false,
+                include_work_time: false,
+                today_only: false,
             })
             .await
         })
@@ -4565,6 +4585,8 @@ fn run_time_metrics_report(
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
                 include_subagents: false,
+                include_work_time: false,
+                today_only: false,
             })
             .await
         })
@@ -4650,6 +4672,8 @@ fn run_graph_command(
     benchmark: bool,
     no_spinner: bool,
     subagents: bool,
+    work_time: bool,
+    today_only: bool,
 ) -> Result<()> {
     use colored::Colorize;
     use std::time::Instant;
@@ -4683,6 +4707,8 @@ fn run_graph_command(
                 group_by: GroupBy::default(),
                 scanner_settings: tui::settings::load_scanner_settings_for_home(&home_dir),
                 include_subagents: subagents,
+                include_work_time: work_time,
+                today_only,
             })
             .await
         })
@@ -4696,15 +4722,18 @@ fn run_graph_command(
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
     let output_data = to_ts_token_contribution_data(&graph_result, None);
-    let json_output = if subagents {
-        // Attach the opt-in subagent breakdown as a separate top-level key so the
-        // shared contribution-data shape (and therefore the submit payload) stays
+    let json_output = if subagents || work_time {
+        // Attach opt-in breakdowns as separate top-level keys so the shared
+        // contribution-data shape (and therefore the submit payload) stays
         // byte-for-byte identical to the default output.
         let mut value = serde_json::to_value(&output_data)?;
-        if let (serde_json::Value::Object(map), Some(summary)) =
-            (&mut value, graph_result.subagents.as_ref())
-        {
-            map.insert("subagents".to_string(), serde_json::to_value(summary)?);
+        if let serde_json::Value::Object(map) = &mut value {
+            if let Some(summary) = graph_result.subagents.as_ref() {
+                map.insert("subagents".to_string(), serde_json::to_value(summary)?);
+            }
+            if let Some(work) = graph_result.today_work_time.as_ref() {
+                map.insert("todayWorkTime".to_string(), serde_json::to_value(work)?);
+            }
         }
         serde_json::to_string_pretty(&value)?
     } else {
@@ -5142,6 +5171,8 @@ fn run_submit_command(
                 // Submit path: never compute subagents — the submit payload must
                 // be identical with or without this feature.
                 include_subagents: false,
+                include_work_time: false,
+                today_only: false,
             })
             .await
         })

--- a/crates/tokscale-core/src/aggregator.rs
+++ b/crates/tokscale-core/src/aggregator.rs
@@ -324,6 +324,7 @@ pub fn generate_graph_result(
         contributions,
         time_metrics: None,
         subagents: None,
+        today_work_time: None,
     }
 }
 

--- a/crates/tokscale-core/src/lib.rs
+++ b/crates/tokscale-core/src/lib.rs
@@ -391,6 +391,11 @@ pub struct GraphResult {
     /// so default output (and the submit payload) is unchanged.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subagents: Option<aggregator::SubagentSummary>,
+    /// Opt-in per-client active work time for today, in milliseconds. Populated
+    /// only when [`ReportOptions::include_work_time`] is set; omitted otherwise.
+    /// Read-only — never alters totals or the default/submit payload.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub today_work_time: Option<std::collections::HashMap<String, i64>>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -410,6 +415,15 @@ pub struct ReportOptions {
     /// output, totals, and submit payload are completely unaffected. Intended
     /// for the menu bar app, which opts in via `tokens graph --subagents`.
     pub include_subagents: bool,
+    /// When true, attach today's per-client active work time to
+    /// [`GraphResult::today_work_time`]. Opt-in like `include_subagents`; never
+    /// affects totals or default output. The menu bar opts in via
+    /// `tokens graph --work-time`.
+    pub include_work_time: bool,
+    /// When true, only scan transcript files modified today (skips historical
+    /// files at the filesystem layer) and keep only today's messages. Powers the
+    /// menu bar's fast "today" refresh. Opt-in; default false scans everything.
+    pub today_only: bool,
 }
 
 #[derive(Debug, Clone, serde::Serialize)]
@@ -511,7 +525,20 @@ fn parse_all_messages_with_pricing(
         pricing,
         true,
         &scanner::ScannerSettings::default(),
+        false,
     )
+}
+
+/// Local-timezone midnight (today, 00:00) as Unix ms. Used by today-only scans
+/// to drop files older than today. Returns None only on a DST midnight gap.
+fn local_today_start_ms() -> Option<i64> {
+    use chrono::{Local, TimeZone};
+    let midnight = Local::now().date_naive().and_hms_opt(0, 0, 0)?;
+    match Local.from_local_datetime(&midnight) {
+        chrono::LocalResult::Single(dt) => Some(dt.timestamp_millis()),
+        chrono::LocalResult::Ambiguous(dt, _) => Some(dt.timestamp_millis()),
+        chrono::LocalResult::None => None,
+    }
 }
 
 fn parse_all_messages_with_pricing_with_env_strategy(
@@ -520,6 +547,7 @@ fn parse_all_messages_with_pricing_with_env_strategy(
     pricing: Option<&pricing::PricingService>,
     use_env_roots: bool,
     scanner_settings: &scanner::ScannerSettings,
+    today_only: bool,
 ) -> Vec<UnifiedMessage> {
     #[derive(Debug)]
     struct CachedParseOutcome {
@@ -837,12 +865,19 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         parse_full_log_source(path, pricing, is_headless)
     }
 
-    let scan_result = scanner::scan_all_clients_with_scanner_settings(
+    let mut scan_result = scanner::scan_all_clients_with_scanner_settings(
         home_dir,
         clients,
         use_env_roots,
         scanner_settings,
     );
+    // today-only: drop every transcript not touched today before we read any of
+    // them, so the scan only pays for today's files (the menu bar's light scan).
+    if today_only {
+        if let Some(today_start) = local_today_start_ms() {
+            scan_result.retain_files_modified_since(today_start);
+        }
+    }
     let headless_roots = scanner::headless_roots_with_env_strategy(home_dir, use_env_roots);
     let mut source_cache = message_cache::SourceMessageCache::load();
     source_cache.prune_missing_files();
@@ -1577,6 +1612,7 @@ pub async fn get_model_report(options: ReportOptions) -> Result<ModelReport, Str
         pricing.as_deref(),
         options.use_env_roots,
         &options.scanner_settings,
+        false,
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
@@ -1633,6 +1669,7 @@ pub async fn get_monthly_report(options: ReportOptions) -> Result<MonthlyReport,
         pricing.as_deref(),
         options.use_env_roots,
         &options.scanner_settings,
+        false,
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
@@ -1725,6 +1762,7 @@ pub async fn get_hourly_report(options: ReportOptions) -> Result<HourlyReport, S
         pricing.as_deref(),
         options.use_env_roots,
         &options.scanner_settings,
+        false,
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
@@ -1819,6 +1857,7 @@ async fn generate_graph_with_loaded_pricing(
         pricing,
         options.use_env_roots,
         &options.scanner_settings,
+        options.today_only,
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
@@ -1847,6 +1886,15 @@ async fn generate_graph_with_loaded_pricing(
         if let Some(&ms) = daily_active_time.get(&contribution.date) {
             contribution.active_time_ms = Some(ms);
         }
+    }
+
+    // Opt-in: per-client active time for today, for the menu bar's work-time
+    // cards. Reuses the intervals already derived above — no extra scan. "Today"
+    // is the local-timezone date, matching the daily heatmap's attribution.
+    if options.include_work_time {
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        result.today_work_time =
+            Some(sessionize::compute_active_time_by_client_for_day(&intervals, &today));
     }
 
     Ok(result)
@@ -1878,6 +1926,7 @@ pub async fn get_time_metrics_report(options: ReportOptions) -> Result<TimeMetri
         None,
         options.use_env_roots,
         &options.scanner_settings,
+        false,
     );
 
     let filtered = filter_messages_for_report(all_messages, &options);
@@ -1918,6 +1967,14 @@ fn filter_messages_for_report(
 
     if let Some(until) = &options.until {
         filtered.retain(|m| m.date.as_str() <= until.as_str());
+    }
+
+    if options.today_only {
+        // File-level pruning leaves today's files, but a file touched today can
+        // still hold yesterday's tail (a session crossing midnight). Pin to today
+        // so a today-only report is exactly today.
+        let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+        filtered.retain(|m| m.date == today);
     }
 
     filtered
@@ -2043,6 +2100,7 @@ fn parse_local_unified_messages_resolved(
         pricing,
         options.use_env_roots,
         &options.scanner_settings,
+        false,
     );
     Ok(filter_unified_messages(messages, &options))
 }
@@ -6100,6 +6158,8 @@ mod tests {
                     group_by: GroupBy::default(),
                     scanner_settings: scanner::ScannerSettings::default(),
                     include_subagents: false,
+                    include_work_time: false,
+                    today_only: false,
                 },
                 None,
             ))

--- a/crates/tokscale-core/src/scanner.rs
+++ b/crates/tokscale-core/src/scanner.rs
@@ -118,6 +118,18 @@ impl ScanResult {
         &mut self.files[client as usize]
     }
 
+    /// Drop JSONL transcript files last modified before `since_ms`, so a
+    /// today-only scan never reads historical files. SQLite sources are left
+    /// intact (they're read whole, not per-file). A file whose mtime can't be
+    /// read reports "now" and is kept, so a fresh-but-unreadable file is never
+    /// dropped.
+    pub fn retain_files_modified_since(&mut self, since_ms: i64) {
+        for client_files in &mut self.files {
+            client_files
+                .retain(|path| crate::sessions::utils::file_modified_timestamp_ms(path) >= since_ms);
+        }
+    }
+
     /// Get total number of files found
     pub fn total_files(&self) -> usize {
         self.files.iter().map(|v| v.len()).sum()

--- a/crates/tokscale-core/src/sessionize.rs
+++ b/crates/tokscale-core/src/sessionize.rs
@@ -347,6 +347,78 @@ where
     daily
 }
 
+/// Active time for a single local day, bucketed by client (milliseconds).
+///
+/// Same local-day attribution as [`compute_daily_active_time`]: an interval
+/// straddling midnight contributes only the portion falling inside `day`. Each
+/// client is summed independently, so two AIs used in parallel both count their
+/// own focused time. Powers the menu bar's per-AI work-time cards.
+pub fn compute_active_time_by_client_for_day(
+    intervals: &[SessionInterval],
+    day: &str,
+) -> HashMap<String, i64> {
+    compute_active_time_by_client_for_day_with_timezone(intervals, day, &chrono::Local)
+}
+
+fn compute_active_time_by_client_for_day_with_timezone<Tz>(
+    intervals: &[SessionInterval],
+    day: &str,
+    timezone: &Tz,
+) -> HashMap<String, i64>
+where
+    Tz: chrono::TimeZone,
+{
+    let Ok(date) = chrono::NaiveDate::parse_from_str(day, "%Y-%m-%d") else {
+        return HashMap::new();
+    };
+    let Some(day_start) = local_day_start(date, timezone) else {
+        return HashMap::new();
+    };
+    let Some(next_day_start) = date.succ_opt().and_then(|next| local_day_start(next, timezone))
+    else {
+        return HashMap::new();
+    };
+
+    // Collect each client's active spans that land inside the day. A client often
+    // runs several sessions at once (a main session plus its subagents), so summing
+    // per-session durations would double-count overlapping wall-clock time and can
+    // exceed 24h. Instead union each client's spans and measure the covered time.
+    let mut spans_by_client: HashMap<String, Vec<(i64, i64)>> = HashMap::new();
+    for interval in intervals {
+        if interval.active_duration_ms <= 0 {
+            continue;
+        }
+        let start = interval.start_ts.max(day_start);
+        let end = interval.end_ts.min(next_day_start);
+        if end <= start {
+            continue;
+        }
+        spans_by_client
+            .entry(interval.client.clone())
+            .or_default()
+            .push((start, end));
+    }
+
+    spans_by_client
+        .into_iter()
+        .map(|(client, mut spans)| {
+            spans.sort_unstable_by_key(|&(start, _)| start);
+            let mut covered = 0i64;
+            let (mut cur_start, mut cur_end) = spans[0];
+            for &(start, end) in spans.iter().skip(1) {
+                if start <= cur_end {
+                    cur_end = cur_end.max(end);
+                } else {
+                    covered += cur_end - cur_start;
+                    (cur_start, cur_end) = (start, end);
+                }
+            }
+            covered += cur_end - cur_start;
+            (client, covered)
+        })
+        .collect()
+}
+
 fn local_date<Tz>(timestamp_ms: i64, timezone: &Tz) -> Option<chrono::NaiveDate>
 where
     Tz: chrono::TimeZone,
@@ -438,6 +510,52 @@ mod tests {
         assert_eq!(result[0].end_ts, 1_045_000);
         assert_eq!(result[0].wall_duration_ms, 45_000);
         assert_eq!(result[0].active_duration_ms, 45_000);
+    }
+
+    #[test]
+    fn work_time_buckets_active_time_by_client_for_the_day() {
+        let tz = FixedOffset::east_opt(0).unwrap();
+        let base = tz
+            .with_ymd_and_hms(2024, 1, 1, 1, 0, 0)
+            .unwrap()
+            .timestamp_millis();
+        let msgs = vec![
+            // claude: two messages 1 min apart → one block, 60s active
+            make_msg("claude", "c1", base),
+            make_msg("claude", "c1", base + 60_000),
+            // codex: two messages 2 min apart → one block, 120s active
+            make_msg("codex", "x1", base),
+            make_msg("codex", "x1", base + 120_000),
+        ];
+        let intervals = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        let by_client =
+            compute_active_time_by_client_for_day_with_timezone(&intervals, "2024-01-01", &tz);
+        assert_eq!(by_client.get("claude"), Some(&60_000));
+        assert_eq!(by_client.get("codex"), Some(&120_000));
+        // A different day sees none of this activity.
+        let empty =
+            compute_active_time_by_client_for_day_with_timezone(&intervals, "2024-01-02", &tz);
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn work_time_unions_overlapping_sessions_without_double_counting() {
+        let tz = FixedOffset::east_opt(0).unwrap();
+        let base = tz
+            .with_ymd_and_hms(2024, 1, 1, 1, 0, 0)
+            .unwrap()
+            .timestamp_millis();
+        let hour = 3_600_000i64;
+        // Two overlapping claude sessions (main + subagent): [0h, 1h] and [0.5h, 1.5h].
+        let msgs = vec![
+            make_timed_msg("claude", "main", base, hour),
+            make_timed_msg("claude", "subagent", base + hour / 2, hour),
+        ];
+        let intervals = sessionize(&msgs, DEFAULT_IDLE_GAP_MS);
+        let by_client =
+            compute_active_time_by_client_for_day_with_timezone(&intervals, "2024-01-01", &tz);
+        // Union of [0,60m] and [30m,90m] is 90m — NOT 60m + 60m = 120m.
+        assert_eq!(by_client.get("claude"), Some(&(hour + hour / 2)));
     }
 
     #[test]


### PR DESCRIPTION
Two opt-in, additive flags on `tokens graph` for the menu bar companion.

**`--work-time`** — per-client active work time for today, emitted as a top-level `todayWorkTime` map (like `--subagents`). Each client's session intervals are **unioned**, so parallel sessions/subagents don't double-count (summing them could exceed 24h). Reuses the sessionize intervals already derived (3-min idle gap) — no extra scan.

**`--today-only`** — prunes transcript files not modified today before reading them (`ScanResult::retain_files_modified_since`), so a "today" refresh costs ~2s instead of scanning all history. SQLite sources are left intact; files whose mtime can't be read are kept (never silently dropped).

Both are opt-in and additive: default output, totals, and the submit payload are byte-for-byte unchanged. Powers the menu bar's fast today refresh + per-AI work-time cards.

Tests: sessionize union (two overlapping 1h sessions = 1.5h, not 2h) + per-client today bucket; full core suite (859) green.