### PR TITLE
fix(submit): allow newer parser revisions to correct usage

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -4158,6 +4158,16 @@ struct TsSourceContribution {
     tokens: TsTokenBreakdown,
     cost: f64,
     messages: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provenance: Option<TsClientContributionProvenance>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TsClientContributionProvenance {
+    schema_version: u32,
+    message_count: i32,
+    model_count: u32,
 }
 
 #[derive(serde::Serialize)]
@@ -4252,6 +4262,8 @@ fn to_ts_token_contribution_data(
     graph: &tokscale_core::GraphResult,
     device: Option<&device::SubmitDevice>,
 ) -> TsTokenContributionData {
+    let include_submit_provenance = device.is_some();
+
     TsTokenContributionData {
         meta: TsExportMeta {
             generated_at: graph.meta.generated_at.clone(),
@@ -4326,6 +4338,13 @@ fn to_ts_token_contribution_data(
                         },
                         cost: s.cost,
                         messages: s.messages,
+                        provenance: include_submit_provenance.then(|| {
+                            TsClientContributionProvenance {
+                                schema_version: if s.client == "codex" { 2 } else { 1 },
+                                message_count: s.messages,
+                                model_count: 1,
+                            }
+                        }),
                     })
                     .collect(),
                 active_time_ms: d.active_time_ms,
@@ -7364,6 +7383,49 @@ mod tests {
             payload.device.as_ref().unwrap().name.as_deref(),
             Some("Test device")
         );
+    }
+
+    #[test]
+    fn test_submit_payload_versions_client_parser_provenance_without_changing_graph_json() {
+        let graph = graph_result_with_contributions(vec![day_with_clients(
+            "2026-12-31",
+            30,
+            vec![
+                client_contribution("codex", "gpt-5.5", "openai", 20, 2.0, 2),
+                client_contribution("claude", "claude-sonnet-4", "anthropic", 10, 1.0, 1),
+            ],
+        )]);
+        let device = device::SubmitDevice {
+            id: "dev_test".to_string(),
+            name: None,
+        };
+
+        let submit_json =
+            serde_json::to_value(to_ts_token_contribution_data(&graph, Some(&device))).unwrap();
+        let submit_clients = submit_json["contributions"][0]["clients"]
+            .as_array()
+            .unwrap();
+        let codex = submit_clients
+            .iter()
+            .find(|client| client["client"] == "codex")
+            .unwrap();
+        let claude = submit_clients
+            .iter()
+            .find(|client| client["client"] == "claude")
+            .unwrap();
+
+        assert_eq!(codex["provenance"]["schemaVersion"], 2);
+        assert_eq!(codex["provenance"]["messageCount"], 2);
+        assert_eq!(codex["provenance"]["modelCount"], 1);
+        assert_eq!(claude["provenance"]["schemaVersion"], 1);
+
+        let graph_json = serde_json::to_value(to_ts_token_contribution_data(&graph, None)).unwrap();
+        for client in graph_json["contributions"][0]["clients"]
+            .as_array()
+            .unwrap()
+        {
+            assert!(client.get("provenance").is_none());
+        }
     }
 
     #[test]

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -233,7 +233,7 @@ describe('POST /api/submit - Client-Level Merge', () => {
         provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
       };
       client.provenance = {
-        schemaVersion: 1,
+        schemaVersion: 2,
         messageCount: 7,
         modelCount: 1,
       };
@@ -242,10 +242,27 @@ describe('POST /api/submit - Client-Level Merge', () => {
 
       expect(result.valid).toBe(true);
       expect(result.data?.contributions[0].clients[0].provenance).toEqual({
-        schemaVersion: 1,
+        schemaVersion: 2,
         messageCount: 7,
         modelCount: 1,
       });
+    });
+
+    it('rejects client provenance newer than the server supports', () => {
+      const payload = createMockSubmissionData({ clients: ['codex'] });
+      const client = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      client.provenance = {
+        schemaVersion: 999,
+        messageCount: 7,
+        modelCount: 1,
+      };
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes('schemaVersion'))).toBe(true);
     });
   });
 

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -112,7 +112,8 @@ vi.mock("@/lib/validation/submission", () => ({
   generateSubmissionHash: mockState.generateSubmissionHash,
 }));
 
