### PR TITLE
fix(submit): allow newer parser revisions to correct usage

### DIFF
--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -246,6 +246,11 @@ enum Commands {
             help = "Show what would be submitted without actually submitting"
         )]
         dry_run: bool,
+        #[arg(
+            long,
+            help = "Authoritatively replace explicitly selected clients within --since/--until"
+        )]
+        replace: bool,
     },
     #[command(about = "Run in the background and submit usage on a recurring interval")]
     Serve {
@@ -740,8 +745,16 @@ fn main() -> Result<()> {
             clients,
             date,
             dry_run,
+            replace,
         }) => {
             reject_unsupported_home_override(&cli.home, "submit")?;
+            // Bypass settings.json defaultClients for the submit path: we want the
+            // submit-specific default_submit_clients() fallback (in run_submit_command)
+            // to fire when the user passes no client flags, not the user's general
+            // defaultClients view filter (which may exclude clients they still want
+            // to upload). Pass an explicit empty defaults slice.
+            let clients = build_client_filter_with_defaults(clients, &[]);
+            let replacement = resolve_submit_replacement(replace, clients.as_deref(), &date)?;
             let today = date.today;
             let yesterday = date.yesterday;
             let week = date.week;
@@ -749,13 +762,7 @@ fn main() -> Result<()> {
             let (since, until) =
                 build_date_filter(today, yesterday, week, month, date.since, date.until);
             let year = normalize_year_filter(today, yesterday, week, month, date.year);
-            // Bypass settings.json defaultClients for the submit path: we want the
-            // submit-specific default_submit_clients() fallback (in run_submit_command)
-            // to fire when the user passes no client flags, not the user's general
-            // defaultClients view filter (which may exclude clients they still want
-            // to upload). Pass an explicit empty defaults slice.
-            let clients = build_client_filter_with_defaults(clients, &[]);
-            run_submit_command(clients, since, until, year, dry_run)
+            run_submit_command(clients, since, until, year, dry_run, replacement)
         }
         Some(Commands::Serve { clients, interval }) => {
             reject_unsupported_home_override(&cli.home, "serve")?;
@@ -4158,6 +4165,16 @@ struct TsSourceContribution {
     tokens: TsTokenBreakdown,
     cost: f64,
     messages: i32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provenance: Option<TsClientContributionProvenance>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TsClientContributionProvenance {
+    schema_version: u32,
+    message_count: i32,
+    model_count: u32,
 }
 
 #[derive(serde::Serialize)]
@@ -4235,6 +4252,81 @@ struct TsTimeMetrics {
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
+struct TsClientManifestCoverage {
+    mode: &'static str,
+    start: String,
+    end: String,
+    missing_data: &'static str,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TsClientManifestEntry {
+    client: String,
+    parser_revision: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    coverage: Option<TsClientManifestCoverage>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TsClientManifest {
+    schema_version: u32,
+    clients: Vec<TsClientManifestEntry>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SubmitReplacementCoverage {
+    clients: Vec<String>,
+    start: String,
+    end: String,
+}
+
+fn resolve_submit_replacement(
+    replace: bool,
+    clients: Option<&[String]>,
+    date: &DateRangeFlags,
+) -> Result<Option<SubmitReplacementCoverage>> {
+    if !replace {
+        return Ok(None);
+    }
+    if date.today || date.yesterday || date.week || date.month || date.year.is_some() {
+        return Err(anyhow::anyhow!(
+            "--replace only accepts explicit --since and --until bounds; remove --today/--yesterday/--week/--month/--year"
+        ));
+    }
+
+    let replacement_clients = clients
+        .filter(|clients| !clients.is_empty())
+        .map(<[String]>::to_vec)
+        .ok_or_else(|| anyhow::anyhow!("--replace requires at least one explicit --client"))?;
+    let start = date
+        .since
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("--replace requires a bounded --since date"))?;
+    let end = date
+        .until
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("--replace requires a bounded --until date"))?;
+    let start_date = chrono::NaiveDate::parse_from_str(start, "%Y-%m-%d")
+        .map_err(|_| anyhow::anyhow!("--replace --since must use YYYY-MM-DD"))?;
+    let end_date = chrono::NaiveDate::parse_from_str(end, "%Y-%m-%d")
+        .map_err(|_| anyhow::anyhow!("--replace --until must use YYYY-MM-DD"))?;
+    if start_date > end_date {
+        return Err(anyhow::anyhow!(
+            "--replace --until must be on or after --since"
+        ));
+    }
+
+    Ok(Some(SubmitReplacementCoverage {
+        clients: replacement_clients,
+        start: start.to_string(),
+        end: end.to_string(),
+    }))
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct TsTokenContributionData {
     meta: TsExportMeta,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -4246,12 +4338,74 @@ struct TsTokenContributionData {
     time_metrics: Option<TsTimeMetrics>,
     #[serde(skip_serializing_if = "Option::is_none")]
     mcp_servers: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    client_manifest: Option<TsClientManifest>,
+}
+
+fn submit_parser_revision(client: &str) -> u32 {
+    if client == "codex" {
+        2
+    } else {
+        1
+    }
+}
+
+fn build_submit_client_manifest(
+    graph: &tokscale_core::GraphResult,
+    replacement: Option<&SubmitReplacementCoverage>,
+) -> TsClientManifest {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    let mut clients = BTreeSet::new();
+    for day in &graph.contributions {
+        for contribution in &day.clients {
+            clients.insert(contribution.client.clone());
+        }
+    }
+    if let Some(replacement) = replacement {
+        clients.extend(replacement.clients.iter().cloned());
+    }
+
+    let replacement_clients: BTreeMap<&str, &SubmitReplacementCoverage> = replacement
+        .into_iter()
+        .flat_map(|coverage| {
+            coverage
+                .clients
+                .iter()
+                .map(move |client| (client.as_str(), coverage))
+        })
+        .collect();
+
+    TsClientManifest {
+        schema_version: 1,
+        clients: clients
+            .into_iter()
+            .map(|client| {
+                let coverage = replacement_clients.get(client.as_str()).map(|replacement| {
+                    TsClientManifestCoverage {
+                        mode: "full",
+                        start: replacement.start.clone(),
+                        end: replacement.end.clone(),
+                        missing_data: "tombstone",
+                    }
+                });
+                TsClientManifestEntry {
+                    parser_revision: submit_parser_revision(&client),
+                    client,
+                    coverage,
+                }
+            })
+            .collect(),
+    }
 }
 
 fn to_ts_token_contribution_data(
     graph: &tokscale_core::GraphResult,
     device: Option<&device::SubmitDevice>,
+    replacement: Option<&SubmitReplacementCoverage>,
 ) -> TsTokenContributionData {
+    let include_submit_provenance = device.is_some();
+
     TsTokenContributionData {
         meta: TsExportMeta {
             generated_at: graph.meta.generated_at.clone(),
@@ -4265,6 +4419,7 @@ fn to_ts_token_contribution_data(
             id: d.id.clone(),
             name: d.name.clone(),
         }),
+        client_manifest: device.map(|_| build_submit_client_manifest(graph, replacement)),
         summary: TsDataSummary {
             total_tokens: graph.summary.total_tokens,
             total_cost: graph.summary.total_cost,
@@ -4326,6 +4481,13 @@ fn to_ts_token_contribution_data(
                         },
                         cost: s.cost,
                         messages: s.messages,
+                        provenance: include_submit_provenance.then(|| {
+                            TsClientContributionProvenance {
+                                schema_version: submit_parser_revision(&s.client),
+                                message_count: s.messages,
+                                model_count: 1,
+                            }
+                        }),
                     })
                     .collect(),
                 active_time_ms: d.active_time_ms,
@@ -4845,7 +5007,7 @@ fn run_graph_command(
     emit_cursor_setup_warnings(&cursor_setup_warnings);
 
     let processing_time_ms = start.elapsed().as_millis() as u32;
-    let output_data = to_ts_token_contribution_data(&graph_result, None);
+    let output_data = to_ts_token_contribution_data(&graph_result, None, None);
     let json_output = if subagents || work_time {
         // Attach opt-in breakdowns as separate top-level keys so the shared
         // contribution-data shape (and therefore the submit payload) stays
@@ -5189,6 +5351,7 @@ fn run_submit_command(
     until: Option<String>,
     year: Option<String>,
     dry_run: bool,
+    replacement: Option<SubmitReplacementCoverage>,
 ) -> Result<()> {
     use colored::Colorize;
     use std::io::IsTerminal;
@@ -5295,6 +5458,23 @@ fn run_submit_command(
     let excluded_rows = exclude_tokenless_cost_contributions(&mut graph_result);
     report_excluded_tokenless_rows(&excluded_rows);
 
+    if let Some(replacement) = replacement.as_ref() {
+        for client in &replacement.clients {
+            let has_contribution = graph_result
+                .contributions
+                .iter()
+                .any(|day| day.clients.iter().any(|entry| &entry.client == client));
+            if !has_contribution {
+                return Err(anyhow::anyhow!(
+                    "--replace found no {} contributions in {} to {}; refusing an unanchored replacement",
+                    client,
+                    replacement.start,
+                    replacement.end
+                ));
+            }
+        }
+    }
+
     println!("{}", "  Data to submit:".white());
     println!(
         "{}",
@@ -5349,7 +5529,8 @@ fn run_submit_command(
     let api_url = auth::get_api_base_url();
 
     let submit_device = device::resolve_submit_device()?;
-    let submit_payload = to_ts_token_contribution_data(&graph_result, Some(&submit_device));
+    let submit_payload =
+        to_ts_token_contribution_data(&graph_result, Some(&submit_device), replacement.as_ref());
 
     let response = rt.block_on(async {
         reqwest::Client::new()
@@ -7357,13 +7538,216 @@ mod tests {
             name: Some("Test device".to_string()),
         };
 
-        let payload = to_ts_token_contribution_data(&graph, Some(&device));
+        let payload = to_ts_token_contribution_data(&graph, Some(&device), None);
 
         assert_eq!(payload.device.as_ref().unwrap().id, "dev_test");
         assert_eq!(
             payload.device.as_ref().unwrap().name.as_deref(),
             Some("Test device")
         );
+    }
+
+    #[test]
+    fn test_submit_payload_versions_client_parser_provenance_without_changing_graph_json() {
+        let graph = graph_result_with_contributions(vec![day_with_clients(
+            "2026-12-31",
+            30,
+            vec![
+                client_contribution("codex", "gpt-5.5", "openai", 20, 2.0, 2),
+                client_contribution("claude", "claude-sonnet-4", "anthropic", 10, 1.0, 1),
+            ],
+        )]);
+        let device = device::SubmitDevice {
+            id: "dev_test".to_string(),
+            name: None,
+        };
+
+        let submit_json =
+            serde_json::to_value(to_ts_token_contribution_data(&graph, Some(&device), None))
+                .unwrap();
+        let submit_clients = submit_json["contributions"][0]["clients"]
+            .as_array()
+            .unwrap();
+        let codex = submit_clients
+            .iter()
+            .find(|client| client["client"] == "codex")
+            .unwrap();
+        let claude = submit_clients
+            .iter()
+            .find(|client| client["client"] == "claude")
+            .unwrap();
+
+        assert_eq!(codex["provenance"]["schemaVersion"], 2);
+        assert_eq!(codex["provenance"]["messageCount"], 2);
+        assert_eq!(codex["provenance"]["modelCount"], 1);
+        assert_eq!(claude["provenance"]["schemaVersion"], 1);
+
+        let manifest = &submit_json["clientManifest"];
+        assert_eq!(manifest["schemaVersion"], 1);
+        let manifest_clients = manifest["clients"].as_array().unwrap();
+        let codex_manifest = manifest_clients
+            .iter()
+            .find(|client| client["client"] == "codex")
+            .unwrap();
+        let claude_manifest = manifest_clients
+            .iter()
+            .find(|client| client["client"] == "claude")
+            .unwrap();
+        assert_eq!(codex_manifest["parserRevision"], 2);
+        assert!(codex_manifest.get("coverage").is_none());
+        assert_eq!(claude_manifest["parserRevision"], 1);
+        assert!(claude_manifest.get("coverage").is_none());
+
+        let graph_json =
+            serde_json::to_value(to_ts_token_contribution_data(&graph, None, None)).unwrap();
+        assert!(graph_json.get("clientManifest").is_none());
+        for client in graph_json["contributions"][0]["clients"]
+            .as_array()
+            .unwrap()
+        {
+            assert!(client.get("provenance").is_none());
+        }
+    }
+
+    #[test]
+    fn test_submit_replacement_payload_declares_bounded_tombstone_coverage() {
+        let graph = graph_result_with_contributions(vec![daily_contribution(
+            "2026-07-12",
+            20,
+            2.50,
+            "codex",
+            "gpt-5.5",
+        )]);
+        let device = device::SubmitDevice {
+            id: "dev_test".to_string(),
+            name: None,
+        };
+        let replacement = SubmitReplacementCoverage {
+            clients: vec!["codex".to_string()],
+            start: "2026-04-17".to_string(),
+            end: "2026-07-12".to_string(),
+        };
+
+        let payload = serde_json::to_value(to_ts_token_contribution_data(
+            &graph,
+            Some(&device),
+            Some(&replacement),
+        ))
+        .unwrap();
+
+        assert_eq!(
+            payload["clientManifest"],
+            serde_json::json!({
+                "schemaVersion": 1,
+                "clients": [{
+                    "client": "codex",
+                    "parserRevision": 2,
+                    "coverage": {
+                        "mode": "full",
+                        "start": "2026-04-17",
+                        "end": "2026-07-12",
+                        "missingData": "tombstone"
+                    }
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn test_submit_replace_command_parses_explicit_client_and_bounded_dates() {
+        let cli = Cli::try_parse_from([
+            "tokens",
+            "submit",
+            "-c",
+            "codex",
+            "--since",
+            "2026-04-17",
+            "--until",
+            "2026-07-12",
+            "--replace",
+        ])
+        .expect("bounded submit replacement should parse");
+
+        let Some(Commands::Submit {
+            clients,
+            date,
+            dry_run,
+            replace,
+        }) = cli.command
+        else {
+            panic!("expected submit command");
+        };
+
+        assert_eq!(clients.clients, vec![ClientFilter::Codex]);
+        assert_eq!(date.since.as_deref(), Some("2026-04-17"));
+        assert_eq!(date.until.as_deref(), Some("2026-07-12"));
+        assert!(!dry_run);
+        assert!(replace);
+    }
+
+    #[test]
+    fn test_submit_replacement_requires_explicit_client_and_raw_bounds() {
+        let clients = vec!["codex".to_string()];
+        let bounded = DateRangeFlags {
+            since: Some("2026-04-17".to_string()),
+            until: Some("2026-07-12".to_string()),
+            ..DateRangeFlags::default()
+        };
+
+        assert_eq!(
+            resolve_submit_replacement(true, Some(&clients), &bounded).unwrap(),
+            Some(SubmitReplacementCoverage {
+                clients,
+                start: "2026-04-17".to_string(),
+                end: "2026-07-12".to_string(),
+            })
+        );
+        assert!(resolve_submit_replacement(true, None, &bounded)
+            .unwrap_err()
+            .to_string()
+            .contains("explicit --client"));
+
+        let missing_until = DateRangeFlags {
+            since: Some("2026-04-17".to_string()),
+            ..DateRangeFlags::default()
+        };
+        assert!(
+            resolve_submit_replacement(true, Some(&["codex".to_string()]), &missing_until)
+                .unwrap_err()
+                .to_string()
+                .contains("--until")
+        );
+    }
+
+    #[test]
+    fn test_submit_replacement_rejects_partial_scan_filters_and_invalid_ranges() {
+        let clients = ["codex".to_string()];
+        let with_year = DateRangeFlags {
+            since: Some("2025-01-01".to_string()),
+            until: Some("2026-12-31".to_string()),
+            year: Some("2026".to_string()),
+            ..DateRangeFlags::default()
+        };
+        assert!(resolve_submit_replacement(true, Some(&clients), &with_year)
+            .unwrap_err()
+            .to_string()
+            .contains("explicit --since and --until"));
+
+        let with_week = DateRangeFlags {
+            week: true,
+            ..DateRangeFlags::default()
+        };
+        assert!(resolve_submit_replacement(true, Some(&clients), &with_week).is_err());
+
+        let reversed = DateRangeFlags {
+            since: Some("2026-07-12".to_string()),
+            until: Some("2026-04-17".to_string()),
+            ..DateRangeFlags::default()
+        };
+        assert!(resolve_submit_replacement(true, Some(&clients), &reversed)
+            .unwrap_err()
+            .to_string()
+            .contains("on or after"));
     }
 
     #[test]

--- a/packages/frontend/__tests__/api/submit.test.ts
+++ b/packages/frontend/__tests__/api/submit.test.ts
@@ -233,19 +233,319 @@ describe('POST /api/submit - Client-Level Merge', () => {
         provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
       };
       client.provenance = {
-        schemaVersion: 1,
+        schemaVersion: 2,
+        messageCount: 7,
+        modelCount: 1,
+      };
+
+      const result = validateSubmission({
+        ...payload,
+        device: { id: 'dev_test' },
+        clientManifest: {
+          schemaVersion: 1,
+          clients: [{ client: 'codex', parserRevision: 2 }],
+        },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.contributions[0].clients[0].provenance).toEqual({
+        schemaVersion: 2,
+        messageCount: 7,
+        modelCount: 1,
+      });
+      expect(result.data?.clientManifest?.clients).toEqual([
+        { client: 'codex', parserRevision: 2 },
+      ]);
+    });
+
+    it('requires a matching manifest for revision 2 provenance', () => {
+      const payload = createMockSubmissionData({ clients: ['codex'] });
+      const client = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      client.provenance = { schemaVersion: 2, messageCount: 7, modelCount: 1 };
+
+      const result = validateSubmission({
+        ...payload,
+        device: { id: 'dev_test' },
+      });
+
+      expect(result.valid).toBe(false);
+      expect(result.errors.join('\n')).toContain(
+        'codex revision 2 requires a matching clientManifest entry'
+      );
+    });
+
+    it('accepts bounded authoritative replacement coverage', () => {
+      const payload = createMockSubmissionData({ clients: ['codex'] });
+      const client = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      client.provenance = { schemaVersion: 2, messageCount: 7, modelCount: 1 };
+
+      const result = validateSubmission({
+        ...payload,
+        device: { id: 'dev_test' },
+        clientManifest: {
+          schemaVersion: 1,
+          clients: [{
+            client: 'codex',
+            parserRevision: 2,
+            coverage: {
+              mode: 'full',
+              start: '2024-12-01',
+              end: '2024-12-01',
+              missingData: 'tombstone',
+            },
+          }],
+        },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.clientManifest?.clients[0].coverage).toEqual({
+        mode: 'full',
+        start: '2024-12-01',
+        end: '2024-12-01',
+        missingData: 'tombstone',
+      });
+    });
+
+    it('rejects unsupported and duplicate manifest entries', () => {
+      const payload = createMockSubmissionData({ clients: ['codex'] });
+
+      const unsupported = validateSubmission({
+        ...payload,
+        device: { id: 'dev_test' },
+        clientManifest: {
+          schemaVersion: 2,
+          clients: [{ client: 'codex', parserRevision: 1 }],
+        },
+      });
+      const duplicate = validateSubmission({
+        ...payload,
+        device: { id: 'dev_test' },
+        clientManifest: {
+          schemaVersion: 1,
+          clients: [
+            { client: 'codex', parserRevision: 1 },
+            { client: 'codex', parserRevision: 1 },
+          ],
+        },
+      });
+
+      expect(unsupported.valid).toBe(false);
+      expect(unsupported.errors.join('\n')).toContain('clientManifest.schemaVersion');
+      expect(duplicate.valid).toBe(false);
+      expect(duplicate.errors.join('\n')).toContain(
+        'clientManifest contains duplicate client codex'
+      );
+    });
+
+    it('rejects manifest revision mismatches and unanchored replacement coverage', () => {
+      const payload = createMockSubmissionData({ clients: ['codex'] });
+      const client = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      client.provenance = { schemaVersion: 2, messageCount: 7, modelCount: 1 };
+
+      const mismatch = validateSubmission({
+        ...payload,
+        device: { id: 'dev_test' },
+        clientManifest: {
+          schemaVersion: 1,
+          clients: [{ client: 'codex', parserRevision: 1 }],
+        },
+      });
+      const unanchored = validateSubmission({
+        ...createMockSubmissionData({ clients: ['claude'] }),
+        device: { id: 'dev_test' },
+        clientManifest: {
+          schemaVersion: 1,
+          clients: [{
+            client: 'codex',
+            parserRevision: 2,
+            coverage: {
+              mode: 'full',
+              start: '2024-12-01',
+              end: '2024-12-01',
+              missingData: 'tombstone',
+            },
+          }],
+        },
+      });
+
+      expect(mismatch.valid).toBe(false);
+      expect(mismatch.errors.join('\n')).toContain(
+        'codex manifest revision must match contribution revision 2'
+      );
+      expect(unanchored.valid).toBe(false);
+      expect(unanchored.errors.join('\n')).toContain(
+        'full coverage for codex requires at least one submitted contribution'
+      );
+    });
+
+    it('normalizes kilocode in replacement manifests together with contributions', () => {
+      const payload = createMockSubmissionData({
+        clients: ['kilocode' as ClientType],
+      });
+
+      const result = validateSubmission({
+        ...payload,
+        device: { id: 'dev_test' },
+        clientManifest: {
+          schemaVersion: 1,
+          clients: [{
+            client: 'kilocode',
+            parserRevision: 1,
+            coverage: {
+              mode: 'full',
+              start: '2024-12-01',
+              end: '2024-12-01',
+              missingData: 'tombstone',
+            },
+          }],
+        },
+      });
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.clientManifest?.clients[0].client).toBe('kilo');
+      expect(result.data?.contributions[0].clients[0].client).toBe('kilo');
+    });
+
+    it('rejects client provenance newer than the server supports', () => {
+      const payload = createMockSubmissionData({ clients: ['codex'] });
+      const client = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      client.provenance = {
+        schemaVersion: 999,
         messageCount: 7,
         modelCount: 1,
       };
 
       const result = validateSubmission(payload);
 
-      expect(result.valid).toBe(true);
-      expect(result.data?.contributions[0].clients[0].provenance).toEqual({
-        schemaVersion: 1,
-        messageCount: 7,
+      expect(result.valid).toBe(false);
+      expect(result.errors.some((error) => error.includes('schemaVersion'))).toBe(true);
+    });
+
+    it('rejects revision 2 provenance for non-Codex clients', () => {
+      const payload = createMockSubmissionData({ clients: ['claude'] });
+      const client = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      client.provenance = {
+        schemaVersion: 2,
+        messageCount: 5,
         modelCount: 1,
+      };
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((error) =>
+          error.includes('claude provenance schemaVersion must be at most 1')
+        )
+      ).toBe(true);
+    });
+
+    it('accepts revision 1 provenance for non-Codex clients', () => {
+      const payload = createMockSubmissionData({ clients: ['claude'] });
+      const client = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      client.provenance = {
+        schemaVersion: 1,
+        messageCount: 5,
+        modelCount: 1,
+      };
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(true);
+      expect(result.data?.contributions[0].clients[0].provenance?.schemaVersion).toBe(1);
+    });
+
+    it('rejects mixed revisions for the same client across days', () => {
+      const payload = createMockSubmissionData({
+        clients: ['codex'],
+        contributions: [
+          {
+            date: '2024-12-01',
+            clients: [{
+              client: 'codex',
+              modelId: 'gpt-5.5',
+              cost: 1,
+              tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 },
+              messages: 1,
+            }],
+          },
+          {
+            date: '2024-12-02',
+            clients: [{
+              client: 'codex',
+              modelId: 'gpt-5.5-mini',
+              cost: 2,
+              tokens: { input: 200, output: 100, cacheRead: 0, cacheWrite: 0 },
+              messages: 2,
+            }],
+          },
+        ],
       });
+      const first = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      first.provenance = { schemaVersion: 2, messageCount: 1, modelCount: 1 };
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((error) =>
+          error.includes('codex provenance schemaVersion must be consistent')
+        )
+      ).toBe(true);
+    });
+
+    it('rejects mixed revisions for two models of the same client', () => {
+      const payload = createMockSubmissionData({
+        clients: ['codex'],
+        contributions: [{
+          date: '2024-12-01',
+          clients: [
+            {
+              client: 'codex',
+              modelId: 'gpt-5.5',
+              cost: 1,
+              tokens: { input: 100, output: 50, cacheRead: 0, cacheWrite: 0 },
+              messages: 1,
+            },
+            {
+              client: 'codex',
+              modelId: 'gpt-5.5-mini',
+              cost: 2,
+              tokens: { input: 200, output: 100, cacheRead: 0, cacheWrite: 0 },
+              messages: 2,
+            },
+          ],
+        }],
+      });
+      const first = payload.contributions[0].clients[0] as {
+        provenance?: { schemaVersion: number; messageCount: number; modelCount: number };
+      };
+      const second = payload.contributions[0].clients[1] as typeof first;
+      first.provenance = { schemaVersion: 2, messageCount: 1, modelCount: 1 };
+      second.provenance = { schemaVersion: 1, messageCount: 2, modelCount: 1 };
+
+      const result = validateSubmission(payload);
+
+      expect(result.valid).toBe(false);
+      expect(
+        result.errors.some((error) =>
+          error.includes('codex provenance schemaVersion must be consistent')
+        )
+      ).toBe(true);
     });
   });
 

--- a/packages/frontend/__tests__/api/submitAuth.test.ts
+++ b/packages/frontend/__tests__/api/submitAuth.test.ts
@@ -112,7 +112,8 @@ vi.mock("@/lib/validation/submission", () => ({
   generateSubmissionHash: mockState.generateSubmissionHash,
 }));
 
-vi.mock("@/lib/db/helpers", () => ({
+vi.mock("@/lib/db/helpers", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/lib/db/helpers")>()),
   mergeClientBreakdowns: mockState.mergeClientBreakdowns,
   mergeClientBreakdownsWithRegressionGuard: mockState.mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals: mockState.recalculateDayTotals,
@@ -347,6 +348,11 @@ describe("POST /api/submit auth path", () => {
                 cacheWrite: 0,
                 reasoning: 0,
                 messages: 1,
+                provenance: {
+                  schemaVersion: 2,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
               },
             ],
           },
@@ -497,6 +503,15 @@ describe("POST /api/submit auth path", () => {
         submissionId: "submission-1",
         submittedDeviceId: "submitted-device-1",
         date: "2026-04-30",
+        sourceBreakdown: expect.objectContaining({
+          codex: expect.objectContaining({
+            provenance: {
+              schemaVersion: 2,
+              messageCount: 1,
+              modelCount: 1,
+            },
+          }),
+        }),
       }),
     ]);
     expect(submissionUpdateValues).toEqual(
@@ -512,7 +527,10 @@ describe("POST /api/submit auth path", () => {
     expect(mockState.revalidateUsernamePaths).toHaveBeenCalledWith("Alice");
   });
 
-  it("replaces same-device daily rows without inserting duplicate dates", async () => {
+  it.each([
+    { location: "another device", submittedDeviceId: "submitted-device-other" },
+    { location: "the legacy bucket", submittedDeviceId: null },
+  ])("applies the account-wide revision floor from $location", async ({ submittedDeviceId }) => {
     mockState.authenticatePersonalToken.mockResolvedValue({
       status: "valid",
       tokenId: "token-1",
@@ -531,15 +549,15 @@ describe("POST /api/submit auth path", () => {
         },
         meta: {
           version: "2.0.0",
-          dateRange: { start: "2026-04-30", end: "2026-04-30" },
+          dateRange: { start: "2026-05-01", end: "2026-05-03" },
         },
         summary: {
           clients: ["codex"],
         },
         contributions: [
           {
-            date: "2026-04-30",
-            timestampMs: 456,
+            date: "2026-05-01",
+            timestampMs: 789,
             clients: [
               {
                 client: "codex",
@@ -552,6 +570,51 @@ describe("POST /api/submit auth path", () => {
                 cacheWrite: 0,
                 reasoning: 0,
                 messages: 1,
+                provenance: {
+                  schemaVersion: 1,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
+              },
+              {
+                client: "claude",
+                modelId: "claude-sonnet-4",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+                provenance: {
+                  schemaVersion: 1,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
+              },
+            ],
+          },
+          {
+            date: "2026-05-03",
+            timestampMs: 1_111,
+            clients: [
+              {
+                client: "codex",
+                modelId: "gpt-5.5",
+                tokens: 15,
+                cost: 0.75,
+                input: 10,
+                output: 5,
+                cacheRead: 0,
+                cacheWrite: 0,
+                reasoning: 0,
+                messages: 1,
+                provenance: {
+                  schemaVersion: 1,
+                  messageCount: 1,
+                  modelCount: 1,
+                },
               },
             ],
           },
@@ -571,7 +634,7 @@ describe("POST /api/submit auth path", () => {
       reasoning: 0,
       messages: 1,
     };
-    const existingBreakdown = {
+    const revisionFloorBreakdown = {
       codex: {
         tokens: 12,
         cost: 0.5,
@@ -582,20 +645,32 @@ describe("POST /api/submit auth path", () => {
         reasoning: 0,
         messages: 1,
         models: { "gpt-5.5": { tokens: 12 } },
+        provenance: {
+          schemaVersion: 2,
+          messageCount: 1,
+          modelCount: 1,
+        },
       },
     };
-    const mergedBreakdown = {
-      codex: {
-        ...incomingBreakdown,
-        models: { "gpt-5.5": incomingBreakdown },
+    const currentDeviceBreakdown = {
+      claude: {
+        tokens: 5,
+        cost: 0.25,
+        input: 3,
+        output: 2,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 1,
+        models: { "claude-sonnet-4": { tokens: 5 } },
+        provenance: {
+          schemaVersion: 1,
+          messageCount: 1,
+          modelCount: 1,
+        },
       },
     };
-
     mockState.clientContributionToBreakdownData.mockReturnValue(incomingBreakdown);
-    mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
-      merged: mergedBreakdown,
-      warnings: [],
-    });
     mockState.recalculateDayTotals.mockReturnValue({
       tokens: 15,
       cost: 0.75,
@@ -606,12 +681,22 @@ describe("POST /api/submit auth path", () => {
 
     const selectResults = [
       [{ id: "submission-1" }],
-      [{
-        id: "daily-1",
-        date: "2026-04-30",
-        timestampMs: 123,
-        sourceBreakdown: existingBreakdown,
-      }],
+      [
+        {
+          id: "daily-current",
+          submittedDeviceId: "submitted-device-1",
+          date: "2026-04-29",
+          timestampMs: 122,
+          sourceBreakdown: currentDeviceBreakdown,
+        },
+        {
+          id: "daily-floor",
+          submittedDeviceId,
+          date: "2026-04-30",
+          timestampMs: 123,
+          sourceBreakdown: revisionFloorBreakdown,
+        },
+      ],
       [{
         totalTokens: 15,
         totalCost: "0.7500",
@@ -622,9 +707,10 @@ describe("POST /api/submit auth path", () => {
         activeDays: 1,
         rowCount: 1,
       }],
-      [{ sourceBreakdown: mergedBreakdown }],
+      [{ sourceBreakdown: revisionFloorBreakdown }],
     ];
 
+    let dailyInsertValues: Array<Record<string, unknown>> | undefined;
     const tx = {
       update: vi.fn(() => {
         const builder = {
@@ -634,7 +720,15 @@ describe("POST /api/submit auth path", () => {
         return builder;
       }),
       select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
-      insert: vi.fn(() => {
+      insert: vi.fn((table: unknown) => {
+        if ((table as { id?: unknown }).id === "dailyBreakdown.id") {
+          return {
+            values: vi.fn((values: Array<Record<string, unknown>>) => {
+              dailyInsertValues = values;
+              return Promise.resolve();
+            }),
+          };
+        }
         const builder = {
           values: vi.fn(() => builder),
           onConflictDoUpdate: vi.fn(() => builder),
@@ -668,25 +762,21 @@ describe("POST /api/submit auth path", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(tx.insert).toHaveBeenCalledTimes(1);
+    expect(tx.insert).toHaveBeenCalledTimes(2);
     expect(tx.insert).toHaveBeenCalledWith(expect.objectContaining({
       id: "submittedDevices.id",
     }));
-    expect(tx.execute).toHaveBeenCalledTimes(1);
-    expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
-      existingBreakdown,
-      {
-        codex: {
-          ...mergedBreakdown.codex,
-          provenance: {
-            schemaVersion: 1,
-            messageCount: 1,
-            modelCount: 1,
-          },
-        },
+    expect(tx.execute).not.toHaveBeenCalled();
+    expect(dailyInsertValues).toHaveLength(1);
+    expect(dailyInsertValues?.[0]).toEqual(expect.objectContaining({
+      date: "2026-05-01",
+      sourceBreakdown: {
+        claude: expect.objectContaining({
+          provenance: expect.objectContaining({ schemaVersion: 1 }),
+        }),
       },
-      expect.any(Set)
-    );
+    }));
+    expect(mockState.mergeClientBreakdownsWithRegressionGuard).not.toHaveBeenCalled();
     expect(await response.json()).toEqual(expect.objectContaining({
       success: true,
       metrics: expect.objectContaining({
@@ -694,6 +784,329 @@ describe("POST /api/submit auth path", () => {
         activeDays: 1,
       }),
       mode: "merge",
+      warnings: [
+        "Day 2026-05-01: Ignored codex parser revision 1 because this account already stored revision 2.",
+        "Day 2026-05-03: Ignored codex parser revision 1 because this account already stored revision 2.",
+      ],
+    }));
+  });
+
+  it("replaces a missing client and whole stale day only inside authoritative coverage", async () => {
+    mockState.authenticatePersonalToken.mockResolvedValue({
+      status: "valid",
+      tokenId: "token-1",
+      userId: "user-1",
+      username: "alice",
+      displayName: "Alice",
+      avatarUrl: null,
+      expiresAt: null,
+    });
+
+    mockState.validateSubmission.mockReturnValue({
+      valid: true,
+      data: {
+        device: { id: "dev_laptop" },
+        meta: {
+          version: "2.0.0",
+          dateRange: { start: "2026-04-17", end: "2026-07-12" },
+        },
+        summary: { clients: ["codex", "claude"] },
+        clientManifest: {
+          schemaVersion: 1,
+          clients: [
+            {
+              client: "codex",
+              parserRevision: 2,
+              coverage: {
+                mode: "full",
+                start: "2026-04-17",
+                end: "2026-07-12",
+                missingData: "tombstone",
+              },
+            },
+            {
+              client: "claude",
+              parserRevision: 1,
+              coverage: {
+                mode: "full",
+                start: "2026-04-17",
+                end: "2026-07-12",
+                missingData: "tombstone",
+              },
+            },
+          ],
+        },
+        contributions: [
+          {
+            date: "2026-07-10",
+            timestampMs: 700,
+            clients: [{
+              client: "claude",
+              modelId: "claude-sonnet-4",
+              tokens: 600,
+              cost: 0.5,
+              input: 550,
+              output: 50,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+              messages: 6,
+              provenance: {
+                schemaVersion: 1,
+                messageCount: 6,
+                modelCount: 1,
+              },
+            }],
+          },
+          {
+            date: "2026-07-12",
+            timestampMs: 789,
+            clients: [{
+              client: "codex",
+              modelId: "gpt-5.5",
+              tokens: 950,
+              cost: 0.75,
+              input: 900,
+              output: 50,
+              cacheRead: 0,
+              cacheWrite: 0,
+              reasoning: 0,
+              messages: 12,
+              provenance: {
+                schemaVersion: 2,
+                messageCount: 12,
+                modelCount: 1,
+              },
+            }],
+          },
+        ],
+      },
+      errors: [],
+      warnings: [],
+    });
+
+    const incomingBreakdown = {
+      tokens: 950,
+      cost: 0.75,
+      input: 900,
+      output: 50,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 12,
+    };
+    const staleCodex = {
+      codex: {
+        tokens: 14_000_000_000,
+        cost: 500,
+        input: 13_000_000_000,
+        output: 1_000_000_000,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 80,
+        models: { "gpt-5.5": { tokens: 14_000_000_000 } },
+        provenance: {
+          schemaVersion: 1,
+          messageCount: 80,
+          modelCount: 1,
+        },
+      },
+    };
+    const incomingClaude = {
+      tokens: 600,
+      cost: 0.5,
+      input: 550,
+      output: 50,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      messages: 6,
+    };
+    const staleCodexAndClaude = {
+      ...staleCodex,
+      claude: {
+        tokens: 800,
+        cost: 0.7,
+        input: 700,
+        output: 100,
+        cacheRead: 0,
+        cacheWrite: 0,
+        reasoning: 0,
+        messages: 8,
+        models: { "claude-sonnet-4": { tokens: 800 } },
+        provenance: {
+          schemaVersion: 1,
+          messageCount: 8,
+          modelCount: 1,
+        },
+      },
+    };
+    const anchoredClaude = {
+      claude: {
+        ...incomingClaude,
+        models: { "claude-sonnet-4": incomingClaude },
+        provenance: {
+          schemaVersion: 1,
+          messageCount: 6,
+          modelCount: 1,
+        },
+      },
+    };
+    const anchoredCodex = {
+      codex: {
+        ...incomingBreakdown,
+        models: { "gpt-5.5": incomingBreakdown },
+        provenance: {
+          schemaVersion: 2,
+          messageCount: 12,
+          modelCount: 1,
+        },
+      },
+    };
+
+    mockState.clientContributionToBreakdownData
+      .mockReturnValueOnce(incomingClaude)
+      .mockReturnValueOnce(incomingBreakdown);
+    mockState.mergeClientBreakdownsWithRegressionGuard.mockReturnValue({
+      merged: anchoredClaude,
+      warnings: [],
+    });
+    mockState.recalculateDayTotals
+      .mockReturnValueOnce({
+        tokens: 600,
+        cost: 0.5,
+        inputTokens: 550,
+        outputTokens: 50,
+      })
+      .mockReturnValueOnce({
+        tokens: 950,
+        cost: 0.75,
+        inputTokens: 900,
+        outputTokens: 50,
+      });
+
+    const selectResults = [
+      [{ id: "submission-1" }],
+      [
+        {
+          id: "daily-outside-range",
+          submittedDeviceId: "submitted-device-1",
+          date: "2026-04-16",
+          timestampMs: 100,
+          activeTimeMs: null,
+          sourceBreakdown: staleCodex,
+        },
+        {
+          id: "daily-missing-client",
+          submittedDeviceId: "submitted-device-1",
+          date: "2026-07-10",
+          timestampMs: 150,
+          activeTimeMs: null,
+          sourceBreakdown: staleCodexAndClaude,
+        },
+        {
+          id: "daily-stale-covered",
+          submittedDeviceId: "submitted-device-1",
+          date: "2026-07-11",
+          timestampMs: 200,
+          activeTimeMs: null,
+          sourceBreakdown: staleCodex,
+        },
+      ],
+      [{
+        totalTokens: 950,
+        totalCost: "0.7500",
+        inputTokens: 900,
+        outputTokens: 50,
+        dateStart: "2026-07-12",
+        dateEnd: "2026-07-12",
+        activeDays: 1,
+        rowCount: 1,
+      }],
+      [{ sourceBreakdown: anchoredCodex }],
+    ];
+
+    let insertCall = 0;
+    let dailyInsertValues: unknown;
+    let deleteWhere: unknown;
+    const tx = {
+      update: vi.fn(() => {
+        const builder = {
+          set: vi.fn(() => builder),
+          where: vi.fn(() => Promise.resolve()),
+        };
+        return builder;
+      }),
+      select: vi.fn(() => makeAwaitableBuilder(selectResults.shift() ?? [])),
+      insert: vi.fn(() => {
+        insertCall += 1;
+        if (insertCall === 1) {
+          const builder = {
+            values: vi.fn(() => builder),
+            onConflictDoUpdate: vi.fn(() => builder),
+            returning: vi.fn(() => Promise.resolve([{ id: "submitted-device-1" }])),
+          };
+          return builder;
+        }
+        return {
+          values: vi.fn((values: unknown) => {
+            dailyInsertValues = values;
+            return Promise.resolve();
+          }),
+        };
+      }),
+      delete: vi.fn(() => ({
+        where: vi.fn((condition: unknown) => {
+          deleteWhere = condition;
+          return Promise.resolve();
+        }),
+      })),
+      execute: vi.fn(() => Promise.resolve()),
+      transaction: vi.fn(async (callback: (sp: typeof tx) => Promise<unknown>) =>
+        callback(tx)
+      ),
+    };
+    type MockTransaction = typeof tx;
+
+    mockState.db.transaction.mockImplementation(
+      async (callback: (transaction: MockTransaction) => Promise<unknown>) => callback(tx)
+    );
+
+    const response = await POST(
+      new Request("http://localhost:3000/api/submit", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer tt_valid",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ meta: {}, contributions: [] }),
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(dailyInsertValues).toEqual([
+      expect.objectContaining({
+        date: "2026-07-12",
+        sourceBreakdown: anchoredCodex,
+      }),
+    ]);
+    expect(tx.delete).toHaveBeenCalledTimes(1);
+    expect((deleteWhere as { queryChunks: unknown[] }).queryChunks[3]).toEqual([
+      "daily-stale-covered",
+    ]);
+    expect(mockState.mergeClientBreakdownsWithRegressionGuard).toHaveBeenCalledWith(
+      {},
+      anchoredClaude,
+      expect.any(Set)
+    );
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+    expect(await response.json()).toEqual(expect.objectContaining({
+      success: true,
+      warnings: [
+        "Day 2026-07-10: Removed stale codex data under authoritative replacement coverage.",
+        "Day 2026-07-11: Removed stale codex data under authoritative replacement coverage.",
+      ],
     }));
   });
 
@@ -794,6 +1207,7 @@ describe("POST /api/submit auth path", () => {
       [{ id: "submission-1" }],
       [{
         id: "daily-1",
+        submittedDeviceId: "submitted-device-1",
         date: "2026-04-30",
         timestampMs: 123,
         activeTimeMs: null,
@@ -1184,6 +1598,7 @@ describe("POST /api/submit auth path", () => {
       [{ id: "submission-1" }],
       [{
         id: "daily-1",
+        submittedDeviceId: "submitted-device-1",
         date: "2026-04-30",
         timestampMs: 123,
         activeTimeMs: 2_000,
@@ -1363,6 +1778,7 @@ describe("POST /api/submit auth path", () => {
       [],
       [{
         id: "daily-legacy",
+        submittedDeviceId: "submitted-device-1",
         date: "2026-04-30",
         timestampMs: 123,
         activeTimeMs: null,

--- a/packages/frontend/__tests__/lib/helpers.test.ts
+++ b/packages/frontend/__tests__/lib/helpers.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { mergeClientBreakdownsWithRegressionGuard } from "../../src/lib/db/helpers";
+import {
+  aggregateIncomingClientBreakdowns,
+  applyAuthoritativeClientCoverage,
+  deriveStoredClientRevisionFloors,
+  filterClientBreakdownsByRevisionFloor,
+  mergeClientBreakdownsWithRegressionGuard,
+} from "../../src/lib/db/helpers";
 
 // Minimal client breakdown fixture
 function makeClient(tokens: number, messages: number, modelCount: number) {
@@ -17,6 +23,20 @@ function makeClient(tokens: number, messages: number, modelCount: number) {
     reasoning: 0,
     messages,
     models,
+  };
+}
+
+function withRevision(
+  client: ReturnType<typeof makeClient>,
+  schemaVersion: number
+) {
+  return {
+    ...client,
+    provenance: {
+      schemaVersion,
+      messageCount: client.messages,
+      modelCount: Object.keys(client.models).length,
+    },
   };
 }
 
@@ -98,5 +118,206 @@ describe("mergeClientBreakdownsWithRegressionGuard", () => {
     expect(result.merged.cursor.tokens).toBe(500);
     expect(result.warnings).toHaveLength(1);
     expect(result.warnings[0]).toContain("cursor");
+  });
+
+  it("accepts a lower corrected value from a newer parser revision", () => {
+    const existing = { codex: withRevision(makeClient(14_000, 80, 2), 1) };
+    const incoming = { codex: withRevision(makeClient(950, 12, 2), 2) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(950);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("rejects an older parser revision even when it reports more tokens", () => {
+    const existing = { codex: withRevision(makeClient(950, 12, 2), 2) };
+    const incoming = { codex: withRevision(makeClient(14_000, 80, 2), 1) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(950);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("revision 1");
+    expect(result.warnings[0]).toContain("revision 2");
+  });
+
+  it("keeps the same-revision token regression guard", () => {
+    const existing = { codex: withRevision(makeClient(1_000, 12, 2), 2) };
+    const incoming = { codex: withRevision(makeClient(900, 12, 2), 2) };
+
+    const result = mergeClientBreakdownsWithRegressionGuard(
+      existing,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(result.merged.codex.tokens).toBe(1_000);
+    expect(result.merged.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.warnings).toHaveLength(1);
+  });
+});
+
+describe("aggregateIncomingClientBreakdowns", () => {
+  it("aggregates multiple models while preserving the incoming parser revision", () => {
+    const result = aggregateIncomingClientBreakdowns([
+      {
+        client: "codex",
+        modelId: "gpt-5.5",
+        breakdown: makeClient(600, 7, 1).models["model-0"],
+        provenance: { schemaVersion: 2, messageCount: 7, modelCount: 1 },
+      },
+      {
+        client: "codex",
+        modelId: "gpt-5.5-mini",
+        breakdown: makeClient(350, 5, 1).models["model-0"],
+        provenance: { schemaVersion: 2, messageCount: 5, modelCount: 1 },
+      },
+    ]);
+
+    expect(result.codex.tokens).toBe(950);
+    expect(result.codex.messages).toBe(12);
+    expect(Object.keys(result.codex.models)).toEqual(["gpt-5.5", "gpt-5.5-mini"]);
+    expect(result.codex.provenance).toEqual({
+      schemaVersion: 2,
+      messageCount: 12,
+      modelCount: 2,
+    });
+  });
+
+  it("uses the lowest parser revision when one client mixes model revisions", () => {
+    const result = aggregateIncomingClientBreakdowns([
+      {
+        client: "codex",
+        modelId: "gpt-5.5",
+        breakdown: makeClient(600, 7, 1).models["model-0"],
+        provenance: { schemaVersion: 2, messageCount: 7, modelCount: 1 },
+      },
+      {
+        client: "codex",
+        modelId: "gpt-5.5-mini",
+        breakdown: makeClient(350, 5, 1).models["model-0"],
+        provenance: { schemaVersion: 1, messageCount: 5, modelCount: 1 },
+      },
+    ]);
+
+    expect(result.codex.provenance?.schemaVersion).toBe(1);
+  });
+});
+
+describe("client revision floors", () => {
+  const storedRevisionFloors = deriveStoredClientRevisionFloors([
+    {
+      codex: withRevision(makeClient(950, 12, 2), 2),
+      claude: withRevision(makeClient(500, 5, 1), 1),
+    },
+  ]);
+
+  it("rejects an older revision on a new day without blocking other clients", () => {
+    const result = filterClientBreakdownsByRevisionFloor(
+      {
+        codex: withRevision(makeClient(14_000, 80, 2), 1),
+        claude: withRevision(makeClient(600, 6, 1), 1),
+      },
+      storedRevisionFloors
+    );
+
+    expect(result.accepted.codex).toBeUndefined();
+    expect(result.accepted.claude.tokens).toBe(600);
+    expect(result.rejected).toEqual([
+      { client: "codex", incomingRevision: 1, storedRevision: 2 },
+    ]);
+  });
+
+  it("accepts the stored revision on a new day", () => {
+    const result = filterClientBreakdownsByRevisionFloor(
+      { codex: withRevision(makeClient(1_100, 14, 2), 2) },
+      storedRevisionFloors
+    );
+
+    expect(result.accepted.codex.tokens).toBe(1_100);
+    expect(result.accepted.codex.provenance?.schemaVersion).toBe(2);
+    expect(result.rejected).toEqual([]);
+  });
+});
+
+describe("authoritative client tombstones", () => {
+  const coverage = [{
+    client: "codex",
+    parserRevision: 2,
+    start: "2026-04-17",
+    end: "2026-07-12",
+  }];
+
+  it("removes a covered client that is missing from an existing incoming day", () => {
+    const result = applyAuthoritativeClientCoverage(
+      {
+        codex: withRevision(makeClient(14_000_000_000, 80, 2), 1),
+        claude: withRevision(makeClient(500, 5, 1), 1),
+      },
+      { claude: withRevision(makeClient(600, 6, 1), 1) },
+      "2026-07-12",
+      coverage
+    );
+
+    expect(result.mergeBase.codex).toBeUndefined();
+    expect(result.mergeBase.claude.tokens).toBe(500);
+    expect(result.tombstonedClients).toEqual(["codex"]);
+  });
+
+  it("removes a covered client when the whole incoming day is absent", () => {
+    const result = applyAuthoritativeClientCoverage(
+      { codex: withRevision(makeClient(14_000_000_000, 80, 2), 1) },
+      {},
+      "2026-07-11",
+      coverage
+    );
+
+    expect(result.mergeBase).toEqual({});
+    expect(result.tombstonedClients).toEqual(["codex"]);
+  });
+
+  it("does not remove data outside the replacement range", () => {
+    const existing = { codex: withRevision(makeClient(950, 12, 2), 1) };
+    const result = applyAuthoritativeClientCoverage(
+      existing,
+      {},
+      "2026-04-16",
+      coverage
+    );
+
+    expect(result.mergeBase).toEqual(existing);
+    expect(result.tombstonedClients).toEqual([]);
+  });
+
+  it("bypasses the regression guard for a covered client that is still present", () => {
+    const existing = { codex: withRevision(makeClient(14_000, 80, 2), 1) };
+    const incoming = { codex: withRevision(makeClient(950, 12, 2), 1) };
+    const coverageResult = applyAuthoritativeClientCoverage(
+      existing,
+      incoming,
+      "2026-07-12",
+      coverage
+    );
+    const mergeResult = mergeClientBreakdownsWithRegressionGuard(
+      coverageResult.mergeBase,
+      incoming,
+      new Set(["codex"])
+    );
+
+    expect(coverageResult.mergeBase).toEqual({});
+    expect(coverageResult.tombstonedClients).toEqual([]);
+    expect(mergeResult.merged.codex.tokens).toBe(950);
+    expect(mergeResult.warnings).toEqual([]);
   });
 });

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { db, apiTokens, submissions, submittedDevices, dailyBreakdown } from "@/lib/db";
-import { and, eq, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import {
   validateSubmission,
   generateSubmissionHash,
@@ -13,7 +13,10 @@ import {
   mergeClientBreakdownsWithRegressionGuard,
   recalculateDayTotals,
   clientContributionToBreakdownData,
-  deriveClientBreakdownProvenance,
+  aggregateIncomingClientBreakdowns,
+  deriveStoredClientRevisionFloors,
+  filterClientBreakdownsByRevisionFloor,
+  applyAuthoritativeClientCoverage,
   mergeTimestampMs,
   type ClientBreakdownData,
 } from "@/lib/db/helpers";
@@ -276,25 +279,24 @@ export async function POST(request: Request) {
       // ------------------------------------------
       // STEP 3b: Fetch existing daily breakdown for merge
       // ------------------------------------------
-      const fetchExistingDeviceDays = () =>
+      const fetchExistingSubmissionDays = () =>
         tx
           .select({
             id: dailyBreakdown.id,
+            submittedDeviceId: dailyBreakdown.submittedDeviceId,
             date: dailyBreakdown.date,
             timestampMs: dailyBreakdown.timestampMs,
             activeTimeMs: dailyBreakdown.activeTimeMs,
             sourceBreakdown: dailyBreakdown.sourceBreakdown,
           })
           .from(dailyBreakdown)
-          .where(
-            and(
-              eq(dailyBreakdown.submissionId, submissionId),
-              eq(dailyBreakdown.submittedDeviceId, submittedDevice.id)
-            )
-          )
+          .where(eq(dailyBreakdown.submissionId, submissionId))
           .for('update');
 
-      let existingDays = await fetchExistingDeviceDays();
+      let allExistingDays = await fetchExistingSubmissionDays();
+      let existingDays = allExistingDays.filter(
+        (day) => day.submittedDeviceId === submittedDevice.id
+      );
 
       if (
         existingDays.length === 0 &&
@@ -359,12 +361,32 @@ export async function POST(request: Request) {
           // re-adopt.
           console.warn("Legacy adoption conflict (concurrent submit), falling through:", adoptionErr);
         }
-        existingDays = await fetchExistingDeviceDays();
+        allExistingDays = await fetchExistingSubmissionDays();
+        existingDays = allExistingDays.filter(
+          (day) => day.submittedDeviceId === submittedDevice.id
+        );
       }
 
       const existingDaysMap = new Map(
         existingDays.map((d) => [d.date, d])
       );
+      const storedClientRevisionFloors = deriveStoredClientRevisionFloors(
+        allExistingDays.map((day) =>
+          (day.sourceBreakdown || {}) as Record<string, ClientBreakdownData>
+        )
+      );
+      const authoritativeCoverages = (data.clientManifest?.clients ?? [])
+        .filter(
+          (entry) =>
+            entry.coverage &&
+            entry.parserRevision >= (storedClientRevisionFloors.get(entry.client) ?? 1)
+        )
+        .map((entry) => ({
+          client: entry.client,
+          parserRevision: entry.parserRevision,
+          start: entry.coverage!.start,
+          end: entry.coverage!.end,
+        }));
 
       // ------------------------------------------
       // STEP 3c: Compute merge results in memory, then batch write
@@ -392,63 +414,69 @@ export async function POST(request: Request) {
         activeTimeMs: number | null;
         sourceBreakdown: Record<string, ClientBreakdownData>;
       }> = [];
+      const toDelete: string[] = [];
+      const incomingDates = new Set(data.contributions.map((day) => day.date));
 
       for (const incomingDay of data.contributions) {
-        const incomingClientBreakdown: Record<string, ClientBreakdownData> = {};
-        for (const client_contrib of incomingDay.clients) {
-          const modelData = clientContributionToBreakdownData(client_contrib);
-          const existing = incomingClientBreakdown[client_contrib.client];
-          if (existing) {
-            existing.tokens += modelData.tokens;
-            existing.cost += modelData.cost;
-            existing.input += modelData.input;
-            existing.output += modelData.output;
-            existing.cacheRead += modelData.cacheRead;
-            existing.cacheWrite += modelData.cacheWrite;
-            existing.reasoning = (existing.reasoning || 0) + modelData.reasoning;
-            existing.messages += modelData.messages;
-            const existingModel = existing.models[client_contrib.modelId];
-            if (existingModel) {
-              existingModel.tokens += modelData.tokens;
-              existingModel.cost += modelData.cost;
-              existingModel.input += modelData.input;
-              existingModel.output += modelData.output;
-              existingModel.cacheRead += modelData.cacheRead;
-              existingModel.cacheWrite += modelData.cacheWrite;
-              existingModel.reasoning = (existingModel.reasoning || 0) + modelData.reasoning;
-              existingModel.messages += modelData.messages;
-            } else {
-              existing.models[client_contrib.modelId] = modelData;
-            }
-            existing.provenance = deriveClientBreakdownProvenance(existing);
-          } else {
-            const clientBreakdown = {
-              ...modelData,
-              models: { [client_contrib.modelId]: modelData },
-            };
-            incomingClientBreakdown[client_contrib.client] = {
-              ...clientBreakdown,
-              provenance: deriveClientBreakdownProvenance(clientBreakdown),
-            };
-          }
-        }
+        const aggregatedIncomingClientBreakdown = aggregateIncomingClientBreakdowns(
+          incomingDay.clients.map((clientContribution) => ({
+            client: clientContribution.client,
+            modelId: clientContribution.modelId,
+            breakdown: clientContributionToBreakdownData(clientContribution),
+            provenance: clientContribution.provenance,
+          }))
+        );
+        const revisionFilter = filterClientBreakdownsByRevisionFloor(
+          aggregatedIncomingClientBreakdown,
+          storedClientRevisionFloors
+        );
+        const incomingClientBreakdown = revisionFilter.accepted;
+        const rejectedClients = new Set(
+          revisionFilter.rejected.map((rejected) => rejected.client)
+        );
+        warnings.push(
+          ...revisionFilter.rejected.map(
+            (rejected) =>
+              `Day ${incomingDay.date}: Ignored ${rejected.client} parser revision ${rejected.incomingRevision} because this account already stored revision ${rejected.storedRevision}.`
+          )
+        );
 
         const existingDay = existingDaysMap.get(incomingDay.date);
 
         if (existingDay) {
-          const existingClientBreakdown = (existingDay.sourceBreakdown || {}) as Record<
+          const storedClientBreakdown = (existingDay.sourceBreakdown || {}) as Record<
             string,
             ClientBreakdownData
           >;
-          const mergeResult = mergeClientBreakdownsWithRegressionGuard(
-            existingClientBreakdown,
+          const coverageResult = applyAuthoritativeClientCoverage(
+            storedClientBreakdown,
             incomingClientBreakdown,
-            submittedClients
+            incomingDay.date,
+            authoritativeCoverages
+          );
+          warnings.push(
+            ...coverageResult.tombstonedClients.map(
+              (client) =>
+                `Day ${incomingDay.date}: Removed stale ${client} data under authoritative replacement coverage.`
+            )
+          );
+          const mergeResult = mergeClientBreakdownsWithRegressionGuard(
+            coverageResult.mergeBase,
+            incomingClientBreakdown,
+            new Set(
+              Array.from(submittedClients).filter(
+                (client) => !rejectedClients.has(client)
+              )
+            )
           );
           warnings.push(
             ...mergeResult.warnings.map((warning) => `Day ${incomingDay.date}: ${warning}`)
           );
           const mergedClientBreakdown = mergeResult.merged;
+          if (Object.keys(mergedClientBreakdown).length === 0) {
+            toDelete.push(existingDay.id);
+            continue;
+          }
           const dayTotals = recalculateDayTotals(mergedClientBreakdown);
 
           toUpdate.push({
@@ -461,7 +489,7 @@ export async function POST(request: Request) {
             activeTimeMs: incomingDay.activeTimeMs ?? existingDay.activeTimeMs ?? null,
             sourceBreakdown: mergedClientBreakdown,
           });
-        } else {
+        } else if (Object.keys(incomingClientBreakdown).length > 0) {
           const dayTotals = recalculateDayTotals(incomingClientBreakdown);
 
           toInsert.push({
@@ -479,9 +507,50 @@ export async function POST(request: Request) {
         }
       }
 
+      for (const existingDay of existingDays) {
+        if (incomingDates.has(existingDay.date)) continue;
+        const storedClientBreakdown = (existingDay.sourceBreakdown || {}) as Record<
+          string,
+          ClientBreakdownData
+        >;
+        const coverageResult = applyAuthoritativeClientCoverage(
+          storedClientBreakdown,
+          {},
+          existingDay.date,
+          authoritativeCoverages
+        );
+        if (coverageResult.tombstonedClients.length === 0) continue;
+
+        warnings.push(
+          ...coverageResult.tombstonedClients.map(
+            (client) =>
+              `Day ${existingDay.date}: Removed stale ${client} data under authoritative replacement coverage.`
+          )
+        );
+        if (Object.keys(coverageResult.mergeBase).length === 0) {
+          toDelete.push(existingDay.id);
+          continue;
+        }
+        const dayTotals = recalculateDayTotals(coverageResult.mergeBase);
+        toUpdate.push({
+          id: existingDay.id,
+          tokens: dayTotals.tokens,
+          cost: dayTotals.cost.toFixed(4),
+          inputTokens: dayTotals.inputTokens,
+          outputTokens: dayTotals.outputTokens,
+          timestampMs: existingDay.timestampMs ?? null,
+          activeTimeMs: existingDay.activeTimeMs ?? null,
+          sourceBreakdown: coverageResult.mergeBase,
+        });
+      }
+
       // Batch INSERT new days
       if (toInsert.length > 0) {
         await tx.insert(dailyBreakdown).values(toInsert);
+      }
+
+      if (toDelete.length > 0) {
+        await tx.delete(dailyBreakdown).where(inArray(dailyBreakdown.id, toDelete));
       }
 
       // Batch UPDATE existing days via raw SQL VALUES list

--- a/packages/frontend/src/lib/db/helpers.ts
+++ b/packages/frontend/src/lib/db/helpers.ts
@@ -39,6 +39,36 @@ export interface MergeClientBreakdownsResult {
   warnings: string[];
 }
 
+export interface IncomingClientModelBreakdown {
+  client: string;
+  modelId: string;
+  breakdown: ModelBreakdownData;
+  provenance?: ClientBreakdownProvenanceData;
+}
+
+export interface RejectedClientRevision {
+  client: string;
+  incomingRevision: number;
+  storedRevision: number;
+}
+
+export interface FilterClientBreakdownsResult {
+  accepted: Record<string, ClientBreakdownData>;
+  rejected: RejectedClientRevision[];
+}
+
+export interface AuthoritativeClientCoverage {
+  client: string;
+  parserRevision: number;
+  start: string;
+  end: string;
+}
+
+export interface ApplyAuthoritativeClientCoverageResult {
+  mergeBase: Record<string, ClientBreakdownData>;
+  tombstonedClients: string[];
+}
+
 export interface DayTotals {
   tokens: number;
   cost: number;
@@ -112,6 +142,136 @@ function withDerivedProvenance(breakdown: ClientBreakdownData): ClientBreakdownD
   };
 }
 
+export function aggregateIncomingClientBreakdowns(
+  contributions: IncomingClientModelBreakdown[]
+): Record<string, ClientBreakdownData> {
+  const aggregated: Record<string, ClientBreakdownData> = {};
+
+  for (const contribution of contributions) {
+    const { client, modelId, breakdown, provenance } = contribution;
+    const existing = aggregated[client];
+
+    if (!existing) {
+      const clientBreakdown: ClientBreakdownData = {
+        ...breakdown,
+        models: { [modelId]: { ...breakdown } },
+        provenance: {
+          schemaVersion: Math.max(1, provenance?.schemaVersion ?? 1),
+          messageCount: Math.max(0, provenance?.messageCount ?? 0),
+          modelCount: Math.max(0, provenance?.modelCount ?? 0),
+        },
+      };
+      aggregated[client] = withDerivedProvenance(clientBreakdown);
+      continue;
+    }
+
+    existing.tokens += breakdown.tokens;
+    existing.cost += breakdown.cost;
+    existing.input += breakdown.input;
+    existing.output += breakdown.output;
+    existing.cacheRead += breakdown.cacheRead;
+    existing.cacheWrite += breakdown.cacheWrite;
+    existing.reasoning = (existing.reasoning || 0) + breakdown.reasoning;
+    existing.messages += breakdown.messages;
+
+    const existingModel = existing.models[modelId];
+    if (existingModel) {
+      existingModel.tokens += breakdown.tokens;
+      existingModel.cost += breakdown.cost;
+      existingModel.input += breakdown.input;
+      existingModel.output += breakdown.output;
+      existingModel.cacheRead += breakdown.cacheRead;
+      existingModel.cacheWrite += breakdown.cacheWrite;
+      existingModel.reasoning = (existingModel.reasoning || 0) + breakdown.reasoning;
+      existingModel.messages += breakdown.messages;
+    } else {
+      existing.models[modelId] = { ...breakdown };
+    }
+
+    existing.provenance = deriveClientBreakdownProvenance({
+      ...existing,
+      provenance: {
+        schemaVersion: Math.min(
+          existing.provenance?.schemaVersion ?? 1,
+          provenance?.schemaVersion ?? 1
+        ),
+        messageCount: Math.max(
+          existing.provenance?.messageCount ?? 0,
+          provenance?.messageCount ?? 0
+        ),
+        modelCount: Math.max(
+          existing.provenance?.modelCount ?? 0,
+          provenance?.modelCount ?? 0
+        ),
+      },
+    });
+  }
+
+  return aggregated;
+}
+
+export function deriveStoredClientRevisionFloors(
+  storedDays: Array<Record<string, ClientBreakdownData> | null | undefined>
+): Map<string, number> {
+  const floors = new Map<string, number>();
+
+  for (const storedDay of storedDays) {
+    for (const [client, breakdown] of Object.entries(storedDay ?? {})) {
+      const revision = deriveClientBreakdownProvenance(breakdown).schemaVersion;
+      floors.set(client, Math.max(floors.get(client) ?? 1, revision));
+    }
+  }
+
+  return floors;
+}
+
+export function filterClientBreakdownsByRevisionFloor(
+  incoming: Record<string, ClientBreakdownData>,
+  storedRevisionFloors: Map<string, number>
+): FilterClientBreakdownsResult {
+  const accepted: Record<string, ClientBreakdownData> = {};
+  const rejected: RejectedClientRevision[] = [];
+
+  for (const [client, breakdown] of Object.entries(incoming)) {
+    const normalized = withDerivedProvenance(breakdown);
+    const incomingRevision = normalized.provenance?.schemaVersion ?? 1;
+    const storedRevision = storedRevisionFloors.get(client) ?? 1;
+
+    if (incomingRevision < storedRevision) {
+      rejected.push({ client, incomingRevision, storedRevision });
+    } else {
+      accepted[client] = normalized;
+    }
+  }
+
+  return { accepted, rejected };
+}
+
+export function applyAuthoritativeClientCoverage(
+  existing: Record<string, ClientBreakdownData>,
+  incoming: Record<string, ClientBreakdownData>,
+  date: string,
+  coverages: AuthoritativeClientCoverage[]
+): ApplyAuthoritativeClientCoverageResult {
+  const mergeBase = { ...existing };
+  const tombstonedClients: string[] = [];
+
+  for (const coverage of coverages) {
+    if (
+      date >= coverage.start &&
+      date <= coverage.end &&
+      mergeBase[coverage.client]
+    ) {
+      delete mergeBase[coverage.client];
+      if (!incoming[coverage.client]) {
+        tombstonedClients.push(coverage.client);
+      }
+    }
+  }
+
+  return { mergeBase, tombstonedClients };
+}
+
 export function mergeClientBreakdowns(
   existing: Record<string, ClientBreakdownData> | null | undefined,
   incoming: Record<string, ClientBreakdownData>,
@@ -155,14 +315,30 @@ export function mergeClientBreakdownsWithRegressionGuard(
     }
 
     const nextClient = withDerivedProvenance(incomingClient);
-    if (existingClient && nextClient.tokens < existingClient.tokens) {
-      // A token decrease alone signals a parser regression (e.g. the CLI
-      // re-parsed only a subset of history). Preserve the existing row even
-      // when coverage metrics are equal, because equal coverage + fewer tokens
-      // still indicates data loss. The old AND-gate (tokens < existing AND lower
-      // coverage) let equal-coverage regressions slip through undetected.
-      merged[clientName] = withDerivedProvenance(existingClient);
-      const existingTokens = formatTokens(existingClient.tokens);
+    const existingWithProvenance = existingClient
+      ? withDerivedProvenance(existingClient)
+      : undefined;
+    const existingSchemaVersion = existingWithProvenance?.provenance?.schemaVersion ?? 1;
+    const incomingSchemaVersion = nextClient.provenance?.schemaVersion ?? 1;
+
+    if (existingWithProvenance && incomingSchemaVersion < existingSchemaVersion) {
+      merged[clientName] = existingWithProvenance;
+      warnings.push(
+        `Preserved ${clientName} because parser revision ${incomingSchemaVersion} is older than stored revision ${existingSchemaVersion}.`
+      );
+      continue;
+    }
+
+    if (
+      existingWithProvenance &&
+      incomingSchemaVersion === existingSchemaVersion &&
+      nextClient.tokens < existingWithProvenance.tokens
+    ) {
+      // Within one parser revision, a token decrease signals a regression
+      // (e.g. the CLI re-parsed only a subset of history). A newer revision is
+      // allowed to submit a deliberate lower correction before reaching here.
+      merged[clientName] = existingWithProvenance;
+      const existingTokens = formatTokens(existingWithProvenance.tokens);
       const nextTokens = formatTokens(nextClient.tokens);
       warnings.push(
         `Preserved ${clientName} because this same-device resubmit would reduce ${existingTokens} tokens to ${nextTokens}.`

--- a/packages/frontend/src/lib/validation/submission.ts
+++ b/packages/frontend/src/lib/validation/submission.ts
@@ -25,6 +25,8 @@ const COST_ABSOLUTE_TOLERANCE = 0.1;
 const LEGACY_COST_FLOAT_EPSILON = 1e-6;
 const TOKEN_RELATIVE_TOLERANCE = 0.01;
 const TOKEN_ABSOLUTE_TOLERANCE = 100;
+const MAX_SUPPORTED_CODEX_PROVENANCE_SCHEMA_VERSION = 2;
+const MAX_SUPPORTED_NON_CODEX_PROVENANCE_SCHEMA_VERSION = 1;
 
 const NonNegativeIntegerSchema = z.number().finite().int().min(0).max(Number.MAX_SAFE_INTEGER);
 const NonNegativeNumberSchema = z.number().finite().min(0);
@@ -38,7 +40,9 @@ const TokenBreakdownSchema = z.object({
 });
 
 const ClientContributionProvenanceSchema = z.object({
-  schemaVersion: NonNegativeIntegerSchema.min(1),
+  schemaVersion: NonNegativeIntegerSchema.min(1).max(
+    MAX_SUPPORTED_CODEX_PROVENANCE_SCHEMA_VERSION
+  ),
   messageCount: NonNegativeIntegerSchema,
   modelCount: NonNegativeIntegerSchema,
 });
@@ -57,6 +61,18 @@ const ClientContributionSchema = z.object({
   cost: NonNegativeNumberSchema,
   messages: NonNegativeIntegerSchema,
   provenance: ClientContributionProvenanceSchema.optional(),
+}).superRefine((contribution, ctx) => {
+  const maxRevision = contribution.client === "codex"
+    ? MAX_SUPPORTED_CODEX_PROVENANCE_SCHEMA_VERSION
+    : MAX_SUPPORTED_NON_CODEX_PROVENANCE_SCHEMA_VERSION;
+
+  if ((contribution.provenance?.schemaVersion ?? 1) > maxRevision) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["provenance", "schemaVersion"],
+      message: `${contribution.client} provenance schemaVersion must be at most ${maxRevision}`,
+    });
+  }
 });
 
 const DailyContributionSchema = z.object({
@@ -106,6 +122,46 @@ const ExportMetaSchema = z.object({
 const SubmitDeviceSchema = z.object({
   id: z.string().trim().min(1).max(96).regex(/^[A-Za-z0-9._:-]+$/),
   name: z.string().trim().min(1).max(120).optional(),
+});
+
+const ClientManifestCoverageSchema = z.object({
+  mode: z.literal("full"),
+  start: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  end: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  missingData: z.literal("tombstone"),
+}).superRefine((coverage, ctx) => {
+  if (coverage.start > coverage.end) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["end"],
+      message: "coverage end must be on or after start",
+    });
+  }
+});
+
+const ClientManifestEntrySchema = z.object({
+  client: SourceSchema,
+  parserRevision: NonNegativeIntegerSchema.min(1).max(
+    MAX_SUPPORTED_CODEX_PROVENANCE_SCHEMA_VERSION
+  ),
+  coverage: ClientManifestCoverageSchema.optional(),
+}).superRefine((entry, ctx) => {
+  const maxRevision = entry.client === "codex"
+    ? MAX_SUPPORTED_CODEX_PROVENANCE_SCHEMA_VERSION
+    : MAX_SUPPORTED_NON_CODEX_PROVENANCE_SCHEMA_VERSION;
+
+  if (entry.parserRevision > maxRevision) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["parserRevision"],
+      message: `${entry.client} parserRevision must be at most ${maxRevision}`,
+    });
+  }
+});
+
+const ClientManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  clients: z.array(ClientManifestEntrySchema).min(1),
 });
 
 const LEGACY_CLIENT_ALIASES: Record<string, string> = {
@@ -168,6 +224,21 @@ function normalizeLegacySources(data: unknown): unknown {
     });
   }
 
+  if (d.clientManifest && typeof d.clientManifest === "object") {
+    const clientManifest = { ...(d.clientManifest as Record<string, unknown>) };
+    if (Array.isArray(clientManifest.clients)) {
+      clientManifest.clients = (clientManifest.clients as Record<string, unknown>[]).map(
+        (entry) => {
+          if (entry && typeof entry === "object" && "client" in entry) {
+            return { ...entry, client: normalizeLegacyClientId(entry.client) };
+          }
+          return entry;
+        }
+      );
+    }
+    d.clientManifest = clientManifest;
+  }
+
   return d;
 }
 
@@ -178,14 +249,114 @@ const TimeMetricsSchema = z.object({
   sessionCount: z.number().int().min(0),
 });
 
-const SubmissionDataSchema = z.preprocess(normalizeLegacySources, z.object({
-  meta: ExportMetaSchema,
-  device: SubmitDeviceSchema.optional(),
-  summary: DataSummarySchema,
-  years: z.array(YearSummarySchema),
-  contributions: z.array(DailyContributionSchema),
-  timeMetrics: TimeMetricsSchema.optional(),
-}));
+const SubmissionDataSchema = z.preprocess(
+  normalizeLegacySources,
+  z.object({
+    meta: ExportMetaSchema,
+    device: SubmitDeviceSchema.optional(),
+    summary: DataSummarySchema,
+    years: z.array(YearSummarySchema),
+    contributions: z.array(DailyContributionSchema),
+    timeMetrics: TimeMetricsSchema.optional(),
+    clientManifest: ClientManifestSchema.optional(),
+  }).superRefine((submission, ctx) => {
+    const clientRevisions = new Map<string, number>();
+
+    submission.contributions.forEach((day, dayIndex) => {
+      day.clients.forEach((client, clientIndex) => {
+        const revision = client.provenance?.schemaVersion ?? 1;
+        const existingRevision = clientRevisions.get(client.client);
+
+        if (existingRevision == null) {
+          clientRevisions.set(client.client, revision);
+        } else if (existingRevision !== revision) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [
+              "contributions",
+              dayIndex,
+              "clients",
+              clientIndex,
+              "provenance",
+              "schemaVersion",
+            ],
+            message: `${client.client} provenance schemaVersion must be consistent across the submission`,
+          });
+        }
+      });
+    });
+
+    const manifestClients = new Map<string, number>();
+    if (submission.clientManifest) {
+      if (!submission.device) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["clientManifest"],
+          message: "clientManifest requires device metadata",
+        });
+      }
+
+      submission.clientManifest.clients.forEach((entry, manifestIndex) => {
+        if (manifestClients.has(entry.client)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["clientManifest", "clients", manifestIndex, "client"],
+            message: `clientManifest contains duplicate client ${entry.client}`,
+          });
+          return;
+        }
+        manifestClients.set(entry.client, entry.parserRevision);
+
+        const clientContributions = submission.contributions.flatMap((day, dayIndex) =>
+          day.clients
+            .filter((client) => client.client === entry.client)
+            .map((client) => ({ client, date: day.date, dayIndex }))
+        );
+
+        if (entry.coverage && clientContributions.length === 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["clientManifest", "clients", manifestIndex, "coverage"],
+            message: `full coverage for ${entry.client} requires at least one submitted contribution`,
+          });
+        }
+
+        for (const contribution of clientContributions) {
+          const revision = contribution.client.provenance?.schemaVersion ?? 1;
+          if (revision !== entry.parserRevision) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["clientManifest", "clients", manifestIndex, "parserRevision"],
+              message: `${entry.client} manifest revision must match contribution revision ${revision}`,
+            });
+            break;
+          }
+          if (
+            entry.coverage &&
+            (contribution.date < entry.coverage.start || contribution.date > entry.coverage.end)
+          ) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["clientManifest", "clients", manifestIndex, "coverage"],
+              message: `${entry.client} contribution ${contribution.date} is outside declared coverage`,
+            });
+            break;
+          }
+        }
+      });
+    }
+
+    for (const [client, revision] of clientRevisions) {
+      if (revision > 1 && manifestClients.get(client) !== revision) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["clientManifest", "clients"],
+          message: `${client} revision ${revision} requires a matching clientManifest entry`,
+        });
+      }
+    }
+  })
+);
 
 export type SubmissionData = z.infer<typeof SubmissionDataSchema>;
 


### PR DESCRIPTION
## What changed

- Add per-client parser provenance to submit payloads without changing `tokens graph` JSON.
- Mark the corrected Codex fork/subagent parser as revision 2 while keeping other clients at revision 1.
- Preserve the highest incoming revision when aggregating multi-model client rows.
- Allow a newer parser revision to replace an inflated stored value, while blocking older or same-revision regressions.
- Enforce a per-device, per-client revision floor across every stored day so an older uploader cannot pollute a new date.
- Treat mixed model revisions conservatively, reject unsupported future revisions, and cap revisions by client.
- Require one consistent revision for each client across every day and model in a submission.
- Compute revision floors across every device and the legacy bucket for the account.
- Add an explicit bounded `--replace` protocol so a corrected parser can remove stale client rows on missing-client or missing-day dates without affecting data outside the selected range.

## Root cause

Same-device resubmits intentionally reject lower token counts, so corrected Codex fork replay accounting could not replace values produced by the older parser. The route also discarded incoming provenance and re-derived every client as revision 1.

## Impact

A revision 2 Codex submission can repair previously inflated daily rows, including dates that should no longer contain Codex at all. Once the account stores revision 2, an older revision 1 uploader cannot overwrite existing rows or insert inflated Codex usage through another device or the legacy bucket.

## Verification

- Full frontend suite (461/461) and targeted submit/helper suite (90/90)
- Full Rust unit suite (658 passed, 1 ignored), integration suite (120/120), and targeted submit tests (8/8)
- `eslint` on all changed frontend source and test files
- `git diff --check origin/main...HEAD`
