### PR TITLE
feat(menubar): per-AI work time, cache-hit fix, tiered today/history refresh

### DIFF
--- a/packages/menubar/Sources/TokscaleMenuBar/MenuBarModel.swift
+++ b/packages/menubar/Sources/TokscaleMenuBar/MenuBarModel.swift
@@ -15,6 +15,12 @@ final class MenuBarModel: ObservableObject {
     private let store = TokscaleSummaryStore()
     private var refreshTimer: Timer?
     private var lastAutoRefresh = Date()
+    // Two-tier scan throttles: today's spend is cheap to rescan (`--today-only`,
+    // ~2s) so it refreshes often; the full history scan is expensive (merged, tens
+    // of seconds) so it runs at most daily. A full scan also covers today, so it
+    // bumps both stamps.
+    private var lastTodayScan = Date.distantPast
+    private var lastHistoryScan = Date.distantPast
 
     init() {
         reload()
@@ -26,6 +32,15 @@ final class MenuBarModel: ObservableObject {
     func reload() {
         do {
             let loaded = try store.load()
+            // Skip the dashboard rebuild + badge re-render when the data version is
+            // unchanged — the 60s tick reloads even when nothing was scanned, and
+            // rebuilding the model + rendering the NSImage every minute is wasteful.
+            if let loaded, let current = summary, errorMessage == nil,
+                loaded.generatedAt == current.generatedAt,
+                loaded.health.quotaRefreshedAt == current.health.quotaRefreshedAt
+            {
+                return
+            }
             summary = loaded
             dashboard = loaded.map { TokscaleDashboardModel(summary: $0) }
             menuBarImage = MenuBarBadgeRenderer.image(for: loaded)
@@ -77,6 +92,29 @@ final class MenuBarModel: ObservableObject {
             Task { @MainActor in
                 guard let self else { return }
                 self.isBackgroundScanning = false
+                self.lastHistoryScan = Date()
+                // The merged history scan owns all-time/history, but its per-client
+                // today work time can be noisy (cross-machine duplicates / stray
+                // timestamps). Chain a local today-only scan to fill in accurate
+                // work time + today's spend; it reloads once done, so the panel
+                // never flashes an empty work-time line between the two scans.
+                self.backgroundTodayScan()
+            }
+        }
+    }
+
+    // Cheap today-only rescan: re-reads just today's files (~2s) and patches the
+    // today figures + work time over the existing summary, leaving history alone.
+    private func backgroundTodayScan() {
+        guard !isBackgroundScanning else { return }
+        isBackgroundScanning = true
+        let summaryURL = store.summaryURL
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            _ = MenuBarModel.runTodayScan(summaryURL: summaryURL)
+            Task { @MainActor in
+                guard let self else { return }
+                self.isBackgroundScanning = false
+                self.lastTodayScan = Date()
                 self.reload()
             }
         }
@@ -98,13 +136,19 @@ final class MenuBarModel: ObservableObject {
         let cadence = RefreshCadence(
             storedValue: UserDefaults.standard.string(forKey: RefreshCadence.storageKey)
         )
-        let allowScan = cadence.minimumInterval != nil
-        let needsScan = allowScan
-            && !isBackgroundScanning
-            && (summary?.needsScanOnOpen(minimumInterval: 600) ?? true)
+        // First page wins: quota refreshes immediately on every open (fast, local),
+        // even while a scan runs. Then pick the cheapest scan that's due: a daily
+        // full history scan, otherwise a throttled today-only scan (~2s). With
+        // "Refresh on open = Off" only quota refreshes, never a background scan.
         refreshQuota { [weak self] in
-            if needsScan {
-                self?.backgroundFullScan()
+            guard let self, cadence.minimumInterval != nil, !self.isBackgroundScanning else {
+                return
+            }
+            let now = Date()
+            if now.timeIntervalSince(self.lastHistoryScan) > 86_400 {
+                self.backgroundFullScan()
+            } else if now.timeIntervalSince(self.lastTodayScan) > 600 {
+                self.backgroundTodayScan()
             }
         }
     }
@@ -189,6 +233,42 @@ final class MenuBarModel: ObservableObject {
         }
     }
 
+    /// Cheap today-only refresh: rescan just today's files (`graph --today-only`,
+    /// ~2s) and patch today's spend + work time over the existing summary, leaving
+    /// the slow-to-scan history untouched. Stays on the local binary (today's data
+    /// is all local), so it skips the merged-home wrapper the full scan uses.
+    nonisolated private static func runTodayScan(summaryURL: URL) -> String {
+        guard let binary = tokensBinaryURL() else {
+            return "Refresh failed: tokens command unavailable"
+        }
+        guard let existing = try? Data(contentsOf: summaryURL), !existing.isEmpty else {
+            return "Today refresh skipped: no summary yet"
+        }
+        let graph = runCapturing(
+            executableURL: binary,
+            arguments: ["graph", "--today-only", "--work-time", "--no-spinner"],
+            timeout: 60
+        )
+        guard graph.ok, let graphData = graph.data, !graphData.isEmpty else {
+            return "Today refresh failed: \(graph.message ?? "graph scan")"
+        }
+        guard
+            let patched = GraphCompanionAdapter.patchTodayData(
+                companionData: existing,
+                todayGraphData: graphData,
+                todayDate: localDateString()
+            )
+        else {
+            return "Today refresh failed: patch"
+        }
+        do {
+            try writeAtomic(patched, to: summaryURL)
+            return "Refresh finished."
+        } catch {
+            return "Today refresh failed: \(error)"
+        }
+    }
+
     /// Quota-only refresh: run `tokens usage` and patch the existing summary. Keeps
     /// the previous quota when the fetch returns nothing, so a transient failure
     /// doesn't blank the badge to "No live".
@@ -248,7 +328,7 @@ final class MenuBarModel: ObservableObject {
         if FileManager.default.isExecutableFile(atPath: wrapper.path) {
             return (wrapper, [])
         }
-        return (binary, ["graph", "--subagents", "--no-spinner"])
+        return (binary, ["graph", "--subagents", "--work-time", "--no-spinner"])
     }
 
     nonisolated private static func tokensBinaryURL() -> URL? {

--- a/packages/menubar/Sources/TokscaleMenuBar/TokensPopoverView.swift
+++ b/packages/menubar/Sources/TokscaleMenuBar/TokensPopoverView.swift
@@ -648,16 +648,33 @@ private struct ProviderGlanceCard: View {
                 }
             }
 
-            if focus.cacheHitPercent > 0.5 {
-                HStack(spacing: 5) {
-                    Image(systemName: "bolt.fill")
-                        .font(.system(size: 11, weight: .bold))
-                        .foregroundStyle(.green)
-                    Text("Cache hit \(Int(focus.cacheHitPercent.rounded()))%")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(.primary)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.7)
+            if focus.workTime != "—" || focus.cacheHitPercent > 0.5 {
+                HStack(spacing: 8) {
+                    if focus.workTime != "—" {
+                        HStack(spacing: 5) {
+                            Image(systemName: "clock.fill")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundStyle(color)
+                            Text("Active \(focus.workTime)")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                        }
+                    }
+                    Spacer(minLength: 4)
+                    if focus.cacheHitPercent > 0.5 {
+                        HStack(spacing: 5) {
+                            Image(systemName: "bolt.fill")
+                                .font(.system(size: 11, weight: .bold))
+                                .foregroundStyle(.green)
+                            Text("Cache hit \(Int(focus.cacheHitPercent.rounded()))%")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                        }
+                    }
                 }
             }
         }

--- a/packages/menubar/Sources/TokscaleMenuBarCore/GraphCompanionAdapter.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/GraphCompanionAdapter.swift
@@ -20,6 +20,8 @@ public enum GraphCompanionAdapter {
         let summary: Summary
         let contributions: [Contribution]
         let subagents: Subagents?
+        /// Opt-in per-client active work time for today (ms), from `graph --work-time`.
+        let todayWorkTime: [String: Int64]?
 
         struct Meta: Decodable {
             let generatedAt: String
@@ -217,6 +219,57 @@ public enum GraphCompanionAdapter {
         return try? JSONSerialization.data(withJSONObject: dict, options: [])
     }
 
+    /// Patch only today's figures into an existing companion summary, from a fast
+    /// today-only graph scan. All-time totals, history, top, and quota are left
+    /// untouched — they come from the slower full scan — so the menu bar can
+    /// refresh today's spend and work time cheaply without rescanning history.
+    public static func patchTodayData(
+        companionData: Data,
+        todayGraphData: Data,
+        todayDate: String
+    ) -> Data? {
+        guard var dict = (try? JSONSerialization.jsonObject(with: companionData)) as? [String: Any]
+        else { return nil }
+        guard
+            let todayData = try? companionJSON(
+                graphData: todayGraphData,
+                usageData: nil,
+                todayDate: todayDate,
+                summaryPath: "",
+                lastScanDurationMs: 0,
+                quotaRefreshedAt: nil
+            ),
+            let todayDict = (try? JSONSerialization.jsonObject(with: todayData)) as? [String: Any]
+        else { return nil }
+
+        // Today panel + glance come straight from the today-only scan.
+        if let today = todayDict["today"] { dict["today"] = today }
+        if let collapsed = todayDict["collapsed"] { dict["collapsed"] = collapsed }
+        if let generatedAt = todayDict["generatedAt"] { dict["generatedAt"] = generatedAt }
+
+        // Patch each provider's today-scoped fields (and work time) from the today
+        // scan; providers absent from today reset to zero. All-time costUsd/tokens/
+        // cacheHitPercent stay owned by the full scan.
+        if let realProviders = dict["providers"] as? [[String: Any]] {
+            var byClient: [String: [String: Any]] = [:]
+            for p in (todayDict["providers"] as? [[String: Any]]) ?? [] {
+                if let client = p["client"] as? String { byClient[client] = p }
+            }
+            dict["providers"] = realProviders.map { provider -> [String: Any] in
+                var provider = provider
+                let client = provider["client"] as? String ?? ""
+                let t = byClient[client]
+                provider["todayCostUsd"] = t?["todayCostUsd"] ?? 0
+                provider["todayTokens"] = t?["todayTokens"] ?? 0
+                provider["todayMessages"] = t?["todayMessages"] ?? 0
+                provider["workTimeMs"] = t?["workTimeMs"] ?? 0
+                return provider
+            }
+        }
+
+        return try? JSONSerialization.data(withJSONObject: dict, options: [])
+    }
+
     // MARK: - breakdowns (mirror companion_summary.rs from_graph)
 
     private static func providerBreakdown(_ graph: Graph, todayDate: String) -> [[String: Any]] {
@@ -229,6 +282,7 @@ public enum GraphCompanionAdapter {
             var todayMessages = 0
             var cacheRead: Int64 = 0
             var freshInput: Int64 = 0
+            var cacheWrite: Int64 = 0
             var modelCosts: [String: Double] = [:]
         }
         var providers: [String: Acc] = [:]
@@ -242,6 +296,7 @@ public enum GraphCompanionAdapter {
                 acc.messages += client.messages
                 acc.cacheRead += client.tokens.cacheRead
                 acc.freshInput += client.tokens.input
+                acc.cacheWrite += client.tokens.cacheWrite
                 acc.modelCosts[client.modelId, default: 0] += client.cost
                 if isToday {
                     acc.todayCost += client.cost
@@ -254,9 +309,10 @@ public enum GraphCompanionAdapter {
         return providers
             .map { client, acc -> [String: Any] in
                 let topModel = acc.modelCosts.max { $0.value < $1.value }?.key
-                // Prompt-cache hit rate: how much of the read input came from cache
-                // (cache reads are ~10× cheaper than fresh input).
-                let readTotal = acc.cacheRead + acc.freshInput
+                // Prompt-cache hit rate: cache reads (hits) over everything first read
+                // this turn — fresh input plus first-time cache writes (both misses).
+                // Counting cacheWrite is what keeps Claude off a permanent ~100%.
+                let readTotal = acc.cacheRead + acc.freshInput + acc.cacheWrite
                 let cacheHitPercent = readTotal > 0
                     ? Double(acc.cacheRead) / Double(readTotal) * 100
                     : 0
@@ -269,6 +325,7 @@ public enum GraphCompanionAdapter {
                     "todayTokens": acc.todayTokens,
                     "todayMessages": acc.todayMessages,
                     "cacheHitPercent": cacheHitPercent,
+                    "workTimeMs": graph.todayWorkTime?[client] ?? 0,
                 ]
                 if let topModel { row["topModel"] = topModel }
                 return row

--- a/packages/menubar/Sources/TokscaleMenuBarCore/TokscaleSummary.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/TokscaleSummary.swift
@@ -249,7 +249,8 @@ public struct TokscaleDashboardModel: Equatable {
                         messages: "\(row.messages) messages",
                         share: Self.providerShare(row.costUsd, totalCost: summary.totals.costUsd),
                         hasLiveQuotaRefresh: hasLiveQuotaRefresh,
-                        cacheHitPercent: row.cacheHitPercent
+                        cacheHitPercent: row.cacheHitPercent,
+                        workTimeMs: row.workTimeMs
                     )
                 )
             }
@@ -328,7 +329,8 @@ public struct TokscaleDashboardModel: Equatable {
             messages: "0 messages",
             share: 0,
             hasLiveQuotaRefresh: false,
-            cacheHitPercent: 0
+            cacheHitPercent: 0,
+            workTimeMs: 0
         )
     }
 
@@ -360,7 +362,8 @@ public struct TokscaleDashboardModel: Equatable {
                 messages: "0 messages",
                 share: 0,
                 hasLiveQuotaRefresh: quotaWasRefreshed,
-                cacheHitPercent: 0
+                cacheHitPercent: 0,
+                workTimeMs: 0
             )
         )
     }
@@ -387,7 +390,7 @@ public struct TokscaleDashboardModel: Equatable {
             primaryQuota: primary,
             weeklyQuota: weekly,
             quotaStatus: quota.isEmpty ? "No live quota" : (summaryStale && !details.hasLiveQuotaRefresh ? "Cached" : "Live"),
-            workTime: "Work time unavailable",
+            workTime: formatWorkTime(details.workTimeMs),
             focusedModelTime: Self.focusedModelTimeLabel(providerId: details.id, model: details.model),
             cacheHitPercent: details.cacheHitPercent
         )
@@ -699,6 +702,7 @@ public extension TokscaleDashboardModel {
         public let share: Double
         public let hasLiveQuotaRefresh: Bool
         public let cacheHitPercent: Double
+        public let workTimeMs: Int64
     }
 
     struct ProviderFocus: Equatable {
@@ -794,10 +798,12 @@ public extension TokscaleSummary {
         public let todayMessages: Int
         public let topModel: String?
         public let cacheHitPercent: Double
+        public let workTimeMs: Int64
 
         enum CodingKeys: String, CodingKey {
             case client, costUsd, tokens, messages
             case todayCostUsd, todayTokens, todayMessages, topModel, cacheHitPercent
+            case workTimeMs
         }
 
         public init(from decoder: Decoder) throws {
@@ -811,6 +817,7 @@ public extension TokscaleSummary {
             todayMessages = try c.decode(Int.self, forKey: .todayMessages)
             topModel = try c.decodeIfPresent(String.self, forKey: .topModel)
             cacheHitPercent = try c.decodeIfPresent(Double.self, forKey: .cacheHitPercent) ?? 0
+            workTimeMs = try c.decodeIfPresent(Int64.self, forKey: .workTimeMs) ?? 0
         }
 
         public init(
@@ -822,7 +829,8 @@ public extension TokscaleSummary {
             todayTokens: Int64,
             todayMessages: Int,
             topModel: String?,
-            cacheHitPercent: Double = 0
+            cacheHitPercent: Double = 0,
+            workTimeMs: Int64 = 0
         ) {
             self.client = client
             self.costUsd = costUsd
@@ -833,6 +841,7 @@ public extension TokscaleSummary {
             self.todayMessages = todayMessages
             self.topModel = topModel
             self.cacheHitPercent = cacheHitPercent
+            self.workTimeMs = workTimeMs
         }
     }
 
@@ -964,6 +973,23 @@ private func formatDuration(milliseconds: Int) -> String {
         return "\(minutes)m \(remainingSeconds)s"
     }
     return "\(remainingSeconds)s"
+}
+
+/// Per-AI active work time for a day: "9h 41m", "46m", "<1m", or "—" when idle.
+/// Drives the provider cards' work-time line. Idle gaps over 3 min are already
+/// excluded upstream in `sessionize`, so this is focused time, not elapsed.
+private func formatWorkTime(_ milliseconds: Int64) -> String {
+    guard milliseconds > 0 else { return "—" }
+    let totalMinutes = Int(milliseconds / 60_000)
+    let hours = totalMinutes / 60
+    let minutes = totalMinutes % 60
+    if hours > 0 {
+        return "\(hours)h \(minutes)m"
+    }
+    if minutes > 0 {
+        return "\(minutes)m"
+    }
+    return "<1m"
 }
 
 func parseISODate(_ value: String) -> Date? {

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/GraphCompanionAdapterTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/GraphCompanionAdapterTests.swift
@@ -181,4 +181,154 @@ final class GraphCompanionAdapterTests: XCTestCase {
         XCTAssertEqual(summary.quota[0].provider, "Claude")
         XCTAssertEqual(summary.health.quotaRefreshedAt, "2026-06-07T04:00:00+00:00")
     }
+
+    // Claude pattern: almost every token is cache (reads + first-time writes), fresh
+    // input ~0. A cache-hit rate must count cacheWrite as a miss — otherwise the
+    // denominator collapses to cacheRead and the rate pins to 100%.
+    // 900 read / 100 write / 0 input → 90%, not 100%.
+    func testCacheHitRateCountsCacheWriteAsMiss() throws {
+        let graph = """
+        {
+          "meta": { "generatedAt": "2026-06-07T03:00:00+00:00", "version": "3.0.3",
+                    "dateRange": { "start": "2026-06-07", "end": "2026-06-07" } },
+          "summary": {
+            "totalTokens": 1050, "totalCost": 10.0, "activeDays": 1,
+            "averagePerDay": 10.0, "maxCostInSingleDay": 10.0,
+            "clients": ["claude"], "models": ["claude-opus-4-8"]
+          },
+          "years": [],
+          "contributions": [
+            {
+              "date": "2026-06-07", "intensity": 4,
+              "totals": { "tokens": 1050, "cost": 10.0, "messages": 4 },
+              "tokenBreakdown": { "input": 0, "output": 50, "cacheRead": 900, "cacheWrite": 100, "reasoning": 0 },
+              "clients": [
+                { "client": "claude", "modelId": "claude-opus-4-8", "providerId": "anthropic",
+                  "cost": 10.0, "messages": 4,
+                  "tokens": { "input": 0, "output": 50, "cacheRead": 900, "cacheWrite": 100, "reasoning": 0 } }
+              ]
+            }
+          ]
+        }
+        """
+        let companion = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graph.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let summary = try TokscaleSummary.decode(companion)
+        let claude = try XCTUnwrap(summary.providers.first { $0.client == "claude" })
+        XCTAssertEqual(claude.cacheHitPercent, 90.0, accuracy: 0.01)
+    }
+
+    // `graph --work-time` adds a top-level todayWorkTime map (client → active ms).
+    // The adapter routes each into its provider, and the dashboard formats it for
+    // the cards: 1h → "1h 0m", 45 min → "45m".
+    func testWorkTimeFromGraphPopulatesProviders() throws {
+        let graph = """
+        {
+          "meta": { "generatedAt": "2026-06-07T03:00:00+00:00", "version": "3.0.3",
+                    "dateRange": { "start": "2026-06-07", "end": "2026-06-07" } },
+          "summary": {
+            "totalTokens": 3000, "totalCost": 30.0, "activeDays": 1,
+            "averagePerDay": 30.0, "maxCostInSingleDay": 30.0,
+            "clients": ["claude", "codex"], "models": ["claude-opus-4-8", "gpt-5"]
+          },
+          "years": [],
+          "contributions": [
+            {
+              "date": "2026-06-07", "intensity": 4,
+              "totals": { "tokens": 3000, "cost": 30.0, "messages": 12 },
+              "tokenBreakdown": { "input": 3000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 },
+              "clients": [
+                { "client": "claude", "modelId": "claude-opus-4-8", "providerId": "anthropic",
+                  "cost": 20.0, "messages": 8,
+                  "tokens": { "input": 2000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } },
+                { "client": "codex", "modelId": "gpt-5", "providerId": "openai",
+                  "cost": 10.0, "messages": 4,
+                  "tokens": { "input": 1000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }
+              ]
+            }
+          ],
+          "todayWorkTime": { "claude": 3600000, "codex": 2700000 }
+        }
+        """
+        let companion = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graph.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let summary = try TokscaleSummary.decode(companion)
+        let claude = try XCTUnwrap(summary.providers.first { $0.client == "claude" })
+        XCTAssertEqual(claude.workTimeMs, 3_600_000)
+        let codex = try XCTUnwrap(summary.providers.first { $0.client == "codex" })
+        XCTAssertEqual(codex.workTimeMs, 2_700_000)
+
+        let dashboard = TokscaleDashboardModel(summary: summary)
+        XCTAssertEqual(dashboard.providerFocus(for: "claude").workTime, "1h 0m")
+        XCTAssertEqual(dashboard.providerFocus(for: "codex").workTime, "45m")
+    }
+
+    // The menu bar's cheap "today" refresh: a today-only scan patches today's
+    // spend + work time over the existing summary, leaving all-time totals,
+    // per-provider lifetime cost, and quota owned by the slow full scan.
+    func testPatchTodayDataRefreshesTodayButKeepsHistory() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: Data(usageJSON.utf8),
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: "2026-06-07T03:01:00+00:00"
+        )
+        // Today-only scan: only 2026-06-07, claude spent more + logged 1h work time.
+        let todayGraph = """
+        {
+          "meta": { "generatedAt": "2026-06-07T09:00:00+00:00", "version": "3.0.3",
+                    "dateRange": { "start": "2026-06-07", "end": "2026-06-07" } },
+          "summary": { "totalTokens": 5000, "totalCost": 50.0, "activeDays": 1,
+                       "averagePerDay": 50.0, "maxCostInSingleDay": 50.0,
+                       "clients": ["claude"], "models": ["claude-opus-4-8"] },
+          "years": [],
+          "contributions": [
+            { "date": "2026-06-07", "intensity": 4,
+              "totals": { "tokens": 5000, "cost": 50.0, "messages": 25 },
+              "tokenBreakdown": { "input": 5000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 },
+              "clients": [
+                { "client": "claude", "modelId": "claude-opus-4-8", "providerId": "anthropic",
+                  "cost": 50.0, "messages": 25,
+                  "tokens": { "input": 5000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }
+              ] }
+          ],
+          "todayWorkTime": { "claude": 3600000 }
+        }
+        """
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchTodayData(
+                companionData: full,
+                todayGraphData: Data(todayGraph.utf8),
+                todayDate: "2026-06-07"
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+        // Today panel refreshed to the today-only numbers.
+        XCTAssertEqual(summary.today.costUsd, 50.0, accuracy: 0.001)
+        XCTAssertEqual(summary.today.tokens, 5000)
+        // All-time totals untouched (still the full scan's 3500 / 35).
+        XCTAssertEqual(summary.totals.tokens, 3500)
+        XCTAssertEqual(summary.totals.costUsd, 35.0, accuracy: 0.001)
+        // Claude: today refreshed + work time set; lifetime cost preserved (30).
+        let claude = try XCTUnwrap(summary.providers.first { $0.client == "claude" })
+        XCTAssertEqual(claude.todayCostUsd, 50.0, accuracy: 0.001)
+        XCTAssertEqual(claude.workTimeMs, 3_600_000)
+        XCTAssertEqual(claude.costUsd, 30.0, accuracy: 0.001)
+        // Quota preserved from the full scan.
+        XCTAssertEqual(summary.quota.count, 1)
+    }
 }


### PR DESCRIPTION
Builds on the SwiftUI quota companion (#7) with per-AI work time, a cache-hit fix, and a tiered refresh.

**Per-AI work time** — each provider card shows today's active work time (clock icon, paired with cache hit on one row), from `graph --work-time`'s `todayWorkTime`. Sourced from the local today-only scan; the merged history scan deliberately omits it (cross-machine timestamps are noisy and can union to a bogus 24h).

**Cache-hit fix** — the hit rate now counts `cacheWrite` as a miss (`cacheRead / (cacheRead + input + cacheWrite)`), so Claude — which routes nearly everything through prompt cache — is no longer pinned at ~100% (shows a real ~98%). Providers without cacheWrite (Codex/Gemini) are unaffected.

**Tiered refresh** — a cheap today-only scan (~2s, `graph --today-only --work-time`) patches today's spend + work time over the existing summary on open; the full merged history scan runs at most daily. `reload` skips the dashboard rebuild + badge re-render when the data version is unchanged.

Runtime-depends on graph `--work-time` / `--today-only` (#9); the Swift code + tests are independent (mock JSON), so this compiles and tests standalone.

Tests: adapter work-time parse + `patchTodayData` (today refreshed, history/totals/quota preserved) + cache-hit-counts-cacheWrite; 48 menu-bar tests green.