### PR TITLE
fix(menubar): avoid automatic full history scans

### DIFF
--- a/packages/menubar/Sources/TokscaleMenuBar/MenuBarModel.swift
+++ b/packages/menubar/Sources/TokscaleMenuBar/MenuBarModel.swift
@@ -26,6 +26,7 @@ final class MenuBarModel: ObservableObject {
     // bumps both stamps.
     private var lastTodayScan = Date.distantPast
     private var lastHistoryScan = Date.distantPast
+    private let openRefreshScanPolicy = OpenRefreshScanPolicy()
 
     init() {
         reload()
@@ -137,33 +138,35 @@ final class MenuBarModel: ObservableObject {
     }
 
     func refreshOnOpenIfNeeded() {
-        // No cache yet: do the first full scan in the background so the popover stays
-        // responsive while it runs.
+        // No cache yet: avoid auto-starting a full-history scan from merely
+        // opening the menu. The explicit Refresh command still runs the full scan.
         if summary == nil {
-            backgroundFullScan()
+            refreshStatus = "Open Refresh skipped: no summary yet."
             return
         }
-        // First page wins: always refresh live quota right away (fast, local), even
-        // while a background scan is running, so the glance page is current the
-        // instant the popover opens. The full usage scan is slow (minutes), so it
-        // runs silently in the background afterwards and is throttled hard. With
-        // "Refresh on open = Off" only the background scan is skipped, never quota.
         guard !isRefreshing else { return }
         let cadence = RefreshCadence(
             storedValue: UserDefaults.standard.string(forKey: RefreshCadence.storageKey)
         )
         // First page wins: quota refreshes immediately on every open (fast, local),
-        // even while a scan runs. Then pick the cheapest scan that's due: a daily
-        // full history scan, otherwise a throttled today-only scan (~2s). With
-        // "Refresh on open = Off" only quota refreshes, never a background scan.
+        // even while a scan runs. Then run at most a throttled today-only scan
+        // (~2s); full history scans only start from the explicit Refresh action.
+        // With "Refresh on open = Off" only the background scan is skipped, never quota.
+        let needsUsageScan: Bool
+        if let interval = cadence.minimumInterval {
+            needsUsageScan = summary?.needsScanOnOpen(minimumInterval: interval) ?? true
+        } else {
+            needsUsageScan = false
+        }
         refreshQuota { [weak self] in
-            guard let self, cadence.minimumInterval != nil, !self.isBackgroundScanning else {
-                return
-            }
-            let now = Date()
-            if now.timeIntervalSince(self.lastHistoryScan) > 86_400 {
-                self.backgroundFullScan()
-            } else if now.timeIntervalSince(self.lastTodayScan) > 600 {
+            guard let self else { return }
+            let scan = self.openRefreshScanPolicy.scan(
+                summaryIsMissing: self.summary == nil,
+                needsUsageScan: needsUsageScan,
+                isBackgroundScanning: self.isBackgroundScanning,
+                lastTodayScan: self.lastTodayScan
+            )
+            if scan == .today {
                 self.backgroundTodayScan()
             }
         }

--- a/packages/menubar/Sources/TokscaleMenuBarCore/RefreshCadence.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/RefreshCadence.swift
@@ -38,3 +38,28 @@ public enum RefreshCadence: String, CaseIterable, Sendable {
         }
     }
 }
+
+public struct OpenRefreshScanPolicy: Sendable {
+    public enum Scan: Equatable, Sendable {
+        case none
+        case today
+    }
+
+    public init() {}
+
+    public func scan(
+        summaryIsMissing: Bool,
+        needsUsageScan: Bool,
+        isBackgroundScanning: Bool,
+        lastTodayScan: Date,
+        now: Date = Date()
+    ) -> Scan {
+        if summaryIsMissing || !needsUsageScan || isBackgroundScanning {
+            return .none
+        }
+        if now.timeIntervalSince(lastTodayScan) <= 600 {
+            return .none
+        }
+        return .today
+    }
+}

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/RefreshCadenceTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/RefreshCadenceTests.swift
@@ -19,4 +19,47 @@ final class RefreshCadenceTests: XCTestCase {
             XCTAssertEqual(RefreshCadence(storedValue: cadence.rawValue), cadence)
         }
     }
+
+    func testOpenRefreshScanPolicyNeverStartsHistoryScanAutomatically() throws {
+        let policy = OpenRefreshScanPolicy()
+        let now = try Self.isoDate("2026-06-04T02:30:00Z")
+
+        XCTAssertEqual(
+            policy.scan(
+                summaryIsMissing: true,
+                needsUsageScan: true,
+                isBackgroundScanning: false,
+                lastTodayScan: .distantPast,
+                now: now
+            ),
+            .none
+        )
+
+        XCTAssertEqual(
+            policy.scan(
+                summaryIsMissing: false,
+                needsUsageScan: true,
+                isBackgroundScanning: false,
+                lastTodayScan: .distantPast,
+                now: now
+            ),
+            .today
+        )
+
+        XCTAssertEqual(
+            policy.scan(
+                summaryIsMissing: false,
+                needsUsageScan: true,
+                isBackgroundScanning: false,
+                lastTodayScan: try Self.isoDate("2026-06-04T02:25:30Z"),
+                now: now
+            ),
+            .none
+        )
+    }
+
+    private static func isoDate(_ value: String) throws -> Date {
+        let formatter = ISO8601DateFormatter()
+        return try XCTUnwrap(formatter.date(from: value))
+    }
 }


### PR DESCRIPTION
## Summary

Stops the menu bar app from starting a full-history graph scan just because the app starts or the popover opens. On large local/merged histories that scan can pin several CPU cores for minutes.

> Note: the earlier bad commit on `main` (2eaff15, "bundle graph refresh CLI", which baked a machine-specific merged-home refresh script into every build) has already been reverted directly on `main` in 0a084b4. This PR now contains only the scan-guard fix.

## Root Cause

The refresh-on-open path could trigger a full scan when there was no summary yet (first run), or when the daily full-scan throttle was due.

## Changes

- Adds `OpenRefreshScanPolicy` (Core, pure logic): the open-refresh path may run at most a throttled today-only scan (~2s); full-history scans only start from the explicit Refresh action.
- Skips automatic scanning entirely when there is no summary yet, instead of doing a first-run full scan in the background.
- Quota still refreshes on every open, including with "Refresh on open = Off" (unchanged).
- Adds regression tests that lock the policy so automatic open refresh can never choose a full history scan.

## Testing

- `swift test`: 49 tests, 0 failures.
