### PR TITLE
fix(submit): allow newer parser revisions to correct usage

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4158,6 +4158,16 @@ struct TsSourceContribution {
     tokens: TsTokenBreakdown,
     cost: f64,
     messages: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provenance: Option<TsClientContributionProvenance>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TsClientContributionProvenance {
+    schema_version: u32,
+    message_count: i32,
+    model_count: u32,
 }
 
 #[derive(serde::Serialize)]
@@ -4252,6 +4262,8 @@ fn to_ts_token_contribution_data(
     graph: &tokscale_core::GraphResult,
     device: Option<&device::SubmitDevice>,
 ) -> TsTokenContributionData {
+    let include_submit_provenance = device.is_some();
+
     TsTokenContributionData {
         meta: TsExportMeta {
             generated_at: graph.meta.generated_at.clone(),
@@ -4326,6 +4338,13 @@ fn to_ts_token_contribution_data(
                         },
                         cost: s.cost,
                         messages: s.messages,
+                        provenance: include_submit_provenance.then(|| {
+                            TsClientContributionProvenance {
+                                schema_version: if s.client == "codex" { 2 } else { 1 },
+                                message_count: s.messages,
+                                model_count: 1,
+                            }
+                        }),
                     })
                     .collect(),
                 active_time_ms: d.active_time_ms,
@@ -7364,6 +7383,49 @@ mod tests {
             payload.device.as_ref().unwrap().name.as_deref(),
             Some("Test device")
         );
+    }
+
+    #[test]
+    fn test_submit_payload_versions_client_parser_provenance_without_changing_graph_json() {
+        let graph = graph_result_with_contributions(vec![day_with_clients(
+            "2026-12-31",
+            30,
+            vec![
+                client_contribution("codex", "gpt-5.5", "openai", 20, 2.0, 2),
+                client_contribution("claude", "claude-sonnet-4", "anthropic", 10, 1.0, 1),
+            ],
+        )]);
+        let device = device::SubmitDevice {
+            id: "dev_test".to_string(),
+            name: None,
+        };
+
+        let submit_json =
+            serde_json::to_value(to_ts_token_contribution_data(&graph, Some(&device))).unwrap();
+        let submit_clients = submit_json["contributions"][0]["clients"]
+            .as_array()
+            .unwrap();
+        let codex = submit_clients
+            .iter()
+            .find(|client| client["client"] == "codex")
+            .unwrap();
+        let claude = submit_clients
+            .iter()
+            .find(|client| client["client"] == "claude")
+            .unwrap();
+
+        assert_eq!(codex["provenance"]["schemaVersion"], 2);
+        assert_eq!(codex["provenance"]["messageCount"], 2);
+        assert_eq!(codex["provenance"]["modelCount"], 1);
+        assert_eq!(claude["provenance"]["schemaVersion"], 1);
+
+        let graph_json = serde_json::to_value(to_ts_token_contribution_data(&graph, None)).unwrap();
+        for client in graph_json["contributions"][0]["clients"]
+            .as_array()
+            .unwrap()
+        {
+            assert!(client.get("provenance").is_none());
+        }
     }
 
     #[test]

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -112,7 +112,8 @@ vi.mock("@/lib/validation/submission", () => ({
   generateSubmissionHash: mockState.generateSubmissionHash,
 }));
 
-vi.mock("@/lib/db/helpers", () => ({
+vi.mock("@/lib/db/helpers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/lib/db/helpers")>()),
   mergeClientBreakdowns: mockState.mergeClientBreakdowns,
   mergeClientBreakdownsWithRegressionGuard: mockState.mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals: mockState.recalculateDayTotals,
@@ -347,6 +348,11 @@ describe("POST /api/submit auth path", () => {
                 cacheWrite: 0,
                 reasoning: 0,
                 messages: 1,
+                provenance: {
+                  schemaVersion: 2,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
               },
             ],
           },
@@ -497,6 +503,15 @@ describe("POST /api/submit auth path", () => {
         submissionId: "submission-1",
         submittedDeviceId: "submitted-device-1",
         date: "2026-04-30",
+        sourceBreakdown: expect.objectContaining({
+          codex: expect.objectContaining({
+            provenance: {
+              schemaVersion: 2,
+              messageCount: 1,
+              modelCount: 1,
+            },
+          }),
+        }),
       }),
     ]);
     expect(submissionUpdateValues).toEqual(

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { mergeClientBreakdownsWithRegressionGuard } from "../../src/lib/db/helpers";
+import {
+  aggregateIncomingClientBreakdowns,
+  mergeClientBreakdownsWithRegressionGuard,
+} from "../../src/lib/db/helpers";
 
 // Minimal client breakdown fixture
 function makeClient(tokens: number, messages: number, modelCount: number) {
@@ -17,6 +20,20 @@ function makeClient(tokens: number, messages: number, modelCount: number) {
     reasoning: 0,
     messages,
     models,
+  };
+}
+
+function withRevision(
+  client: ReturnType<typeof makeClient>,
+  schemaVersion: number
+) {
+  return {
+    ...client,
+    provenance: {
+      schemaVersion,
+      messageCount: client.messages,
+      modelCount: Object.keys(client.models).length,
+    },
   };
 }
 
@@ -98,5 +115,80 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
     expect(result.merged.cursor.tokens).toBe(500);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("cursor");
+  });
+
+  it("accepts a lower corrected value from a newer parser revision", () => {
+    const existing = { codex: withRevision(makeClient(14_000, 80, 2), 1) };
+    const incoming = { codex: withRevision(makeClient(950, 12, 2), 2) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(950);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("rejects an older parser revision even when it reports more tokens", () => {
+    const existing = { codex: withRevision(makeClient(950, 12, 2), 2) };
+    const incoming = { codex: withRevision(makeClient(14_000, 80, 2), 1) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(950);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("revision 1");
+    expect(result.warnings[0]).toContain("revision 2");
+  });
+
+  it("keeps the same-revision token regression guard", () => {
+    const existing = { codex: withRevision(makeClient(1_000, 12, 2), 2) };
+    const incoming = { codex: withRevision(makeClient(900, 12, 2), 2) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(1_000);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toHaveLength(1);
+  });
+});
+
+describe("aggregateIncomingClientBreakdowns", () => {
+  it("aggregates multiple models while preserving the incoming parser revision", () => {
+    const result = aggregateIncomingClientBreakdowns([
+      {
+        client: "codex",
+        modelId: "gpt-5.5",
+        breakdown: makeClient(600, 7, 1).models["model-0"],
+        provenance: { schemaVersion: 2, messageCount: 7, modelCount: 1 },
+      },
+      {
+        client: "codex",
+        modelId: "gpt-5.5-mini",
+        breakdown: makeClient(350, 5, 1).models["model-0"],
+        provenance: { schemaVersion: 2, messageCount: 5, modelCount: 1 },
+      },
+    ]);
+
+    expect(result.codex.tokens).toBe(950);
+    expect(result.codex.messages).toBe(12);
+    expect(Object.keys(result.codex.models)).toEqual(["gpt-5.5", "gpt-5.5-mini"]);
+    expect(result.codex.provenance).toEqual({
+      schemaVersion: 2,
+      messageCount: 12,
+      modelCount: 2,
+    });
   });
 });

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -13,7 +13,7 @@ import {
   mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals,
   clientContributionToBreakdownData,
-  deriveClientBreakdownProvenance,
+  aggregateIncomingClientBreakdowns,
   mergeTimestampMs,
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
@@ -394,44 +394,14 @@ export async function POST(request: Request) {
       }> = [];
 
       for (const incomingDay of data.contributions) {
-        const incomingClientBreakdown: Record<string, ClientBreakdownData> = {};
-        for (const client_contrib of incomingDay.clients) {
-          const modelData = clientContributionToBreakdownData(client_contrib);
-          const existing = incomingClientBreakdown[client_contrib.client];
-          if (existing) {
-            existing.tokens += modelData.tokens;
-            existing.cost += modelData.cost;
-            existing.input += modelData.input;
-            existing.output += modelData.output;
-            existing.cacheRead += modelData.cacheRead;
-            existing.cacheWrite += modelData.cacheWrite;
-            existing.reasoning = (existing.reasoning || 0) + modelData.reasoning;
-            existing.messages += modelData.messages;
-            const existingModel = existing.models[client_contrib.modelId];
-            if (existingModel) {
-              existingModel.tokens += modelData.tokens;
-              existingModel.cost += modelData.cost;
-              existingModel.input += modelData.input;
-              existingModel.output += modelData.output;
-              existingModel.cacheRead += modelData.cacheRead;
-              existingModel.cacheWrite += modelData.cacheWrite;
-              existingModel.reasoning = (existingModel.reasoning || 0) + modelData.reasoning;
-              existingModel.messages += modelData.messages;
-            } else {
-              existing.models[client_contrib.modelId] = modelData;
-            }
-            existing.provenance = deriveClientBreakdownProvenance(existing);
-          } else {
-            const clientBreakdown = {
-              ...modelData,
-              models: { [client_contrib.modelId]: modelData },
-            };
-            incomingClientBreakdown[client_contrib.client] = {
-              ...clientBreakdown,
-              provenance: deriveClientBreakdownProvenance(clientBreakdown),
-            };
-          }
-        }
+        const incomingClientBreakdown = aggregateIncomingClientBreakdowns(
+          incomingDay.clients.map((clientContribution) => ({
+            client: clientContribution.client,
+            modelId: clientContribution.modelId,
+            breakdown: clientContributionToBreakdownData(clientContribution),
+            provenance: clientContribution.provenance,
+          }))
+        );
 
         const existingDay = existingDaysMap.get(incomingDay.date);
 

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -39,6 +39,13 @@ export interface MergeClientBreakdownsResult {
   warnings: string[];
 }
 
+export interface IncomingClientModelBreakdown {
+  client: string;
+  modelId: string;
+  breakdown: ModelBreakdownData;
+  provenance?: ClientBreakdownProvenanceData;
+}
+
 export interface DayTotals {
   tokens: number;
   cost: number;
@@ -112,6 +119,74 @@ function withDerivedProvenance(breakdown: ClientBreakdownData): ClientBreakdownD
   };
 }
 
+export function aggregateIncomingClientBreakdowns(
+  contributions: IncomingClientModelBreakdown[]
+): Record<string, ClientBreakdownData> {
+  const aggregated: Record<string, ClientBreakdownData> = {};
+
+  for (const contribution of contributions) {
+    const { client, modelId, breakdown, provenance } = contribution;
+    const existing = aggregated[client];
+
+    if (!existing) {
+      const clientBreakdown: ClientBreakdownData = {
+        ...breakdown,
+        models: { [modelId]: { ...breakdown } },
+        provenance: {
+          schemaVersion: Math.max(1, provenance?.schemaVersion ?? 1),
+          messageCount: Math.max(0, provenance?.messageCount ?? 0),
+          modelCount: Math.max(0, provenance?.modelCount ?? 0),
+        },
+      };
+      aggregated[client] = withDerivedProvenance(clientBreakdown);
+      continue;
+    }
+
+    existing.tokens += breakdown.tokens;
+    existing.cost += breakdown.cost;
+    existing.input += breakdown.input;
+    existing.output += breakdown.output;
+    existing.cacheRead += breakdown.cacheRead;
+    existing.cacheWrite += breakdown.cacheWrite;
+    existing.reasoning = (existing.reasoning || 0) + breakdown.reasoning;
+    existing.messages += breakdown.messages;
+
+    const existingModel = existing.models[modelId];
+    if (existingModel) {
+      existingModel.tokens += breakdown.tokens;
+      existingModel.cost += breakdown.cost;
+      existingModel.input += breakdown.input;
+      existingModel.output += breakdown.output;
+      existingModel.cacheRead += breakdown.cacheRead;
+      existingModel.cacheWrite += breakdown.cacheWrite;
+      existingModel.reasoning = (existingModel.reasoning || 0) + breakdown.reasoning;
+      existingModel.messages += breakdown.messages;
+    } else {
+      existing.models[modelId] = { ...breakdown };
+    }
+
+    existing.provenance = deriveClientBreakdownProvenance({
+      ...existing,
+      provenance: {
+        schemaVersion: Math.max(
+          existing.provenance?.schemaVersion ?? 1,
+          provenance?.schemaVersion ?? 1
+        ),
+        messageCount: Math.max(
+          existing.provenance?.messageCount ?? 0,
+          provenance?.messageCount ?? 0
+        ),
+        modelCount: Math.max(
+          existing.provenance?.modelCount ?? 0,
+          provenance?.modelCount ?? 0
+        ),
+      },
+    });
+  }
+
+  return aggregated;
+}
+
 export function mergeClientBreakdowns(
   existing: Record<string, ClientBreakdownData> | null | undefined,
   incoming: Record<string, ClientBreakdownData>,
@@ -155,14 +230,30 @@ export function mergeClientBreakdownsWithRegressionGuard(
     }
 
     const nextClient = withDerivedProvenance(incomingClient);
-    if (existingClient && nextClient.tokens < existingClient.tokens) {
-      // A token decrease alone signals a parser regression (e.g. the CLI
-      // re-parsed only a subset of history). Preserve the existing row even
-      // when coverage metrics are equal, because equal coverage + fewer tokens
-      // still indicates data loss. The old AND-gate (tokens < existing AND lower
-      // coverage) let equal-coverage regressions slip through undetected.
-      merged[clientName] = withDerivedProvenance(existingClient);
-      const existingTokens = formatTokens(existingClient.tokens);
+    const existingWithProvenance = existingClient
+      ? withDerivedProvenance(existingClient)
+      : undefined;
+    const existingSchemaVersion = existingWithProvenance?.provenance?.schemaVersion ?? 1;
+    const incomingSchemaVersion = nextClient.provenance?.schemaVersion ?? 1;
+
+    if (existingWithProvenance && incomingSchemaVersion < existingSchemaVersion) {
+      merged[clientName] = existingWithProvenance;
+      warnings.push(
+        `Preserved ${clientName} because parser revision ${incomingSchemaVersion} is older than stored revision ${existingSchemaVersion}.`
+      );
+      continue;
+    }
+
+    if (
+      existingWithProvenance &&
+      incomingSchemaVersion === existingSchemaVersion &&
+      nextClient.tokens < existingWithProvenance.tokens
+    ) {
+      // Within one parser revision, a token decrease signals a regression
+      // (e.g. the CLI re-parsed only a subset of history). A newer revision is
+      // allowed to submit a deliberate lower correction before reaching here.
+      merged[clientName] = existingWithProvenance;
+      const existingTokens = formatTokens(existingWithProvenance.tokens);
       const nextTokens = formatTokens(nextClient.tokens);
       warnings.push(
         `Preserved ${clientName} because this same-device resubmit would reduce ${existingTokens} tokens to ${nextTokens}.`


### PR DESCRIPTION
## What changed

- Add per-client parser provenance to submit payloads without changing `tokens graph` JSON.
- Mark the corrected Codex fork/subagent parser as revision 2 while keeping other clients at revision 1.
- Preserve the highest incoming revision when aggregating multi-model client rows.
- Allow a newer parser revision to replace an inflated stored value, while blocking older or same-revision regressions.

## Root cause

Same-device resubmits intentionally reject lower token counts, so corrected Codex fork replay accounting could not replace values produced by the older parser. The route also discarded incoming provenance and re-derived every client as revision 1.

## Impact

A revision 2 Codex submission can repair previously inflated daily rows. Once corrected, an older revision 1 uploader cannot overwrite those rows again.

## Verification

- `cargo test -p tokscale-cli test_submit_payload_versions_client_parser_provenance_without_changing_graph_json`
- `node ../../node_modules/vitest/vitest.mjs run __tests__/api/submit.test.ts __tests__/api/submitAuth.test.ts __tests__/lib/helpers.test.ts` (71/71)
- `git show --check HEAD`
