### PR TITLE
feat(embed): add Today usage option and Detailed template

### DIFF
--- a/packages/frontend/__tests__/api/embedSvgRoute.test.ts
+++ b/packages/frontend/__tests__/api/embedSvgRoute.test.ts
@@ -3,11 +3,13 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const getUserEmbedStats = vi.fn();
 const getUserEmbedContributions = vi.fn();
+const getUserEmbedToday = vi.fn();
 const renderProfileEmbedErrorSvg = vi.fn();
 const renderProfileEmbedSvg = vi.fn();
 const renderMinimalEmbedSvg = vi.fn();
 const renderTerminalEmbedSvg = vi.fn();
 const renderGraphEmbedSvg = vi.fn();
+const renderDetailedEmbedSvg = vi.fn();
 const renderIsometric3DEmbedSvg = vi.fn();
 const renderIsometric3DErrorSvg = vi.fn();
 const isValidGitHubUsername = vi.fn();
@@ -15,7 +17,10 @@ const isValidGitHubUsername = vi.fn();
 vi.mock("@/lib/embed/getUserEmbedStats", () => ({
   getUserEmbedStats,
   getUserEmbedContributions,
+  getUserEmbedToday,
 }));
+
+vi.mock("@/lib/embed/renderDetailedEmbedSvg", () => ({ renderDetailedEmbedSvg }));
 
 vi.mock("@/lib/embed/renderProfileEmbedSvg", () => ({
   renderProfileEmbedErrorSvg,
@@ -61,11 +66,13 @@ beforeAll(async () => {
 beforeEach(() => {
   getUserEmbedStats.mockReset();
   getUserEmbedContributions.mockReset();
+  getUserEmbedToday.mockReset();
   renderProfileEmbedErrorSvg.mockReset();
   renderProfileEmbedSvg.mockReset();
   renderMinimalEmbedSvg.mockReset();
   renderTerminalEmbedSvg.mockReset();
   renderGraphEmbedSvg.mockReset();
+  renderDetailedEmbedSvg.mockReset();
   renderIsometric3DEmbedSvg.mockReset();
   renderIsometric3DErrorSvg.mockReset();
   isValidGitHubUsername.mockReset();
@@ -76,7 +83,9 @@ beforeEach(() => {
   renderMinimalEmbedSvg.mockReturnValue("<svg>minimal</svg>");
   renderTerminalEmbedSvg.mockReturnValue("<svg>terminal</svg>");
   renderGraphEmbedSvg.mockReturnValue("<svg>graph</svg>");
+  renderDetailedEmbedSvg.mockReturnValue("<svg>detailed</svg>");
   getUserEmbedContributions.mockResolvedValue([]);
+  getUserEmbedToday.mockResolvedValue(null);
 });
 
 describe("GET /api/embed/[username]/svg", () => {
@@ -171,6 +180,47 @@ describe("GET /api/embed/[username]/svg", () => {
       expect.anything(),
       expect.objectContaining({ color: null }),
     );
+  });
+
+  it("passes today usage to the renderer when today=1", async () => {
+    getUserEmbedStats.mockResolvedValue(statsFor("octocat"));
+    const todayUsage = { date: "2026-02-24", tokens: 4321, cost: 7.77, clients: [] };
+    getUserEmbedToday.mockResolvedValue(todayUsage);
+
+    await request("?template=graph&today=1");
+
+    expect(getUserEmbedToday).toHaveBeenCalledWith("octocat");
+    expect(renderGraphEmbedSvg).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ today: todayUsage }),
+    );
+  });
+
+  it("does not fetch today usage unless requested", async () => {
+    getUserEmbedStats.mockResolvedValue(statsFor("octocat"));
+
+    await request("?template=graph");
+
+    expect(getUserEmbedToday).not.toHaveBeenCalled();
+    expect(renderGraphEmbedSvg).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ today: null }),
+    );
+  });
+
+  it("dispatches to the detailed template and always fetches today usage", async () => {
+    getUserEmbedStats.mockResolvedValue(statsFor("octocat"));
+    const todayUsage = { date: "2026-02-24", tokens: 4321, cost: 7.77, clients: [] };
+    getUserEmbedToday.mockResolvedValue(todayUsage);
+
+    const response = await request("?template=detailed");
+
+    expect(getUserEmbedToday).toHaveBeenCalledWith("octocat");
+    expect(renderDetailedEmbedSvg).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ today: todayUsage }),
+    );
+    await expect(response.text()).resolves.toBe("<svg>detailed</svg>");
   });
 
   it.each(["orbit", "vitals", "blueprint", "receipt", "pulse"])(

--- a/packages/frontend/__tests__/lib/embedTemplates.test.ts
+++ b/packages/frontend/__tests__/lib/embedTemplates.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { UserEmbedStats, EmbedContributionDay } from "../../src/lib/embed/getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "../../src/lib/embed/getUserEmbedStats";
 import {
   THEMES,
   applyEmbedColor,
@@ -9,6 +9,7 @@ import {
   parseRankFormat,
   formatRank,
 } from "../../src/lib/embed/embedShared";
+import { renderProfileEmbedSvg } from "../../src/lib/embed/renderProfileEmbedSvg";
 import { renderMinimalEmbedSvg } from "../../src/lib/embed/renderMinimalEmbedSvg";
 import { renderTerminalEmbedSvg } from "../../src/lib/embed/renderTerminalEmbedSvg";
 import { renderGraphEmbedSvg } from "../../src/lib/embed/renderGraphEmbedSvg";
@@ -17,6 +18,7 @@ import { renderVitalsEmbedSvg } from "../../src/lib/embed/renderVitalsEmbedSvg";
 import { renderBlueprintEmbedSvg } from "../../src/lib/embed/renderBlueprintEmbedSvg";
 import { renderReceiptEmbedSvg } from "../../src/lib/embed/renderReceiptEmbedSvg";
 import { renderPulseEmbedSvg } from "../../src/lib/embed/renderPulseEmbedSvg";
+import { renderDetailedEmbedSvg } from "../../src/lib/embed/renderDetailedEmbedSvg";
 
 const mockStats: UserEmbedStats = {
   user: { id: "user-id", username: "octocat", displayName: "The Octocat", avatarUrl: null },
@@ -36,12 +38,53 @@ const mockContributions: EmbedContributionDay[] = [
   { date: "2026-02-20", totalTokens: 99999, totalCost: 40, intensity: 4 },
 ];
 
+// Distinctive numbers ($7.77 / 4,321) so "today" output is easy to detect and
+// never collides with the totals in mockStats.
+const mockToday: EmbedTodayUsage = {
+  date: "2026-02-24",
+  tokens: 4321,
+  cost: 7.77,
+  clients: [
+    {
+      source: "claude",
+      tokens: 4000,
+      cost: 6.5,
+      messages: 12,
+      models: [
+        { modelId: "claude-opus-4-8", tokens: 4000, cost: 6.5, input: 1000, output: 500, cacheRead: 2000, cacheWrite: 100, reasoning: 0, messages: 12 },
+      ],
+    },
+    {
+      source: "codex",
+      tokens: 321,
+      cost: 1.27,
+      messages: 3,
+      models: [
+        { modelId: "gpt-5-codex", tokens: 321, cost: 1.27, input: 200, output: 121, cacheRead: 0, cacheWrite: 0, reasoning: 0, messages: 3 },
+      ],
+    },
+  ],
+};
+
+const todayCapableRenderers = {
+  classic: renderProfileEmbedSvg,
+  minimal: renderMinimalEmbedSvg,
+  terminal: renderTerminalEmbedSvg,
+  graph: renderGraphEmbedSvg,
+  orbit: renderOrbitEmbedSvg,
+  vitals: renderVitalsEmbedSvg,
+  blueprint: renderBlueprintEmbedSvg,
+  receipt: renderReceiptEmbedSvg,
+  pulse: renderPulseEmbedSvg,
+};
+
 describe("parseEmbedTemplate", () => {
   it("accepts known templates", () => {
     expect(parseEmbedTemplate("minimal")).toBe("minimal");
     expect(parseEmbedTemplate("terminal")).toBe("terminal");
     expect(parseEmbedTemplate("graph")).toBe("graph");
     expect(parseEmbedTemplate("classic")).toBe("classic");
+    expect(parseEmbedTemplate("detailed")).toBe("detailed");
   });
 
   it("falls back to classic for unknown or missing values", () => {
@@ -250,5 +293,47 @@ describe("graph toggle", () => {
       .toContain("Daily token activity");
     expect(renderReceiptEmbedSvg(mockStats, { contributions: mockContributions, graph: true }))
       .toContain("DAILY ACTIVITY");
+  });
+});
+
+describe("today toggle", () => {
+  for (const [name, render] of Object.entries(todayCapableRenderers)) {
+    it(`${name} omits today usage by default and renders it when today is provided`, () => {
+      // "$7.77" is the mockToday cost and never appears in the totals.
+      expect(render(mockStats, { contributions: mockContributions })).not.toContain("$7.77");
+
+      const withToday = render(mockStats, { contributions: mockContributions, today: mockToday });
+      expect(withToday).toContain("$7.77");
+      expect(withToday).toContain("<svg");
+      expect(withToday.trimEnd().endsWith("</svg>")).toBe(true);
+    });
+  }
+});
+
+describe("renderDetailedEmbedSvg", () => {
+  it("renders today's per-client / per-model breakdown", () => {
+    const svg = renderDetailedEmbedSvg(mockStats, { today: mockToday });
+    expect(svg).toContain("<svg");
+    expect(svg.trimEnd().endsWith("</svg>")).toBe(true);
+    expect(svg).toContain("Today's usage");
+    expect(svg).toContain("Claude Code"); // SOURCE_DISPLAY_NAMES.claude
+    expect(svg).toContain("claude-opus-4-8"); // model id
+    expect(svg).toContain("$7.77"); // today total cost
+  });
+
+  it("renders an empty state when there is no usage today", () => {
+    expect(renderDetailedEmbedSvg(mockStats, { today: null })).toContain("No usage recorded today");
+    expect(
+      renderDetailedEmbedSvg(mockStats, { today: { date: "2026-02-24", tokens: 0, cost: 0, clients: [] } })
+    ).toContain("No usage recorded today");
+  });
+
+  it("escapes the username", () => {
+    const svg = renderDetailedEmbedSvg(
+      { ...mockStats, user: { ...mockStats.user, username: "a<b&c" } },
+      { today: mockToday }
+    );
+    expect(svg).toContain("a&lt;b&amp;c");
+    expect(svg).not.toContain("a<b&c");
   });
 });

--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -133,6 +133,7 @@ type ModuleExports = typeof import("../../src/lib/embed/getUserEmbedStats");
 
 let getUserEmbedStats: ModuleExports["getUserEmbedStats"];
 let getUserEmbedContributions: ModuleExports["getUserEmbedContributions"];
+let getUserEmbedToday: ModuleExports["getUserEmbedToday"];
 
 function serializeSqlCalls(): string[] {
   return mockState.sql.mock.calls.map((call) => {
@@ -150,6 +151,7 @@ beforeAll(async () => {
   const embedModule = await import("../../src/lib/embed/getUserEmbedStats");
   getUserEmbedStats = embedModule.getUserEmbedStats;
   getUserEmbedContributions = embedModule.getUserEmbedContributions;
+  getUserEmbedToday = embedModule.getUserEmbedToday;
 });
 
 beforeEach(() => {
@@ -242,6 +244,57 @@ describe("user embed data", () => {
     expect(sqlTexts.some((text) =>
       text.toLowerCase().includes("lower(users.username) = imlunahey")
     )).toBe(true);
+  });
+
+  it("aggregates today's usage across device rows by client and model", async () => {
+    mockState.pushAwaitedResult([{ id: "user-x" }]);
+    mockState.pushAwaitedResult([
+      {
+        tokens: 100,
+        cost: "1.00",
+        sourceBreakdown: {
+          claude: {
+            tokens: 100, cost: 1, messages: 2,
+            models: { opus: { tokens: 100, cost: 1, input: 50, output: 50, cacheRead: 0, cacheWrite: 0, reasoning: 0, messages: 2 } },
+          },
+        },
+      },
+      {
+        tokens: 350,
+        cost: "3.50",
+        sourceBreakdown: {
+          claude: {
+            tokens: 300, cost: 3, messages: 4,
+            models: { opus: { tokens: 300, cost: 3, input: 100, output: 200, cacheRead: 0, cacheWrite: 0, reasoning: 0, messages: 4 } },
+          },
+          codex: {
+            tokens: 50, cost: 0.5, messages: 1,
+            models: { gpt: { tokens: 50, cost: 0.5, input: 20, output: 30, cacheRead: 0, cacheWrite: 0, reasoning: 0, messages: 1 } },
+          },
+        },
+      },
+    ]);
+
+    const today = await getUserEmbedToday("octocat");
+
+    expect(today?.tokens).toBe(450);
+    expect(today?.cost).toBeCloseTo(4.5);
+    // Clients sorted by cost descending: claude ($4) before codex ($0.5).
+    expect(today?.clients.map((c) => c.source)).toEqual(["claude", "codex"]);
+
+    const claude = today!.clients[0];
+    expect(claude.cost).toBeCloseTo(4);
+    expect(claude.messages).toBe(6);
+    expect(claude.models).toHaveLength(1);
+    expect(claude.models[0].modelId).toBe("opus");
+    expect(claude.models[0].tokens).toBe(400);
+    expect(claude.models[0].cost).toBeCloseTo(4);
+    expect(claude.models[0].output).toBe(250);
+  });
+
+  it("returns null today usage for an unknown user", async () => {
+    mockState.pushAwaitedResult([]);
+    expect(await getUserEmbedToday("ghost")).toBeNull();
   });
 
   it("rejects ambiguous case-insensitive embed stats matches", async () => {

--- a/packages/frontend/src/app/api/embed/[username]/svg/route.ts
+++ b/packages/frontend/src/app/api/embed/[username]/svg/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getUserEmbedStats, getUserEmbedContributions, type EmbedSortBy } from "@/lib/embed/getUserEmbedStats";
+import { getUserEmbedStats, getUserEmbedContributions, getUserEmbedToday, type EmbedSortBy } from "@/lib/embed/getUserEmbedStats";
 import {
   renderProfileEmbedErrorSvg,
   renderProfileEmbedSvg,
@@ -12,6 +12,7 @@ import { renderVitalsEmbedSvg } from "@/lib/embed/renderVitalsEmbedSvg";
 import { renderBlueprintEmbedSvg } from "@/lib/embed/renderBlueprintEmbedSvg";
 import { renderReceiptEmbedSvg } from "@/lib/embed/renderReceiptEmbedSvg";
 import { renderPulseEmbedSvg } from "@/lib/embed/renderPulseEmbedSvg";
+import { renderDetailedEmbedSvg } from "@/lib/embed/renderDetailedEmbedSvg";
 import {
   type EmbedTheme,
   type EmbedTemplate,
@@ -49,6 +50,11 @@ function parseGraph(searchParams: URLSearchParams): boolean {
   return value === "1" || value === "true";
 }
 
+function parseToday(searchParams: URLSearchParams): boolean {
+  const value = searchParams.get("today");
+  return value === "1" || value === "true";
+}
+
 function parseView(searchParams: URLSearchParams): "2d" | "3d" {
   return searchParams.get("view") === "3d" ? "3d" : "2d";
 }
@@ -78,6 +84,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
   const compact = parseCompact(searchParams);
   const sortBy = parseSort(searchParams);
   const showGraph = parseGraph(searchParams);
+  const showToday = parseToday(searchParams);
   const view = parseView(searchParams);
   const template: EmbedTemplate = parseEmbedTemplate(searchParams.get("template"));
   const color: EmbedColorName | null = parseEmbedColor(searchParams.get("color"));
@@ -131,13 +138,21 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     }
 
     // The classic card fetches contributions on demand (`graph=1`); every other
-    // template receives them and decides how/whether to render the graph.
-    const wantsContributions = template === "classic" ? showGraph && !compact : true;
-    const contributions = wantsContributions
-      ? await getUserEmbedContributions(username).catch(() => null)
-      : null;
+    // (non-detailed) template receives them and decides how/whether to render
+    // the graph. The detailed template needs today's usage instead.
+    const wantsContributions = template === "detailed"
+      ? false
+      : template === "classic" ? showGraph && !compact : true;
+    const wantsToday = template === "detailed" || showToday;
+    const [contributions, todayUsage] = await Promise.all([
+      wantsContributions ? getUserEmbedContributions(username).catch(() => null) : null,
+      wantsToday ? getUserEmbedToday(username).catch(() => null) : null,
+    ]);
 
-    const common = { theme, color, sortBy, tokensFormat, costFormat, rankFormat, contributions };
+    // The 4th "today" metric is opt-in via `today=1`; the detailed template
+    // always renders today, so it takes the data directly.
+    const today = showToday ? todayUsage : null;
+    const common = { theme, color, sortBy, tokensFormat, costFormat, rankFormat, contributions, today };
     let svg: string;
     switch (template) {
       case "minimal": svg = renderMinimalEmbedSvg(data, { ...common, graph: showGraph }); break;
@@ -148,6 +163,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       case "blueprint": svg = renderBlueprintEmbedSvg(data, { ...common, graph: showGraph }); break;
       case "receipt": svg = renderReceiptEmbedSvg(data, { ...common, graph: showGraph }); break;
       case "pulse": svg = renderPulseEmbedSvg(data, common); break;
+      case "detailed": svg = renderDetailedEmbedSvg(data, { theme, color, tokensFormat, costFormat, today: todayUsage }); break;
       default:
         svg = renderProfileEmbedSvg(data, { ...common, compact, compactNumbers: compact });
         break;

--- a/packages/frontend/src/components/profile/ProfileEmbedDialog.tsx
+++ b/packages/frontend/src/components/profile/ProfileEmbedDialog.tsx
@@ -76,8 +76,11 @@ export function ProfileEmbedDialog({ open, username, displayName, onClose }: Pro
   const [costFormat, setCostFormat] = useState<EmbedNumberFormat>("compact");
   const [rankFormat, setRankFormat] = useState<EmbedRankFormat>("plain");
   const [graph, setGraph] = useState(false);
+  const [today, setToday] = useState(false);
 
-  const graphCapable = template !== "graph" && template !== "vitals";
+  const graphCapable = template !== "graph" && template !== "vitals" && template !== "detailed";
+  // The detailed template always shows today, so the toggle is hidden there.
+  const todayCapable = template !== "detailed";
 
   useEffect(() => {
     if (!open) return;
@@ -102,6 +105,7 @@ export function ProfileEmbedDialog({ open, username, displayName, onClose }: Pro
     if (color) params.set("color", color);
     if (template === "classic" && compact) params.set("compact", "1");
     if (graph && graphCapable) params.set("graph", "1");
+    if (today && todayCapable) params.set("today", "1");
     if (rankFormat !== "plain") params.set("rank", rankFormat);
     params.set("tokens", tokensFormat);
     params.set("cost", costFormat);
@@ -118,7 +122,7 @@ export function ProfileEmbedDialog({ open, username, displayName, onClose }: Pro
       htmlSnippet: `<a href="${resolvedProfileUrl}"><img alt="Tokens Stats for @${username}" src="${resolvedEmbedUrl}" /></a>`,
       profileUrl: resolvedProfileUrl,
     };
-  }, [color, compact, costFormat, graph, graphCapable, rankFormat, sortBy, template, theme, tokensFormat, username, view]);
+  }, [color, compact, costFormat, graph, graphCapable, rankFormat, sortBy, template, theme, today, todayCapable, tokensFormat, username, view]);
 
   const copyToClipboard = async (value: string, label: string) => {
     try {
@@ -233,6 +237,12 @@ export function ProfileEmbedDialog({ open, username, displayName, onClose }: Pro
             {graphCapable && (
               <OptionGroup label="Contribution graph">
                 <Segmented options={[{ id: "off", label: "Off" }, { id: "on", label: "On" }]} value={graph ? "on" : "off"} onChange={(v) => setGraph(v === "on")} />
+              </OptionGroup>
+            )}
+
+            {todayCapable && (
+              <OptionGroup label="Today's usage">
+                <Segmented options={[{ id: "off", label: "Off" }, { id: "on", label: "On" }]} value={today ? "on" : "off"} onChange={(v) => setToday(v === "on")} />
               </OptionGroup>
             )}
 

--- a/packages/frontend/src/lib/embed/embedShared.ts
+++ b/packages/frontend/src/lib/embed/embedShared.ts
@@ -7,8 +7,9 @@
  * onto the embed accent colors, number-format parsing, font stacks, the
  * contribution-grid layout, and small SVG building blocks.
  */
-import { escapeXml } from "../format";
+import { escapeXml, formatNumber, formatCurrency } from "../format";
 import { colorPalettes, getPaletteNames, type ColorPaletteName } from "../themes";
+import type { EmbedTodayUsage } from "./getUserEmbedStats";
 
 export { escapeXml };
 
@@ -22,7 +23,8 @@ export type EmbedTemplate =
   | "vitals"
   | "blueprint"
   | "receipt"
-  | "pulse";
+  | "pulse"
+  | "detailed";
 export type EmbedNumberFormat = "compact" | "full";
 export type EmbedRankFormat = "plain" | "percent" | "total";
 export type EmbedColorName = ColorPaletteName;
@@ -143,7 +145,23 @@ export const EMBED_TEMPLATES: EmbedTemplate[] = [
   "blueprint",
   "receipt",
   "pulse",
+  "detailed",
 ];
+
+/** Templates that support the optional "Today's usage" 4th metric. */
+export const EMBED_TODAY_CAPABLE = EMBED_TEMPLATES.filter((t) => t !== "detailed");
+
+/**
+ * Combined "<tokens> · <cost>" string for today's usage, used as the 4th metric
+ * value across templates so the wording stays identical everywhere.
+ */
+export function formatTodayInline(
+  today: EmbedTodayUsage,
+  tokensCompact: boolean,
+  costCompact: boolean,
+): string {
+  return `${formatNumber(today.tokens, tokensCompact)} · ${formatCurrency(today.cost, costCompact)}`;
+}
 
 /** Parse the `template` query param, falling back to the classic card. */
 export function parseEmbedTemplate(value: string | null): EmbedTemplate {

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -17,6 +17,37 @@ export interface EmbedContributionDay {
   intensity: 0 | 1 | 2 | 3 | 4;
 }
 
+export interface EmbedTodayModel {
+  modelId: string;
+  tokens: number;
+  cost: number;
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  reasoning: number;
+  messages: number;
+}
+
+export interface EmbedTodayClient {
+  /** ClientType key, e.g. "claude". */
+  source: string;
+  tokens: number;
+  cost: number;
+  messages: number;
+  /** Models used by this client today, sorted by cost descending. */
+  models: EmbedTodayModel[];
+}
+
+export interface EmbedTodayUsage {
+  /** UTC calendar date (YYYY-MM-DD) this usage is for. */
+  date: string;
+  tokens: number;
+  cost: number;
+  /** Clients active today, sorted by cost descending. */
+  clients: EmbedTodayClient[];
+}
+
 export interface UserEmbedStats {
   user: {
     id: string;
@@ -175,6 +206,111 @@ export function getUserEmbedContributions(username: string): Promise<EmbedContri
     [`embed-contrib:${usernameCacheKey}`],
     {
       tags: [`user:${usernameCacheKey}`, `embed-contrib:${usernameCacheKey}`],
+      revalidate: 60,
+    }
+  )();
+}
+
+/** Accumulator mirroring EmbedTodayModel, summed across device rows. */
+type ModelAccumulator = Omit<EmbedTodayModel, "modelId">;
+
+function emptyModelAcc(): ModelAccumulator {
+  return { tokens: 0, cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0, reasoning: 0, messages: 0 };
+}
+
+async function fetchUserEmbedToday(username: string): Promise<EmbedTodayUsage | null> {
+  const matchingUsers = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(usernameEqualsIgnoreCase(username))
+    .limit(USERNAME_LOOKUP_LIMIT);
+  const user = getSingleUsernameMatch(matchingUsers, username);
+
+  if (!user) return null;
+
+  // "Today" is the current UTC calendar date: embeds are server-rendered and
+  // CDN-cached static SVGs, so there is no viewer timezone to localize to.
+  const today = new Date().toISOString().split("T")[0];
+
+  const rows = await db
+    .select({
+      tokens: dailyBreakdown.tokens,
+      cost: dailyBreakdown.cost,
+      sourceBreakdown: dailyBreakdown.sourceBreakdown,
+    })
+    .from(dailyBreakdown)
+    .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
+    .where(and(eq(submissions.userId, user.id), eq(dailyBreakdown.date, today)));
+
+  let totalTokens = 0;
+  let totalCost = 0;
+  // source key -> { tokens, cost, messages, models: modelId -> ModelAccumulator }
+  const clients = new Map<
+    string,
+    { tokens: number; cost: number; messages: number; models: Map<string, ModelAccumulator> }
+  >();
+
+  for (const row of rows) {
+    totalTokens += Number(row.tokens) || 0;
+    totalCost += Number(row.cost) || 0;
+
+    const breakdown = row.sourceBreakdown;
+    if (!breakdown) continue;
+
+    for (const [source, sourceData] of Object.entries(breakdown)) {
+      if (!sourceData) continue;
+      let client = clients.get(source);
+      if (!client) {
+        client = { tokens: 0, cost: 0, messages: 0, models: new Map() };
+        clients.set(source, client);
+      }
+      client.tokens += Number(sourceData.tokens) || 0;
+      client.cost += Number(sourceData.cost) || 0;
+      client.messages += Number(sourceData.messages) || 0;
+
+      const models = sourceData.models ?? {};
+      for (const [modelId, modelData] of Object.entries(models)) {
+        if (!modelData) continue;
+        let acc = client.models.get(modelId);
+        if (!acc) {
+          acc = emptyModelAcc();
+          client.models.set(modelId, acc);
+        }
+        acc.tokens += Number(modelData.tokens) || 0;
+        acc.cost += Number(modelData.cost) || 0;
+        acc.input += Number(modelData.input) || 0;
+        acc.output += Number(modelData.output) || 0;
+        acc.cacheRead += Number(modelData.cacheRead) || 0;
+        acc.cacheWrite += Number(modelData.cacheWrite) || 0;
+        acc.reasoning += Number(modelData.reasoning) || 0;
+        acc.messages += Number(modelData.messages) || 0;
+      }
+    }
+  }
+
+  const clientList: EmbedTodayClient[] = Array.from(clients.entries())
+    .map(([source, client]) => ({
+      source,
+      tokens: client.tokens,
+      cost: client.cost,
+      messages: client.messages,
+      models: Array.from(client.models.entries())
+        .map(([modelId, acc]) => ({ modelId, ...acc }))
+        .sort((a, b) => b.cost - a.cost),
+    }))
+    .sort((a, b) => b.cost - a.cost);
+
+  return { date: today, tokens: totalTokens, cost: totalCost, clients: clientList };
+}
+
+export function getUserEmbedToday(username: string): Promise<EmbedTodayUsage | null> {
+  const usernameCacheKey = normalizeUsernameCacheKey(username);
+
+  return unstable_cache(
+    () => fetchUserEmbedToday(username),
+    [`embed-today:${usernameCacheKey}`],
+    {
+      tags: [`user:${usernameCacheKey}`, `embed-today:${usernameCacheKey}`],
       revalidate: 60,
     }
   )();

--- a/packages/frontend/src/lib/embed/renderBlueprintEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderBlueprintEmbedSvg.ts
@@ -3,7 +3,7 @@
  * dimensioned stat values, a contribution "activity profile", and a drawing
  * title block along the bottom.
  */
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type EmbedTheme,
@@ -28,6 +28,7 @@ export interface RenderBlueprintEmbedOptions {
   rankFormat?: EmbedRankFormat;
   contributions?: EmbedContributionDay[] | null;
   graph?: boolean;
+  today?: EmbedTodayUsage | null;
 }
 
 const W = 640;
@@ -60,6 +61,12 @@ export function renderBlueprintEmbedSvg(
     { value: formatCurrency(data.stats.totalCost, costFormat === "compact"), label: "COST" },
     { value: rankText, label: "LEADERBOARD RANK" },
   ];
+  if (options.today) {
+    stats.push({
+      value: formatNumber(options.today.tokens, tokensFormat === "compact"),
+      label: `TODAY · ${formatCurrency(options.today.cost, costFormat === "compact")}`,
+    });
+  }
 
   const updated = escapeXml(formatDateLabel(data.stats.updatedAt).replace(/^Updated /, ""));
   const parts: string[] = [];
@@ -86,13 +93,14 @@ export function renderBlueprintEmbedSvg(
   add(`  <text x="${W - PAD}" y="40" fill="${palette.text}" font-size="12" font-weight="700" text-anchor="end" font-family="${MONO_FONT_STACK}">@${escapeXml(data.user.username)}</text>`);
   add(`  <line x1="${PAD}" y1="52" x2="${W - PAD}" y2="52" stroke="${palette.divider}"/>`);
 
-  // Dimensioned stats.
+  // Dimensioned stats (columns scale with the stat count: 3, or 4 with today).
+  const colW = INNER / stats.length;
   stats.forEach((s, i) => {
-    const cx = PAD + INNER / 6 + i * (INNER / 3);
+    const cx = PAD + colW / 2 + i * colW;
     // Shrink long values so they never collide with the neighbouring column.
-    const vSize = Math.max(13, Math.min(24, 168 / (s.value.length * 0.62)));
+    const vSize = Math.max(12, Math.min(24, (colW * 0.85) / (s.value.length * 0.62)));
     add(`  <text x="${cx.toFixed(1)}" y="100" fill="${palette.text}" font-size="${vSize.toFixed(1)}" font-weight="700" text-anchor="middle" font-family="${MONO_FONT_STACK}">${escapeXml(s.value)}</text>`);
-    const half = 84;
+    const half = Math.min(84, colW / 2 - 8);
     add(`  <line x1="${cx - half}" y1="116" x2="${cx + half}" y2="116" stroke="${accent}" stroke-width="1"/>`);
     add(`  <line x1="${cx - half}" y1="112" x2="${cx - half}" y2="120" stroke="${accent}" stroke-width="1"/>`);
     add(`  <line x1="${cx + half}" y1="112" x2="${cx + half}" y2="120" stroke="${accent}" stroke-width="1"/>`);

--- a/packages/frontend/src/lib/embed/renderDetailedEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderDetailedEmbedSvg.ts
@@ -1,0 +1,188 @@
+/**
+ * "detailed" embed template — today's usage broken down per client and per
+ * model, the embed analogue of the profile page's BreakdownPanel "Detailed
+ * Breakdown". Always shows the current UTC day; unaffected by the `today`
+ * toggle (which gates the 4th metric on the other templates).
+ */
+import type { UserEmbedStats, EmbedTodayUsage, EmbedTodayClient } from "./getUserEmbedStats";
+import type { ClientType } from "../types";
+import { formatNumber, formatCurrency } from "../format";
+import { SOURCE_DISPLAY_NAMES, SOURCE_COLORS } from "../constants";
+import {
+  type EmbedTheme,
+  type EmbedColorName,
+  type EmbedNumberFormat,
+  resolvePalette,
+  FIGTREE_FONT_STACK,
+  FIGTREE_FONT_IMPORT,
+  MONO_FONT_STACK,
+  brandIcon,
+  formatDateLabel,
+  escapeXml,
+} from "./embedShared";
+
+export interface RenderDetailedEmbedOptions {
+  theme?: EmbedTheme;
+  color?: EmbedColorName | null;
+  tokensFormat?: EmbedNumberFormat;
+  costFormat?: EmbedNumberFormat;
+  today?: EmbedTodayUsage | null;
+}
+
+const W = 680;
+const PAD = 24;
+const INNER = W - PAD * 2;
+const RX = 16;
+const MAX_CLIENTS = 6;
+const MAX_MODELS_PER_CLIENT = 4;
+
+function clientLabel(source: string): string {
+  return SOURCE_DISPLAY_NAMES[source as ClientType] ?? source;
+}
+
+function clientColor(source: string, fallback: string): string {
+  return SOURCE_COLORS[source as ClientType] ?? fallback;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+/** Today's UTC date as "Mon D, YYYY". */
+function formatTodayDate(date: string): string {
+  const parsed = new Date(`${date}T00:00:00.000Z`);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(parsed);
+}
+
+function modelSubLine(model: EmbedTodayClient["models"][number]): string {
+  const bits: string[] = [];
+  if (model.input > 0) bits.push(`in ${formatNumber(model.input, true)}`);
+  if (model.output > 0) bits.push(`out ${formatNumber(model.output, true)}`);
+  const cache = model.cacheRead + model.cacheWrite;
+  if (cache > 0) bits.push(`cache ${formatNumber(cache, true)}`);
+  if (model.reasoning > 0) bits.push(`reason ${formatNumber(model.reasoning, true)}`);
+  bits.push(`${model.messages.toLocaleString("en-US")} msg${model.messages === 1 ? "" : "s"}`);
+  return bits.join("  ·  ");
+}
+
+export function renderDetailedEmbedSvg(
+  data: UserEmbedStats,
+  options: RenderDetailedEmbedOptions = {},
+): string {
+  const theme: EmbedTheme = options.theme === "light" ? "light" : "dark";
+  const palette = resolvePalette(theme, options.color ?? null);
+  const tokensCompact = (options.tokensFormat ?? "compact") === "compact";
+  const costCompact = (options.costFormat ?? "compact") === "compact";
+
+  const today = options.today ?? null;
+  const username = `@${data.user.username}`;
+  const dateLabel = today ? `${formatTodayDate(today.date)} · UTC` : "Today · UTC";
+
+  // Body is built with a running cursor so the card height adapts to content.
+  const body: string[] = [];
+  const add = (s: string) => body.push(s);
+
+  // ---- Header (shared by the populated and empty states) ----
+  add(`  ${brandIcon(PAD, 32, palette.brand)}`);
+  add(`  <text x="${PAD + 18}" y="32" fill="${palette.muted}" font-size="12" font-weight="600" font-family="${FIGTREE_FONT_STACK}">Tokens · Daily Detail</text>`);
+  add(`  <text x="${W - PAD}" y="32" fill="${palette.text}" font-size="14" font-weight="700" text-anchor="end" font-family="${FIGTREE_FONT_STACK}">${escapeXml(username)}</text>`);
+  add(`  <text x="${PAD}" y="62" fill="${palette.title}" font-size="20" font-weight="800" font-family="${FIGTREE_FONT_STACK}">Today's usage</text>`);
+  add(`  <text x="${W - PAD}" y="62" fill="${palette.muted}" font-size="12" font-weight="600" text-anchor="end" font-family="${FIGTREE_FONT_STACK}">${escapeXml(dateLabel)}</text>`);
+  add(`  <rect x="${PAD}" y="76" width="${INNER}" height="1" fill="url(#dt-divider)"/>`);
+
+  const clients = today?.clients ?? [];
+  let height: number;
+
+  if (clients.length === 0) {
+    // ---- Empty state ----
+    add(`  <text x="${W / 2}" y="132" fill="${palette.text}" font-size="15" font-weight="700" text-anchor="middle" font-family="${FIGTREE_FONT_STACK}">No usage recorded today (UTC)</text>`);
+    add(`  <text x="${W / 2}" y="156" fill="${palette.muted}" font-size="12" text-anchor="middle" font-family="${FIGTREE_FONT_STACK}">Submit today's usage to see a per-client breakdown here.</text>`);
+    height = 220;
+  } else {
+    // ---- Summary strip ----
+    const modelIds = new Set<string>();
+    for (const c of clients) for (const m of c.models) modelIds.add(m.modelId);
+    const stat = (value: string, label: string, color: string): string =>
+      `<tspan fill="${color}" font-weight="800">${escapeXml(value)}</tspan><tspan fill="${palette.muted}" font-weight="600"> ${label}</tspan>`;
+    const sep = `<tspan fill="${palette.divider}">      </tspan>`;
+    add(`  <text x="${PAD}" y="102" font-size="13" font-family="${FIGTREE_FONT_STACK}" xml:space="preserve">${[
+      stat(formatNumber(today!.tokens, tokensCompact), "tokens", palette.tokenEnd),
+      stat(formatCurrency(today!.cost, costCompact), "spent", palette.cost),
+      stat(String(clients.length), `client${clients.length === 1 ? "" : "s"}`, palette.text),
+      stat(String(modelIds.size), `model${modelIds.size === 1 ? "" : "s"}`, palette.text),
+    ].join(sep)}</text>`);
+
+    // ---- Per-client sections ----
+    let y = 128;
+    const shownClients = clients.slice(0, MAX_CLIENTS);
+    for (const client of shownClients) {
+      const color = clientColor(client.source, palette.brand);
+      add(`  <circle cx="${PAD + 5}" cy="${y - 4}" r="5" fill="${color}"/>`);
+      add(`  <text x="${PAD + 18}" y="${y}" fill="${palette.text}" font-size="14" font-weight="700" font-family="${FIGTREE_FONT_STACK}">${escapeXml(clientLabel(client.source))}</text>`);
+      add(`  <text x="${W - PAD}" y="${y}" fill="${palette.cost}" font-size="13" font-weight="700" text-anchor="end" font-family="${FIGTREE_FONT_STACK}">${escapeXml(formatCurrency(client.cost, costCompact))}</text>`);
+      y += 22;
+
+      const shownModels = client.models.slice(0, MAX_MODELS_PER_CLIENT);
+      for (const model of shownModels) {
+        add(`  <text x="${PAD + 18}" y="${y}" fill="${palette.text}" font-size="12" font-weight="600" font-family="${MONO_FONT_STACK}">${escapeXml(truncate(model.modelId, 44))}</text>`);
+        add(`  <text x="${W - PAD}" y="${y}" fill="${palette.brand}" font-size="12" font-weight="700" text-anchor="end" font-family="${MONO_FONT_STACK}">${escapeXml(formatCurrency(model.cost, costCompact))}</text>`);
+        y += 15;
+        add(`  <text x="${PAD + 18}" y="${y}" fill="${palette.muted}" font-size="10" font-family="${MONO_FONT_STACK}">${escapeXml(modelSubLine(model))}</text>`);
+        y += 19;
+      }
+
+      const hiddenModels = client.models.length - shownModels.length;
+      if (hiddenModels > 0) {
+        add(`  <text x="${PAD + 18}" y="${y}" fill="${palette.muted}" font-size="11" font-family="${FIGTREE_FONT_STACK}">+${hiddenModels} more model${hiddenModels === 1 ? "" : "s"}</text>`);
+        y += 18;
+      }
+      y += 10;
+    }
+
+    const hiddenClients = clients.length - shownClients.length;
+    if (hiddenClients > 0) {
+      add(`  <text x="${PAD}" y="${y}" fill="${palette.muted}" font-size="11" font-weight="600" font-family="${FIGTREE_FONT_STACK}">+${hiddenClients} more client${hiddenClients === 1 ? "" : "s"}</text>`);
+      y += 18;
+    }
+
+    height = y + 26;
+  }
+
+  // ---- Footer ----
+  const updated = escapeXml(formatDateLabel(data.stats.updatedAt));
+  const footerY = height - 14;
+  add(`  <rect x="${PAD}" y="${footerY - 20}" width="${INNER}" height="1" fill="url(#dt-divider)"/>`);
+  add(`  <text x="${PAD}" y="${footerY}" fill="${palette.muted}" font-size="11" font-family="${FIGTREE_FONT_STACK}">${updated}</text>`);
+  add(`  <text x="${W - PAD}" y="${footerY}" fill="${palette.muted}" font-size="11" text-anchor="end" font-family="${FIGTREE_FONT_STACK}">tokens.ci/u/${escapeXml(data.user.username)}</text>`);
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="${W}" height="${height}" viewBox="0 0 ${W} ${height}" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Tokens daily usage detail for ${escapeXml(username)}">
+  <defs>
+    <style>@import url('${FIGTREE_FONT_IMPORT}');</style>
+    <linearGradient id="dt-bg" x1="0" y1="0" x2="${W}" y2="${height}" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="${palette.bgStart}"/>
+      <stop offset="1" stop-color="${palette.bgEnd}"/>
+    </linearGradient>
+    <radialGradient id="dt-glow" cx="0.85" cy="0.05" r="0.8">
+      <stop offset="0" stop-color="${palette.glowColor}" stop-opacity="${palette.glowOpacity + 0.03}"/>
+      <stop offset="1" stop-color="${palette.glowColor}" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="dt-divider" x1="${PAD}" y1="0" x2="${W - PAD}" y2="0" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="${palette.divider}" stop-opacity="0"/>
+      <stop offset="0.5" stop-color="${palette.divider}" stop-opacity="0.6"/>
+      <stop offset="1" stop-color="${palette.divider}" stop-opacity="0"/>
+    </linearGradient>
+    <clipPath id="dt-clip"><rect width="${W}" height="${height}" rx="${RX}"/></clipPath>
+  </defs>
+  <rect width="${W}" height="${height}" rx="${RX}" fill="url(#dt-bg)"/>
+  <rect width="${W}" height="${height}" rx="${RX}" fill="url(#dt-glow)" clip-path="url(#dt-clip)"/>
+  <rect x="0.5" y="0.5" width="${W - 1}" height="${height - 1}" rx="${RX - 0.5}" fill="none" stroke="${palette.border}"/>
+${body.join("\n")}
+</svg>`;
+}

--- a/packages/frontend/src/lib/embed/renderGraphEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderGraphEmbedSvg.ts
@@ -3,7 +3,7 @@
  * hero: large cells span the full width, with a compact stat strip in the
  * header and a Less/More legend below.
  */
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type EmbedTheme,
@@ -14,6 +14,7 @@ import {
   gradeColors,
   getRankColor,
   formatDateLabel,
+  formatTodayInline,
   brandIcon,
   FIGTREE_FONT_STACK,
   FIGTREE_FONT_IMPORT,
@@ -30,6 +31,7 @@ export interface RenderGraphEmbedOptions {
   costFormat?: EmbedNumberFormat;
   rankFormat?: EmbedRankFormat;
   contributions?: EmbedContributionDay[] | null;
+  today?: EmbedTodayUsage | null;
 }
 
 const W = 900;
@@ -94,11 +96,15 @@ export function renderGraphEmbedSvg(
   const stat = (label: string, value: string, color: string): string =>
     `<tspan fill="${color}" font-weight="800">${escapeXml(value)}</tspan><tspan fill="${palette.muted}" font-weight="600"> ${label}</tspan>`;
   const sep = `<tspan fill="${palette.divider}">      </tspan>`;
-  add(`  <text x="${W - PAD}" y="40" font-size="14" text-anchor="end" font-family="${FIGTREE_FONT_STACK}" xml:space="preserve">${[
+  const statStrip = [
     stat("tokens", tokens, palette.brand),
     stat("spent", cost, palette.cost),
     stat(`rank (${sortBy})`, rankText, rankColor),
-  ].join(sep)}</text>`);
+  ];
+  if (options.today) {
+    statStrip.push(stat("today", formatTodayInline(options.today, tokensFormat === "compact", costFormat === "compact"), palette.tokenEnd));
+  }
+  add(`  <text x="${W - PAD}" y="40" font-size="14" text-anchor="end" font-family="${FIGTREE_FONT_STACK}" xml:space="preserve">${statStrip.join(sep)}</text>`);
 
   // Month labels.
   for (const m of layout.months) {

--- a/packages/frontend/src/lib/embed/renderMinimalEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderMinimalEmbedSvg.ts
@@ -2,7 +2,7 @@
  * "minimal" embed template — a modern card led by a large token count, with
  * cost and rank shown as header badges and an optional contribution graph.
  */
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type EmbedTheme,
@@ -15,6 +15,7 @@ import {
   FIGTREE_FONT_IMPORT,
   brandIcon,
   formatDateLabel,
+  formatTodayInline,
   getRankColor,
   escapeXml,
   formatRank,
@@ -30,6 +31,7 @@ export interface RenderMinimalEmbedOptions {
   rankFormat?: EmbedRankFormat;
   contributions?: EmbedContributionDay[] | null;
   graph?: boolean;
+  today?: EmbedTodayUsage | null;
 }
 
 const W = 600;
@@ -110,6 +112,12 @@ export function renderMinimalEmbedSvg(
   // Token hero.
   add(`  <text x="${PAD}" y="74" fill="${palette.muted}" font-size="10.5" font-weight="600" letter-spacing="0.1em" font-family="${FIGTREE_FONT_STACK}">TOTAL TOKENS</text>`);
   add(`  <text x="${PAD}" y="112" fill="url(#token-grad)" font-size="${tokenSize}" font-weight="800" font-family="${FIGTREE_FONT_STACK}">${escapeXml(tokens)}</text>`);
+
+  // Optional "today" line below the hero.
+  if (options.today) {
+    const todayInline = formatTodayInline(options.today, tokensFormat === "compact", costFormat === "compact");
+    add(`  <text x="${PAD}" y="131" font-family="${FIGTREE_FONT_STACK}"><tspan fill="${palette.muted}" font-size="11" font-weight="600" letter-spacing="0.06em">TODAY  </tspan><tspan fill="${palette.text}" font-size="12" font-weight="700">${escapeXml(todayInline)}</tspan></text>`);
+  }
 
   // Optional contribution graph.
   if (layout) {

--- a/packages/frontend/src/lib/embed/renderOrbitEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderOrbitEmbedSvg.ts
@@ -3,7 +3,7 @@
  * standing (rank percentile), with token / cost / active-day stats stacked
  * alongside.
  */
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type EmbedTheme,
@@ -33,6 +33,7 @@ export interface RenderOrbitEmbedOptions {
   rankFormat?: EmbedRankFormat;
   contributions?: EmbedContributionDay[] | null;
   graph?: boolean;
+  today?: EmbedTodayUsage | null;
 }
 
 const W = 560;
@@ -55,7 +56,10 @@ export function renderOrbitEmbedSvg(
     ? layoutContributions(options.contributions)
     : null;
   const activeDays = layout ? layout.activeDays : null;
-  const H = showGraph && layout ? 369 : 248;
+  // Stat column: tokens + cost, plus active-days and/or today when present.
+  const statCount = 2 + (activeDays !== null ? 1 : 0) + (options.today ? 1 : 0);
+  const stackBottom = 78 + (statCount - 1) * 52 + 24;
+  const H = showGraph && layout ? 369 : Math.max(248, stackBottom + 28);
 
   const fraction = rank && total && total > 0
     ? Math.max(0.02, (total - rank + 1) / total)
@@ -80,6 +84,13 @@ export function renderOrbitEmbedSvg(
   ];
   if (activeDays !== null) {
     stats.push({ label: "ACTIVE DAYS", value: String(activeDays), fill: palette.text });
+  }
+  if (options.today) {
+    stats.push({
+      label: `TODAY · ${formatCurrency(options.today.cost, costFormat === "compact")}`,
+      value: formatNumber(options.today.tokens, tokensFormat === "compact"),
+      fill: palette.tokenEnd,
+    });
   }
 
   const colX = 312;

--- a/packages/frontend/src/lib/embed/renderProfileEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderProfileEmbedSvg.ts
@@ -1,4 +1,4 @@
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type ThemePalette,
@@ -32,6 +32,7 @@ export interface RenderProfileEmbedOptions {
   rankFormat?: EmbedRankFormat;
   sortBy?: EmbedSortBy;
   contributions?: EmbedContributionDay[] | null;
+  today?: EmbedTodayUsage | null;
 }
 
 // Approximate character-width ratio for Figtree at various weights.
@@ -191,9 +192,14 @@ function renderProfileCardSvg(data: UserEmbedStats, options: RenderProfileEmbedO
   const displayNameEstWidth = displayNameRaw ? displayNameRaw.length * APPROX_CHAR_WIDTH_13 : 0;
   const showDisplayName = Boolean(displayName) && displayNameX + displayNameEstWidth < width - px - 12;
 
+  const todayUsage = options.today ?? null;
+  const todayTokens = todayUsage ? formatNumber(todayUsage.tokens, tokensFormat === "compact") : null;
+  const todayCost = todayUsage ? formatCurrency(todayUsage.cost, costFormat === "compact") : null;
+
   const metricsGap = compact ? 8 : 10;
   const metricsW = width - px * 2;
-  const metricW = (metricsW - metricsGap * 2) / 3;
+  const metricCount = todayUsage ? 4 : 3;
+  const metricW = (metricsW - metricsGap * (metricCount - 1)) / metricCount;
   const rankColor = getRankColor(data.stats.rank, palette);
   const rankAccent = (data.stats.rank && data.stats.rank <= 3)
     ? getRankColor(data.stats.rank, palette)
@@ -284,6 +290,22 @@ function renderProfileCardSvg(data: UserEmbedStats, options: RenderProfileEmbedO
     palette,
     compact,
   })}
+  ${
+    todayUsage
+      ? metricCard({
+          x: px + metricW * 3 + metricsGap * 3,
+          y: metricsY,
+          width: metricW,
+          height: metricH,
+          label: `Today · ${todayCost}`,
+          value: todayTokens as string,
+          accentId: "acc-tokens",
+          valueFill: palette.tokenEnd,
+          palette,
+          compact,
+        })
+      : ""
+  }
   ${contributions ? renderContributionGrid(contributions, palette, px, metricsY + metricH + 12) : ""}
   <text x="${px}" y="${footerY}" fill="${palette.muted}" font-size="11" font-family="${FIGTREE_FONT_STACK}">${updated}</text>
   <text x="${width - px}" y="${footerY}" fill="${palette.muted}" font-size="11" font-family="${FIGTREE_FONT_STACK}" text-anchor="end">tokens.ci/u/${escapeXml(

--- a/packages/frontend/src/lib/embed/renderPulseEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderPulseEmbedSvg.ts
@@ -5,7 +5,7 @@
  * The busiest week is marked. No template in the set charts usage as a trend
  * line, so this is the data-visualization-forward option.
  */
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type EmbedTheme,
@@ -16,6 +16,7 @@ import {
   layoutContributions,
   formatDateLabel,
   formatRank,
+  formatTodayInline,
   brandIcon,
   FIGTREE_FONT_STACK,
   FIGTREE_FONT_IMPORT,
@@ -30,6 +31,7 @@ export interface RenderPulseEmbedOptions {
   costFormat?: EmbedNumberFormat;
   rankFormat?: EmbedRankFormat;
   contributions?: EmbedContributionDay[] | null;
+  today?: EmbedTodayUsage | null;
 }
 
 const W = 900;
@@ -118,11 +120,15 @@ export function renderPulseEmbedSvg(
   const stat = (label: string, value: string, color: string): string =>
     `<tspan fill="${color}" font-weight="800" font-size="22">${escapeXml(value)}</tspan><tspan fill="${palette.muted}" font-weight="600" font-size="13"> ${label}</tspan>`;
   const sep = `<tspan fill="${palette.divider}">      </tspan>`;
-  add(`  <text x="${PAD}" y="78" font-family="${FIGTREE_FONT_STACK}" xml:space="preserve">${[
+  const statLine = [
     stat("tokens", tokens, palette.accentTokens),
     stat(`spent (${sortBy})`, cost, palette.cost),
     stat("active days", String(layout.activeDays), palette.text),
-  ].join(sep)}</text>`);
+  ];
+  if (options.today) {
+    statLine.push(stat("today", formatTodayInline(options.today, tokensFormat === "compact", costFormat === "compact"), palette.tokenEnd));
+  }
+  add(`  <text x="${PAD}" y="78" font-family="${FIGTREE_FONT_STACK}" xml:space="preserve">${statLine.join(sep)}</text>`);
 
   // Faint gridlines.
   for (let g = 1; g <= 2; g++) {

--- a/packages/frontend/src/lib/embed/renderReceiptEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderReceiptEmbedSvg.ts
@@ -3,7 +3,7 @@
  * a narrow torn-edge column of monospace line items with dot leaders, a
  * total, and a faux barcode. The narrowest template.
  */
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type EmbedTheme,
@@ -13,6 +13,7 @@ import {
   layoutContributions,
   gradeColors,
   formatDateLabel,
+  formatTodayInline,
   MONO_FONT_STACK,
   escapeXml,
   formatRank,
@@ -28,6 +29,7 @@ export interface RenderReceiptEmbedOptions {
   rankFormat?: EmbedRankFormat;
   contributions?: EmbedContributionDay[] | null;
   graph?: boolean;
+  today?: EmbedTodayUsage | null;
 }
 
 const W = 400;
@@ -65,7 +67,8 @@ export function renderReceiptEmbedSvg(
   const showGraph = options.graph ?? false;
   const drawGraph = showGraph && (options.contributions?.length ?? 0) > 0;
   const GBAND = 72;
-  const H = 354 + (drawGraph ? GBAND : 0);
+  // Each extra line item below shifts the total + barcode down by 26px.
+  const H = 354 + (drawGraph ? GBAND : 0) + (options.today ? 26 : 0);
   const rankText = data.stats.rank
     ? formatRank(data.stats.rank, data.stats.rankTotal ?? null, options.rankFormat)
     : "UNRANKED";
@@ -74,6 +77,9 @@ export function renderReceiptEmbedSvg(
     ["ACTIVE DAYS", String(layout.activeDays)],
     ["LEADERBOARD", rankText],
   ];
+  if (options.today) {
+    items.push(["TODAY", formatTodayInline(options.today, tokensFormat === "compact", costFormat === "compact")]);
+  }
   const total = formatCurrency(data.stats.totalCost, costFormat === "compact");
   const dateLabel = formatDateLabel(data.stats.updatedAt).replace(/^Updated /, "");
 

--- a/packages/frontend/src/lib/embed/renderTerminalEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderTerminalEmbedSvg.ts
@@ -3,7 +3,7 @@
  * command-output aesthetic: window chrome, a prompt line, aligned key/value
  * stats, and the contribution graph as a block grid.
  */
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type EmbedTheme,
@@ -14,6 +14,7 @@ import {
   gradeColors,
   getRankColor,
   formatDateLabel,
+  formatTodayInline,
   MONO_FONT_STACK,
   escapeXml,
   formatRank,
@@ -29,6 +30,7 @@ export interface RenderTerminalEmbedOptions {
   rankFormat?: EmbedRankFormat;
   contributions?: EmbedContributionDay[] | null;
   graph?: boolean;
+  today?: EmbedTodayUsage | null;
 }
 
 const W = 600;
@@ -68,6 +70,13 @@ export function renderTerminalEmbedSvg(
     { label: "cost", value: cost, color: palette.cost },
     { label: "rank", value: `${rankText}  (${sortBy})`, color: rankColor },
   ];
+  if (options.today) {
+    rows.push({
+      label: "today",
+      value: formatTodayInline(options.today, tokensFormat === "compact", costFormat === "compact"),
+      color: palette.tokenEnd,
+    });
+  }
   if (layout) {
     rows.push({ label: "active", value: `${layout.activeDays} days`, color: palette.text });
   }

--- a/packages/frontend/src/lib/embed/renderVitalsEmbedSvg.ts
+++ b/packages/frontend/src/lib/embed/renderVitalsEmbedSvg.ts
@@ -3,7 +3,7 @@
  * active-days ratio, average intensity) with the token total at the center
  * and a labeled legend alongside.
  */
-import type { UserEmbedStats, EmbedContributionDay } from "./getUserEmbedStats";
+import type { UserEmbedStats, EmbedContributionDay, EmbedTodayUsage } from "./getUserEmbedStats";
 import { formatNumber, formatCurrency } from "../format";
 import {
   type EmbedTheme,
@@ -30,10 +30,11 @@ export interface RenderVitalsEmbedOptions {
   costFormat?: EmbedNumberFormat;
   rankFormat?: EmbedRankFormat;
   contributions?: EmbedContributionDay[] | null;
+  today?: EmbedTodayUsage | null;
 }
 
 const W = 520;
-const H = 250;
+const BASE_H = 250;
 const PAD = 24;
 const SW = 12;
 
@@ -72,6 +73,16 @@ export function renderVitalsEmbedSvg(
     { name: "Active days", value: String(layout.activeDays), sub: "of ~365", color: grades[3] },
     { name: "Avg intensity", value: avgIntensity.toFixed(1), sub: "of 4.0", color: grades[2] },
   ];
+  if (options.today) {
+    legend.push({
+      name: "Today (UTC)",
+      value: formatNumber(options.today.tokens, tokensFormat === "compact"),
+      sub: formatCurrency(options.today.cost, costFormat === "compact"),
+      color: palette.tokenEnd,
+    });
+  }
+  // Extend the card when the optional 4th (today) legend row is present.
+  const H = BASE_H + (options.today ? 50 : 0);
 
   const tokens = formatNumber(data.stats.totalTokens, tokensFormat === "compact");
   const cost = formatCurrency(data.stats.totalCost, costFormat === "compact");


### PR DESCRIPTION
## Summary

Adds a **"Today's usage"** option to the profile embed styling, plus a new **Detailed** template — both driven by the current UTC day's usage.

### 1. Today's usage toggle (`today=1`)
When enabled, every one of the 9 existing card templates renders a 4th metric showing **today's tokens + cost**:
- **classic** — a 4th metric card (`Today · $cost` / token value); the metric row reflows from 3 to 4 columns
- **terminal / receipt** — an extra line item
- **graph / pulse** — an extra entry in the header/stat strip
- **minimal** — a `TODAY` line under the token hero
- **orbit / blueprint** — a 4th stat column (height/width adapt)
- **vitals** — a 4th legend row (card extends)

### 2. New `detailed` template
Always shows today's **per-client / per-model** breakdown — the embed analogue of the profile page's *Detailed Breakdown* panel (`BreakdownPanel`). Reuses `SOURCE_DISPLAY_NAMES` / `SOURCE_COLORS`. Includes an empty state for days with no usage.

### Data
New `getUserEmbedToday()` fetcher aggregates `daily_breakdown.sourceBreakdown` across device rows for the current **UTC** date (embeds are server-rendered, CDN-cached static SVGs, so viewer-local time isn't available). Cached with `unstable_cache` (60s, tagged per user) like the existing embed fetchers.

### Dialog
`ProfileEmbedDialog` gains a *Today's usage* Off/On toggle (hidden for the detailed template, which always shows today); `Detailed` appears in the template picker automatically.

## Testing
- `vitest` — 72 passing across `embedTemplates`, `getUserEmbedStats`, `embedSvgRoute`:
  - every template omits today by default and renders it when `today` is provided
  - detailed renderer: breakdown content, empty state, XML escaping
  - `getUserEmbedToday` aggregation (merge across device rows, sort by cost)
  - route: `today=1` passes data through, detailed always fetches today, no fetch otherwise
- `tsc --noEmit` and `eslint` clean for all changed files