-vi.mock("@/lib/db/helpers", () => ({
+vi.mock("@/lib/db/helpers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/lib/db/helpers")>()),
   mergeClientBreakdowns: mockState.mergeClientBreakdowns,
   mergeClientBreakdownsWithRegressionGuard: mockState.mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals: mockState.recalculateDayTotals,
@@ -347,6 +348,11 @@ describe("POST /api/submit auth path", () => {
                 cacheWrite: 0,
                 reasoning: 0,
                 messages: 1,
+                provenance: {
+                  schemaVersion: 2,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
               },
             ],
           },
@@ -497,6 +503,15 @@ describe("POST /api/submit auth path", () => {
         submissionId: "submission-1",
         submittedDeviceId: "submitted-device-1",
         date: "2026-04-30",
+        sourceBreakdown: expect.objectContaining({
+          codex: expect.objectContaining({
+            provenance: {
+              schemaVersion: 2,
+              messageCount: 1,
+              modelCount: 1,
+            },
+          }),
+        }),
       }),
     ]);
     expect(submissionUpdateValues).toEqual(
@@ -512,7 +527,7 @@ describe("POST /api/submit auth path", () => {
     expect(mockState.revalidateUsernamePaths).toHaveBeenCalledWith("Alice");
   });
 
-  it("replaces same-device daily rows without inserting duplicate dates", async () => {
+  it("applies the stored revision floor to new same-device days", async () => {
     mockState.authenticatePersonalToken.mockResolvedValue({
       status: "valid",
       tokenId: "token-1",
@@ -531,7 +546,7 @@ describe("POST /api/submit auth path", () => {
         },
         meta: {
           version: "2.0.0",
-          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+          dateRange: { start: "2026-04-30", end: "2026-05-03" },
         },
         summary: {
           clients: ["codex"],
@@ -552,6 +567,97 @@ describe("POST /api/submit auth path", () => {
                 cacheWrite: 0,
                 reasoning: 0,
                 messages: 1,
+                provenance: {
+                  schemaVersion: 2,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
+              },
+            ],
+          },
+          {
+            date: "2026-05-01",
+            timestampMs: 789,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+                provenance: {
+                  schemaVersion: 1,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
+              },
+              {
+                client: "claude",
+                modelId: "claude-sonnet-4",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+                provenance: {
+                  schemaVersion: 1,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
+              },
+            ],
+          },
+          {
+            date: "2026-05-02",
+            timestampMs: 999,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+                provenance: {
+                  schemaVersion: 2,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
+              },
+            ],
+          },
+          {
+            date: "2026-05-03",
+            timestampMs: 1_111,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+                provenance: {
+                  schemaVersion: 1,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
               },
             ],
           },
@@ -582,6 +688,11 @@ describe("POST /api/submit auth path", () => {
         reasoning: 0,
         messages: 1,
         models: { "gpt-5.5": { tokens: 12 } },
+        provenance: {
+          schemaVersion: 2,
+          messageCount: 1,
+          modelCount: 1,
+        },
       },
     };
     const mergedBreakdown = {
@@ -625,6 +736,7 @@ describe("POST /api/submit auth path", () => {
       [{ sourceBreakdown: mergedBreakdown }],
     ];
 
+    let dailyInsertValues: Array<Record<string, unknown>> | undefined;
     const tx = {
       update: vi.fn(() => {
         const builder = {
@@ -634,7 +746,15 @@ describe("POST /api/submit auth path", () => {
         return builder;
       }),
       select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
-      insert: vi.fn(() => {
+      insert: vi.fn((table: unknown) => {
+        if ((table as { id?: unknown }).id === "dailyBreakdown.id") {
+          return {
+            values: vi.fn((values: Array<Record<string, unknown>>) => {
+              dailyInsertValues = values;
+              return Promise.resolve();
+            }),
+          };
+        }
         const builder = {
           values: vi.fn(() => builder),
           onConflictDoUpdate: vi.fn(() => builder),
@@ -668,18 +788,35 @@ describe("POST /api/submit auth path", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(tx.insert).toHaveBeenCalledTimes(2);
     expect(tx.insert).toHaveBeenCalledWith(expect.objectContaining({
       id: "submittedDevices.id",
     }));
     expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(dailyInsertValues).toHaveLength(2);
+    expect(dailyInsertValues?.[0]).toEqual(expect.objectContaining({
+      date: "2026-05-01",
+      sourceBreakdown: {
+        claude: expect.objectContaining({
+          provenance: expect.objectContaining({ schemaVersion: 1 }),
+        }),
+      },
+    }));
+    expect(dailyInsertValues?.[1]).toEqual(expect.objectContaining({
+      date: "2026-05-02",
+      sourceBreakdown: {
+        codex: expect.objectContaining({
+          provenance: expect.objectContaining({ schemaVersion: 2 }),
+        }),
+      },
+    }));
     expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
       existingBreakdown,
       {
         codex: {
           ...mergedBreakdown.codex,
           provenance: {
-            schemaVersion: 1,
+            schemaVersion: 2,
             messageCount: 1,
             modelCount: 1,
           },
@@ -694,6 +831,10 @@ describe("POST /api/submit auth path", () => {
         activeDays: 1,
       }),
       mode: "merge",
+      warnings: [
+        "Day 2026-05-01: Ignored codex parser revision 1 because this device already stored revision 2.",
+        "Day 2026-05-03: Ignored codex parser revision 1 because this device already stored revision 2.",
+      ],
     }));
   });
 

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { mergeClientBreakdownsWithRegressionGuard } from "../../src/lib/db/helpers";
+import {
+  aggregateIncomingClientBreakdowns,
+  deriveStoredClientRevisionFloors,
+  filterClientBreakdownsByRevisionFloor,
+  mergeClientBreakdownsWithRegressionGuard,
+} from "../../src/lib/db/helpers";
 
 // Minimal client breakdown fixture
 function makeClient(tokens: number, messages: number, modelCount: number) {
@@ -17,6 +22,20 @@ function makeClient(tokens: number, messages: number, modelCount: number) {
     reasoning: 0,
     messages,
     models,
+  };
+}
+
+function withRevision(
+  client: ReturnType<typeof makeClient>,
+  schemaVersion: number
+) {
+  return {
+    ...client,
+    provenance: {
+      schemaVersion,
+      messageCount: client.messages,
+      modelCount: Object.keys(client.models).length,
+    },
   };
 }
 
@@ -98,5 +117,135 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
     expect(result.merged.cursor.tokens).toBe(500);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("cursor");
+  });
+
+  it("accepts a lower corrected value from a newer parser revision", () => {
+    const existing = { codex: withRevision(makeClient(14_000, 80, 2), 1) };
+    const incoming = { codex: withRevision(makeClient(950, 12, 2), 2) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(950);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("rejects an older parser revision even when it reports more tokens", () => {
+    const existing = { codex: withRevision(makeClient(950, 12, 2), 2) };
+    const incoming = { codex: withRevision(makeClient(14_000, 80, 2), 1) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(950);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("revision 1");
+    expect(result.warnings[0]).toContain("revision 2");
+  });
+
+  it("keeps the same-revision token regression guard", () => {
+    const existing = { codex: withRevision(makeClient(1_000, 12, 2), 2) };
+    const incoming = { codex: withRevision(makeClient(900, 12, 2), 2) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(1_000);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toHaveLength(1);
+  });
+});
+
+describe("aggregateIncomingClientBreakdowns", () => {
+  it("aggregates multiple models while preserving the incoming parser revision", () => {
+    const result = aggregateIncomingClientBreakdowns([
+      {
+        client: "codex",
+        modelId: "gpt-5.5",
+        breakdown: makeClient(600, 7, 1).models["model-0"],
+        provenance: { schemaVersion: 2, messageCount: 7, modelCount: 1 },
+      },
+      {
+        client: "codex",
+        modelId: "gpt-5.5-mini",
+        breakdown: makeClient(350, 5, 1).models["model-0"],
+        provenance: { schemaVersion: 2, messageCount: 5, modelCount: 1 },
+      },
+    ]);
+
+    expect(result.codex.tokens).toBe(950);
+    expect(result.codex.messages).toBe(12);
+    expect(Object.keys(result.codex.models)).toEqual(["gpt-5.5", "gpt-5.5-mini"]);
+    expect(result.codex.provenance).toEqual({
+      schemaVersion: 2,
+      messageCount: 12,
+      modelCount: 2,
+    });
+  });
+
+  it("uses the lowest parser revision when one client mixes model revisions", () => {
+    const result = aggregateIncomingClientBreakdowns([
+      {
+        client: "codex",
+        modelId: "gpt-5.5",
+        breakdown: makeClient(600, 7, 1).models["model-0"],
+        provenance: { schemaVersion: 2, messageCount: 7, modelCount: 1 },
+      },
+      {
+        client: "codex",
+        modelId: "gpt-5.5-mini",
+        breakdown: makeClient(350, 5, 1).models["model-0"],
+        provenance: { schemaVersion: 1, messageCount: 5, modelCount: 1 },
+      },
+    ]);
+
+    expect(result.codex.provenance?.schemaVersion).toBe(1);
+  });
+});
+
+describe("client revision floors", () => {
+  const storedRevisionFloors = deriveStoredClientRevisionFloors([
+    {
+      codex: withRevision(makeClient(950, 12, 2), 2),
+      claude: withRevision(makeClient(500, 5, 1), 1),
+    },
+  ]);
+
+  it("rejects an older revision on a new day without blocking other clients", () => {
+    const result = filterClientBreakdownsByRevisionFloor(
+      {
+        codex: withRevision(makeClient(14_000, 80, 2), 1),
+        claude: withRevision(makeClient(600, 6, 1), 1),
+      },
+      storedRevisionFloors
+    );
+
+    expect(result.accepted.codex).toBeUndefined();
+    expect(result.accepted.claude.tokens).toBe(600);
+    expect(result.rejected).toEqual([
+      { client: "codex", incomingRevision: 1, storedRevision: 2 },
+    ]);
+  });
+
+  it("accepts the stored revision on a new day", () => {
+    const result = filterClientBreakdownsByRevisionFloor(
+      { codex: withRevision(makeClient(1_100, 14, 2), 2) },
+      storedRevisionFloors
+    );
+
+    expect(result.accepted.codex.tokens).toBe(1_100);
+    expect(result.accepted.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.rejected).toEqual([]);
   });
 });

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -13,7 +13,9 @@ import {
   mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals,
   clientContributionToBreakdownData,
-  deriveClientBreakdownProvenance,
+  aggregateIncomingClientBreakdowns,
+  deriveStoredClientRevisionFloors,
+  filterClientBreakdownsByRevisionFloor,
   mergeTimestampMs,
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
@@ -365,6 +367,11 @@ export async function POST(request: Request) {
       const existingDaysMap = new Map(
         existingDays.map((d) => [d.date, d])
       );
+      const storedClientRevisionFloors = deriveStoredClientRevisionFloors(
+        existingDays.map((day) =>
+          (day.sourceBreakdown || {}) as Record<string, ClientBreakdownData>
+        )
+      );
 
       // ------------------------------------------
       // STEP 3c: Compute merge results in memory, then batch write
@@ -394,44 +401,28 @@ export async function POST(request: Request) {
       }> = [];
 
       for (const incomingDay of data.contributions) {
-        const incomingClientBreakdown: Record<string, ClientBreakdownData> = {};
-        for (const client_contrib of incomingDay.clients) {
-          const modelData = clientContributionToBreakdownData(client_contrib);
-          const existing = incomingClientBreakdown[client_contrib.client];
-          if (existing) {
-            existing.tokens += modelData.tokens;
-            existing.cost += modelData.cost;
-            existing.input += modelData.input;
-            existing.output += modelData.output;
-            existing.cacheRead += modelData.cacheRead;
-            existing.cacheWrite += modelData.cacheWrite;
-            existing.reasoning = (existing.reasoning || 0) + modelData.reasoning;
-            existing.messages += modelData.messages;
-            const existingModel = existing.models[client_contrib.modelId];
-            if (existingModel) {
-              existingModel.tokens += modelData.tokens;
-              existingModel.cost += modelData.cost;
-              existingModel.input += modelData.input;
-              existingModel.output += modelData.output;
-              existingModel.cacheRead += modelData.cacheRead;
-              existingModel.cacheWrite += modelData.cacheWrite;
-              existingModel.reasoning = (existingModel.reasoning || 0) + modelData.reasoning;
-              existingModel.messages += modelData.messages;
-            } else {
-              existing.models[client_contrib.modelId] = modelData;
-            }
-            existing.provenance = deriveClientBreakdownProvenance(existing);
-          } else {
-            const clientBreakdown = {
-              ...modelData,
-              models: { [client_contrib.modelId]: modelData },
-            };
-            incomingClientBreakdown[client_contrib.client] = {
-              ...clientBreakdown,
-              provenance: deriveClientBreakdownProvenance(clientBreakdown),
-            };
-          }
-        }
+        const aggregatedIncomingClientBreakdown = aggregateIncomingClientBreakdowns(
+          incomingDay.clients.map((clientContribution) => ({
+            client: clientContribution.client,
+            modelId: clientContribution.modelId,
+            breakdown: clientContributionToBreakdownData(clientContribution),
+            provenance: clientContribution.provenance,
+          }))
+        );
+        const revisionFilter = filterClientBreakdownsByRevisionFloor(
+          aggregatedIncomingClientBreakdown,
+          storedClientRevisionFloors
+        );
+        const incomingClientBreakdown = revisionFilter.accepted;
+        const rejectedClients = new Set(
+          revisionFilter.rejected.map((rejected) => rejected.client)
+        );
+        warnings.push(
+          ...revisionFilter.rejected.map(
+            (rejected) =>
+              `Day ${incomingDay.date}: Ignored ${rejected.client} parser revision ${rejected.incomingRevision} because this device already stored revision ${rejected.storedRevision}.`
+          )
+        );
 
         const existingDay = existingDaysMap.get(incomingDay.date);
 
@@ -443,7 +434,11 @@ export async function POST(request: Request) {
           const mergeResult = mergeClientBreakdownsWithRegressionGuard(
             existingClientBreakdown,
             incomingClientBreakdown,
-            submittedClients
+            new Set(
+              Array.from(submittedClients).filter(
+                (client) => !rejectedClients.has(client)
+              )
+            )
           );
           warnings.push(
             ...mergeResult.warnings.map((warning) => `Day ${incomingDay.date}: ${warning}`)
@@ -461,7 +456,7 @@ export async function POST(request: Request) {
             activeTimeMs: incomingDay.activeTimeMs ?? existingDay.activeTimeMs ?? null,
             sourceBreakdown: mergedClientBreakdown,
           });
-        } else {
+        } else if (Object.keys(incomingClientBreakdown).length > 0) {
           const dayTotals = recalculateDayTotals(incomingClientBreakdown);
 
           toInsert.push({

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -39,6 +39,24 @@ export interface MergeClientBreakdownsResult {
   warnings: string[];
 }
 
+export interface IncomingClientModelBreakdown {
+  client: string;
+  modelId: string;
+  breakdown: ModelBreakdownData;
+  provenance?: ClientBreakdownProvenanceData;
+}
+
+export interface RejectedClientRevision {
+  client: string;
+  incomingRevision: number;
+  storedRevision: number;
+}
+
+export interface FilterClientBreakdownsResult {
+  accepted: Record<string, ClientBreakdownData>;
+  rejected: RejectedClientRevision[];
+}
+
 export interface DayTotals {
   tokens: number;
   cost: number;
@@ -112,6 +130,111 @@ function withDerivedProvenance(breakdown: ClientBreakdownData): ClientBreakdownD
   };
 }
 
+export function aggregateIncomingClientBreakdowns(
+  contributions: IncomingClientModelBreakdown[]
+): Record<string, ClientBreakdownData> {
+  const aggregated: Record<string, ClientBreakdownData> = {};
+
+  for (const contribution of contributions) {
+    const { client, modelId, breakdown, provenance } = contribution;
+    const existing = aggregated[client];
+
+    if (!existing) {
+      const clientBreakdown: ClientBreakdownData = {
+        ...breakdown,
+        models: { [modelId]: { ...breakdown } },
+        provenance: {
+          schemaVersion: Math.max(1, provenance?.schemaVersion ?? 1),
+          messageCount: Math.max(0, provenance?.messageCount ?? 0),
+          modelCount: Math.max(0, provenance?.modelCount ?? 0),
+        },
+      };
+      aggregated[client] = withDerivedProvenance(clientBreakdown);
+      continue;
+    }
+
+    existing.tokens += breakdown.tokens;
+    existing.cost += breakdown.cost;
+    existing.input += breakdown.input;
+    existing.output += breakdown.output;
+    existing.cacheRead += breakdown.cacheRead;
+    existing.cacheWrite += breakdown.cacheWrite;
+    existing.reasoning = (existing.reasoning || 0) + breakdown.reasoning;
+    existing.messages += breakdown.messages;
+
+    const existingModel = existing.models[modelId];
+    if (existingModel) {
+      existingModel.tokens += breakdown.tokens;
+      existingModel.cost += breakdown.cost;
+      existingModel.input += breakdown.input;
+      existingModel.output += breakdown.output;
+      existingModel.cacheRead += breakdown.cacheRead;
+      existingModel.cacheWrite += breakdown.cacheWrite;
+      existingModel.reasoning = (existingModel.reasoning || 0) + breakdown.reasoning;
+      existingModel.messages += breakdown.messages;
+    } else {
+      existing.models[modelId] = { ...breakdown };
+    }
+
+    existing.provenance = deriveClientBreakdownProvenance({
+      ...existing,
+      provenance: {
+        schemaVersion: Math.min(
+          existing.provenance?.schemaVersion ?? 1,
+          provenance?.schemaVersion ?? 1
+        ),
+        messageCount: Math.max(
+          existing.provenance?.messageCount ?? 0,
+          provenance?.messageCount ?? 0
+        ),
+        modelCount: Math.max(
+          existing.provenance?.modelCount ?? 0,
+          provenance?.modelCount ?? 0
+        ),
+      },
+    });
+  }
+
+  return aggregated;
+}
+
+export function deriveStoredClientRevisionFloors(
+  storedDays: Array<Record<string, ClientBreakdownData> | null | undefined>
+): Map<string, number> {
+  const floors = new Map<string, number>();
+
+  for (const storedDay of storedDays) {
+    for (const [client, breakdown] of Object.entries(storedDay ?? {})) {
+      const revision = deriveClientBreakdownProvenance(breakdown).schemaVersion;
+      floors.set(client, Math.max(floors.get(client) ?? 1, revision));
+    }
+  }
+
+  return floors;
+}
+
+export function filterClientBreakdownsByRevisionFloor(
+  incoming: Record<string, ClientBreakdownData>,
+  storedRevisionFloors: Map<string, number>
+): FilterClientBreakdownsResult {
+  const accepted: Record<string, ClientBreakdownData> = {};
+  const rejected: RejectedClientRevision[] = [];
+
+  for (const [client, breakdown] of Object.entries(incoming)) {
+    const normalized = withDerivedProvenance(breakdown);
+    const incomingRevision = normalized.provenance?.schemaVersion ?? 1;
+    const storedRevision = storedRevisionFloors.get(client) ?? 1;
+
+    if (incomingRevision < storedRevision) {
+      rejected.push({ client, incomingRevision, storedRevision });
+    } else {
+      accepted[client] = normalized;
+    }
+  }
+
+  return { accepted, rejected };
+}
+
 export function mergeClientBreakdowns(
   existing: Record<string, ClientBreakdownData> | null | undefined,
   incoming: Record<string, ClientBreakdownData>,
@@ -155,14 +278,30 @@ export function mergeClientBreakdownsWithRegressionGuard(
     }
 
     const nextClient = withDerivedProvenance(incomingClient);
-    if (existingClient && nextClient.tokens < existingClient.tokens) {
-      // A token decrease alone signals a parser regression (e.g. the CLI
-      // re-parsed only a subset of history). Preserve the existing row even
-      // when coverage metrics are equal, because equal coverage + fewer tokens
-      // still indicates data loss. The old AND-gate (tokens < existing AND lower
-      // coverage) let equal-coverage regressions slip through undetected.
-      merged[clientName] = withDerivedProvenance(existingClient);
-      const existingTokens = formatTokens(existingClient.tokens);
+    const existingWithProvenance = existingClient
+      ? withDerivedProvenance(existingClient)
+      : undefined;
+    const existingSchemaVersion = existingWithProvenance?.provenance?.schemaVersion ?? 1;
+    const incomingSchemaVersion = nextClient.provenance?.schemaVersion ?? 1;
+
+    if (existingWithProvenance && incomingSchemaVersion < existingSchemaVersion) {
+      merged[clientName] = existingWithProvenance;
+      warnings.push(
+        `Preserved ${clientName} because parser revision ${incomingSchemaVersion} is older than stored revision ${existingSchemaVersion}.`
+      );
+      continue;
+    }
+
+    if (
+      existingWithProvenance &&
+      incomingSchemaVersion === existingSchemaVersion &&
+      nextClient.tokens < existingWithProvenance.tokens
+    ) {
+      // Within one parser revision, a token decrease signals a regression
+      // (e.g. the CLI re-parsed only a subset of history). A newer revision is
+      // allowed to submit a deliberate lower correction before reaching here.
+      merged[clientName] = existingWithProvenance;
+      const existingTokens = formatTokens(existingWithProvenance.tokens);
       const nextTokens = formatTokens(nextClient.tokens);
       warnings.push(
         `Preserved ${clientName} because this same-device resubmit would reduce ${existingTokens} tokens to ${nextTokens}.`

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -25,6 +25,7 @@ const COST_ABSOLUTE_TOLERANCE = 0.1;
 const LEGACY_COST_FLOAT_EPSILON = 1e-6;
 const TOKEN_RELATIVE_TOLERANCE = 0.01;
 const TOKEN_ABSOLUTE_TOLERANCE = 100;
+const MAX_SUPPORTED_CLIENT_PROVENANCE_SCHEMA_VERSION = 2;
 
 const NonNegativeIntegerSchema = z.number().finite().int().min(0).max(Number.MAX_SAFE_INTEGER);
 const NonNegativeNumberSchema = z.number().finite().min(0);
@@ -38,7 +39,9 @@ const TokenBreakdownSchema = z.object({
 });
 
 const ClientContributionProvenanceSchema = z.object({
-  schemaVersion: NonNegativeIntegerSchema.min(1),
+  schemaVersion: NonNegativeIntegerSchema.min(1).max(
+    MAX_SUPPORTED_CLIENT_PROVENANCE_SCHEMA_VERSION
+  ),
   messageCount: NonNegativeIntegerSchema,
   modelCount: NonNegativeIntegerSchema,
 });


### PR DESCRIPTION
## What changed

- Add per-client parser provenance to submit payloads without changing `tokens graph` JSON.
- Mark the corrected Codex fork/subagent parser as revision 2 while keeping other clients at revision 1.
- Preserve the highest incoming revision when aggregating multi-model client rows.
- Allow a newer parser revision to replace an inflated stored value, while blocking older or same-revision regressions.
- Enforce a per-device, per-client revision floor across every stored day so an older uploader cannot pollute a new date.
- Treat mixed model revisions conservatively and reject unsupported future revisions.

## Root cause

Same-device resubmits intentionally reject lower token counts, so corrected Codex fork replay accounting could not replace values produced by the older parser. The route also discarded incoming provenance and re-derived every client as revision 1.

## Impact

A revision 2 Codex submission can repair previously inflated daily rows. Once a device stores revision 2, an older revision 1 uploader cannot overwrite existing rows or insert inflated Codex usage on a new date.

## Verification

- `cargo test -p tokscale-cli test_submit_payload_versions_client_parser_provenance_without_changing_graph_json`
- `node ../../node_modules/vitest/vitest.mjs run __tests__/api/submit.test.ts __tests__/api/submitAuth.test.ts __tests__/lib/helpers.test.ts` (75/75)
- `git show --check HEAD`
