### PR TITLE
feat(menubar): rebuild compact account history dashboard

### DIFF
--- a/packages/frontend/__tests__/api/usersProfile.test.ts
+++ b/packages/frontend/__tests__/api/usersProfile.test.ts
@@ -208,13 +208,15 @@ describe("GET /api/users/[username]", () => {
     mockState.pushExecuteResult([]);
 
     const response = await GET(
-      new Request("http://localhost:3000/api/users/imlunahey"),
+      new Request("http://localhost:3000/api/users/imlunahey?history=all"),
       { params: Promise.resolve({ username: "imlunahey" }) }
     );
     const sqlTexts = serializeSqlCalls();
 
     expect(response.status).toBe(308);
-    expect(response.headers.get("location")).toBe("http://localhost:3000/api/users/ImLunaHey");
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/api/users/ImLunaHey?history=all"
+    );
     expect(mockState.limitCalls[0]).toBe(2);
     expect(sqlTexts.some((text) =>
       text.toLowerCase().includes("lower(users.username) = imlunahey")
@@ -430,6 +432,68 @@ describe("GET /api/users/[username]", () => {
         percentage: 100,
       }),
     ]);
+    expect(mockState.gte).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns full daily history when history=all is requested", async () => {
+    mockState.pushSelectResult([
+      {
+        id: "user-1",
+        username: "alice",
+        displayName: "Alice",
+        avatarUrl: null,
+        createdAt: "2024-01-01T00:00:00.000Z",
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        totalTokens: 10,
+        totalCost: 0.1,
+        inputTokens: 10,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheCreationTokens: 0,
+        reasoningTokens: 0,
+        submissionCount: 1,
+        earliestDate: "2024-01-01",
+        latestDate: "2024-01-01",
+        totalActiveTimeMs: 0,
+        sessionCount: 0,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        sourcesUsed: ["codex"],
+        modelsUsed: ["gpt-5.5"],
+        updatedAt: new Date("2024-01-01T12:00:00.000Z"),
+        cliVersion: "2.0.0",
+        schemaVersion: 2,
+      },
+    ]);
+    mockState.pushSelectResult([
+      {
+        date: "2024-01-01",
+        timestampMs: 100,
+        tokens: 10,
+        cost: "0.1000",
+        inputTokens: 10,
+        outputTokens: 0,
+        sourceBreakdown: {},
+      },
+    ]);
+    mockState.pushExecuteResult([{ rank: 1 }]);
+
+    const response = await GET(
+      new Request("http://localhost:3000/api/users/alice?history=all"),
+      { params: Promise.resolve({ username: "alice" }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.contributions).toEqual([
+      expect.objectContaining({ date: "2024-01-01" }),
+    ]);
+    expect(mockState.gte).not.toHaveBeenCalled();
   });
 
   it("returns submission freshness metadata for the latest submission", async () => {

--- a/packages/frontend/src/app/api/users/[username]/route.ts
+++ b/packages/frontend/src/app/api/users/[username]/route.ts
@@ -23,6 +23,8 @@ interface RouteParams {
 export async function GET(_request: Request, { params }: RouteParams) {
   try {
     const { username } = await params;
+    const includeAllHistory =
+      new URL(_request.url).searchParams.get("history") === "all";
 
     // Find user
     const matchingUsers = await db
@@ -43,7 +45,9 @@ export async function GET(_request: Request, { params }: RouteParams) {
     }
 
     if (username !== user.username) {
-      return NextResponse.redirect(new URL(`/api/users/${user.username}`, _request.url), 308);
+      const canonicalUrl = new URL(_request.url);
+      canonicalUrl.pathname = `/api/users/${user.username}`;
+      return NextResponse.redirect(canonicalUrl, 308);
     }
 
     const oneYearAgo = new Date();
@@ -112,10 +116,12 @@ export async function GET(_request: Request, { params }: RouteParams) {
         .from(dailyBreakdown)
         .innerJoin(submissions, eq(dailyBreakdown.submissionId, submissions.id))
         .where(
-          and(
-            eq(submissions.userId, user.id),
-            gte(dailyBreakdown.date, oneYearAgo.toISOString().split("T")[0])
-          )
+          includeAllHistory
+            ? eq(submissions.userId, user.id)
+            : and(
+                eq(submissions.userId, user.id),
+                gte(dailyBreakdown.date, oneYearAgo.toISOString().split("T")[0])
+              )
         )
         .orderBy(dailyBreakdown.date),
     ]);

--- a/packages/menubar/Sources/TokscaleMenuBar/MenuBarModel.swift
+++ b/packages/menubar/Sources/TokscaleMenuBar/MenuBarModel.swift
@@ -11,12 +11,6 @@ final class MenuBarModel: ObservableObject {
     @Published var isRefreshing = false
     @Published private(set) var isBackgroundScanning = false
     @Published var refreshStatus: String?
-    // The MenuBarExtra(.window) content view stays alive while the panel is
-    // closed, so its repeat-forever animations would keep driving full-rate
-    // render passes forever (~13% CPU measured idle). Views gate their looping
-    // animations on this so a hidden panel costs nothing.
-    @Published private(set) var isPanelVisible = false
-
     private let store = TokscaleSummaryStore()
     private var refreshTimer: Timer?
     private var lastAutoRefresh = Date()
@@ -26,9 +20,32 @@ final class MenuBarModel: ObservableObject {
     // bumps both stamps.
     private var lastTodayScan = Date.distantPast
     private var lastHistoryScan = Date.distantPast
+    private var lastHistoryAttempt = Date.distantPast
+    private var lastQuotaOpenAttempt = Date.distantPast
+    private static let lastHistoryAttemptKey = "tokens.menubar.lastHistoryAttempt"
+    nonisolated private static let summaryMutations = SummaryMutationCoordinator()
 
     init() {
         reload()
+        if let restored = summary.flatMap({
+            BackgroundScanPolicy.restoredScanDates(
+                generatedAt: $0.generatedAt,
+                historyGeneratedAt: $0.health.historyGeneratedAt
+            )
+        }) {
+            lastTodayScan = restored.today
+            lastHistoryScan = restored.history
+        }
+        if let storedAttempt = UserDefaults.standard.object(
+            forKey: Self.lastHistoryAttemptKey
+        ) as? Date {
+            lastHistoryAttempt = storedAttempt
+        }
+        // Land on today's usage right away — don't wait for the first tick or for
+        // the panel to open. Cheap local-only scan, no quota API.
+        if summary != nil {
+            backgroundTodayScan()
+        }
         refreshTimer = Timer.scheduledTimer(withTimeInterval: 60, repeats: true) { [weak self] _ in
             Task { @MainActor in self?.tick() }
         }
@@ -37,24 +54,13 @@ final class MenuBarModel: ObservableObject {
         refreshTimer?.tolerance = 10
     }
 
-    func panelDidShow() {
-        isPanelVisible = true
-    }
-
-    func panelDidHide() {
-        isPanelVisible = false
-    }
-
     func reload() {
         do {
             let loaded = try store.load()
             // Skip the dashboard rebuild + badge re-render when the data version is
             // unchanged — the 60s tick reloads even when nothing was scanned, and
             // rebuilding the model + rendering the NSImage every minute is wasteful.
-            if let loaded, let current = summary, errorMessage == nil,
-                loaded.generatedAt == current.generatedAt,
-                loaded.health.quotaRefreshedAt == current.health.quotaRefreshedAt
-            {
+            if let loaded, let current = summary, errorMessage == nil, loaded == current {
                 return
             }
             summary = loaded
@@ -71,7 +77,28 @@ final class MenuBarModel: ObservableObject {
 
     private func tick() {
         reload()
-        let auto = AutoRefresh(storedValue: UserDefaults.standard.string(forKey: AutoRefresh.storageKey))
+        // Keep usage fresh without the panel ever opening: a cheap local today-only
+        // scan (~2s, no quota API) every ~10 min, plus a daily full history scan.
+        // These run regardless of the quota auto-refresh setting below, so today's
+        // figures never silently freeze on yesterday.
+        if !isRefreshing, !isBackgroundScanning {
+            let now = Date()
+            switch BackgroundScanPolicy.nextAction(
+                now: now,
+                lastHistorySuccess: lastHistoryScan,
+                lastHistoryAttempt: lastHistoryAttempt,
+                lastTodayScan: lastTodayScan
+            ) {
+            case .full:
+                backgroundHistoryRefresh()
+            case .today:
+                backgroundTodayScan()
+            case .none:
+                break
+            }
+        }
+        let auto = AutoRefresh(
+            storedValue: UserDefaults.standard.string(forKey: AutoRefresh.storageKey))
         guard !isRefreshing, let interval = auto.interval else {
             return
         }
@@ -83,13 +110,16 @@ final class MenuBarModel: ObservableObject {
     }
 
     func refreshScan() {
-        let summaryPath = store.summaryURL.path
-        runRefresh(status: "Scanning all AI sessions...") {
-            MenuBarModel.runFullScan(summaryPath: summaryPath)
-        }
+        refreshStatus =
+            summary == nil
+            ? "Building local history cache..."
+            : "Syncing compact history..."
+        backgroundHistoryRefresh()
     }
 
-    func refreshQuota(status: String = "Refreshing live quota...", completion: (@MainActor () -> Void)? = nil) {
+    func refreshQuota(
+        status: String = "Refreshing live quota...", completion: (@MainActor () -> Void)? = nil
+    ) {
         let summaryURL = store.summaryURL
         runRefresh(status: status, completion: completion) {
             MenuBarModel.runQuotaRefresh(summaryURL: summaryURL)
@@ -102,13 +132,19 @@ final class MenuBarModel: ObservableObject {
     private func backgroundFullScan() {
         guard !isBackgroundScanning else { return }
         isBackgroundScanning = true
+        recordHistoryAttempt()
         let summaryPath = store.summaryURL.path
         DispatchQueue.global(qos: .background).async { [weak self] in
-            _ = MenuBarModel.runFullScan(summaryPath: summaryPath)
+            let result = MenuBarModel.runFullScan(summaryPath: summaryPath)
             Task { @MainActor in
                 guard let self else { return }
                 self.isBackgroundScanning = false
+                guard result.succeeded else {
+                    self.refreshStatus = result.message
+                    return
+                }
                 self.lastHistoryScan = Date()
+                self.refreshStatus = "Local history refreshed."
                 // The merged history scan owns all-time/history, but its per-client
                 // today work time can be noisy (cross-machine duplicates / stray
                 // timestamps). Chain a local today-only scan to fill in accurate
@@ -119,6 +155,50 @@ final class MenuBarModel: ObservableObject {
         }
     }
 
+    private func backgroundHistoryRefresh() {
+        if summary == nil {
+            backgroundFullScan()
+        } else {
+            backgroundRemoteHistorySync()
+        }
+    }
+
+    private func backgroundRemoteHistorySync() {
+        guard !isBackgroundScanning else { return }
+        isBackgroundScanning = true
+        recordHistoryAttempt()
+        let summaryURL = store.summaryURL
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            let result = MenuBarModel.runRemoteHistorySync(summaryURL: summaryURL)
+            Task { @MainActor in
+                guard let self else { return }
+                self.isBackgroundScanning = false
+                if result.succeeded {
+                    self.lastHistoryScan = Date()
+                    self.refreshStatus = "History refreshed."
+                } else {
+                    self.refreshStatus = result.message
+                }
+                switch BackgroundScanPolicy.actionAfterRemoteHistorySync(
+                    succeeded: result.succeeded
+                ) {
+                case .full:
+                    self.backgroundFullScan()
+                case .today:
+                    self.backgroundTodayScan()
+                case .none:
+                    break
+                }
+            }
+        }
+    }
+
+    private func recordHistoryAttempt() {
+        let now = Date()
+        lastHistoryAttempt = now
+        UserDefaults.standard.set(now, forKey: Self.lastHistoryAttemptKey)
+    }
+
     // Cheap today-only rescan: re-reads just today's files (~2s) and patches the
     // today figures + work time over the existing summary, leaving history alone.
     private func backgroundTodayScan() {
@@ -126,11 +206,15 @@ final class MenuBarModel: ObservableObject {
         isBackgroundScanning = true
         let summaryURL = store.summaryURL
         DispatchQueue.global(qos: .background).async { [weak self] in
-            _ = MenuBarModel.runTodayScan(summaryURL: summaryURL)
+            let result = MenuBarModel.runTodayScan(summaryURL: summaryURL)
             Task { @MainActor in
                 guard let self else { return }
                 self.isBackgroundScanning = false
-                self.lastTodayScan = Date()
+                if result.succeeded {
+                    self.lastTodayScan = Date()
+                } else {
+                    self.refreshStatus = result.message
+                }
                 self.reload()
             }
         }
@@ -140,7 +224,7 @@ final class MenuBarModel: ObservableObject {
         // No cache yet: do the first full scan in the background so the popover stays
         // responsive while it runs.
         if summary == nil {
-            backgroundFullScan()
+            backgroundHistoryRefresh()
             return
         }
         // First page wins: always refresh live quota right away (fast, local), even
@@ -152,20 +236,39 @@ final class MenuBarModel: ObservableObject {
         let cadence = RefreshCadence(
             storedValue: UserDefaults.standard.string(forKey: RefreshCadence.storageKey)
         )
-        // First page wins: quota refreshes immediately on every open (fast, local),
-        // even while a scan runs. Then pick the cheapest scan that's due: a daily
-        // full history scan, otherwise a throttled today-only scan (~2s). With
-        // "Refresh on open = Off" only quota refreshes, never a background scan.
-        refreshQuota { [weak self] in
+        let refreshUsageIfNeeded: @MainActor () -> Void = { [weak self] in
             guard let self, cadence.minimumInterval != nil, !self.isBackgroundScanning else {
                 return
             }
             let now = Date()
-            if now.timeIntervalSince(self.lastHistoryScan) > 86_400 {
-                self.backgroundFullScan()
-            } else if now.timeIntervalSince(self.lastTodayScan) > 600 {
+            switch BackgroundScanPolicy.nextAction(
+                now: now,
+                lastHistorySuccess: self.lastHistoryScan,
+                lastHistoryAttempt: self.lastHistoryAttempt,
+                lastTodayScan: self.lastTodayScan
+            ) {
+            case .full:
+                self.backgroundHistoryRefresh()
+            case .today:
                 self.backgroundTodayScan()
+            case .none:
+                break
             }
+        }
+        let now = Date()
+        if BackgroundScanPolicy.shouldRefreshQuotaOnOpen(
+            needsRefresh: summary?.needsRefreshOnOpen(
+                now: now,
+                minimumInterval: BackgroundScanPolicy.quotaOpenRefreshInterval
+            ) == true,
+            isRefreshing: isRefreshing,
+            now: now,
+            lastAttempt: lastQuotaOpenAttempt
+        ) {
+            lastQuotaOpenAttempt = now
+            refreshQuota(completion: refreshUsageIfNeeded)
+        } else {
+            refreshUsageIfNeeded()
         }
     }
 
@@ -211,19 +314,31 @@ final class MenuBarModel: ObservableObject {
 
     /// Full scan: `tokens graph --subagents` for usage/history/subagents, `tokens
     /// usage` for live quota, adapted into the companion summary the store reads.
-    nonisolated private static func runFullScan(summaryPath: String) -> String {
+    nonisolated private static func runFullScan(summaryPath: String) -> FullScanResult {
         guard let binary = tokensBinaryURL() else {
-            return "Refresh failed: tokens command unavailable"
+            return .failure("Refresh failed: tokens command unavailable")
         }
         let started = Date()
-        let (graphExec, graphArgs) = graphCommand(binary: binary)
-        let graph = runCapturing(
-            executableURL: graphExec,
-            arguments: graphArgs,
-            timeout: 300
-        )
-        guard graph.ok, let graphData = graph.data, !graphData.isEmpty else {
-            return "Refresh failed: \(graph.message ?? "graph scan")"
+        var graphData: Data?
+        var graphFailure = "graph scan"
+        for command in graphCommands(binary: binary) {
+            let graph = runCapturing(
+                executableURL: command.executableURL,
+                arguments: command.arguments,
+                timeout: 300
+            )
+            if graph.ok, let data = graph.data, !data.isEmpty,
+                GraphCompanionAdapter.isValidGraphData(data)
+            {
+                graphData = data
+                break
+            }
+            graphFailure = graph.ok
+                ? "invalid graph output"
+                : graph.message ?? "graph scan"
+        }
+        guard let graphData else {
+            return .failure("Refresh failed: \(graphFailure)")
         }
         let usage = runCapturing(
             executableURL: binary,
@@ -242,23 +357,86 @@ final class MenuBarModel: ObservableObject {
                 lastScanDurationMs: scanMs,
                 quotaRefreshedAt: usageData != nil ? nowISO : nil
             )
-            try writeAtomic(companion, to: URL(fileURLWithPath: summaryPath))
-            return "Refresh finished."
+            return summaryMutations.replace(
+                summaryURL: URL(fileURLWithPath: summaryPath),
+                with: companion
+            ) ? .success : .failure("Refresh failed: summary write")
         } catch {
-            return "Refresh failed: \(error)"
+            return .failure("Refresh failed: \(error)")
         }
+    }
+
+    nonisolated private static func runRemoteHistorySync(summaryURL: URL) -> FullScanResult {
+        guard let binary = tokensBinaryURL() else {
+            return .failure("History sync failed: tokens command unavailable")
+        }
+        let started = Date()
+        let status = runCapturing(
+            executableURL: binary,
+            arguments: ["status", "--json"],
+            timeout: 15
+        )
+        guard status.ok, let statusData = status.data,
+            let statusJSON = (try? JSONSerialization.jsonObject(with: statusData))
+                as? [String: Any],
+            let apiURLString = statusJSON["apiUrl"] as? String,
+            let auth = statusJSON["auth"] as? [String: Any],
+            let username = auth["username"] as? String,
+            !username.isEmpty,
+            var profileURL = URL(string: apiURLString),
+            profileURL.scheme == "https" || profileURL.scheme == "http"
+        else {
+            return .failure("History sync unavailable: tokens.ci login not found")
+        }
+        if !profileURL.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            .hasSuffix("api")
+        {
+            profileURL.appendPathComponent("api")
+        }
+        profileURL.appendPathComponent("users")
+        profileURL.appendPathComponent(username)
+        guard var profileComponents = URLComponents(
+            url: profileURL,
+            resolvingAgainstBaseURL: false
+        ) else {
+            return .failure("History sync failed: invalid profile URL")
+        }
+        var queryItems = profileComponents.queryItems ?? []
+        queryItems.removeAll { $0.name == "history" }
+        queryItems.append(URLQueryItem(name: "history", value: "all"))
+        profileComponents.queryItems = queryItems
+        guard let fullHistoryURL = profileComponents.url else {
+            return .failure("History sync failed: invalid profile URL")
+        }
+
+        let fetch = fetch(fullHistoryURL, timeout: 30)
+        guard fetch.ok, let profileData = fetch.data, !profileData.isEmpty else {
+            return .failure("History sync failed; kept local cache")
+        }
+        let elapsedMs = Int(Date().timeIntervalSince(started) * 1000)
+        let syncedAt = ISO8601DateFormatter().string(from: Date())
+        let wrote = summaryMutations.mutate(summaryURL: summaryURL) { latest in
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: latest,
+                profileData: profileData,
+                todayDate: localDateString(),
+                syncedAt: syncedAt,
+                lastScanDurationMs: elapsedMs
+            )
+        }
+        guard wrote else {
+            return .failure("Remote history rejected; kept corrected local cache")
+        }
+        return .success
     }
 
     /// Cheap today-only refresh: rescan just today's files (`graph --today-only`,
     /// ~2s) and patch today's spend + work time over the existing summary, leaving
     /// the slow-to-scan history untouched. Stays on the local binary (today's data
     /// is all local), so it skips the merged-home wrapper the full scan uses.
-    nonisolated private static func runTodayScan(summaryURL: URL) -> String {
+    nonisolated private static func runTodayScan(summaryURL: URL) -> FullScanResult {
         guard let binary = tokensBinaryURL() else {
-            return "Refresh failed: tokens command unavailable"
-        }
-        guard let existing = try? Data(contentsOf: summaryURL), !existing.isEmpty else {
-            return "Today refresh skipped: no summary yet"
+            return .failure("Refresh failed: tokens command unavailable")
         }
         let graph = runCapturing(
             executableURL: binary,
@@ -266,23 +444,16 @@ final class MenuBarModel: ObservableObject {
             timeout: 60
         )
         guard graph.ok, let graphData = graph.data, !graphData.isEmpty else {
-            return "Today refresh failed: \(graph.message ?? "graph scan")"
+            return .failure("Today refresh failed: \(graph.message ?? "graph scan")")
         }
-        guard
-            let patched = GraphCompanionAdapter.patchTodayData(
-                companionData: existing,
+        let wrote = summaryMutations.mutate(summaryURL: summaryURL) { latest in
+            GraphCompanionAdapter.patchTodayData(
+                companionData: latest,
                 todayGraphData: graphData,
                 todayDate: localDateString()
             )
-        else {
-            return "Today refresh failed: patch"
         }
-        do {
-            try writeAtomic(patched, to: summaryURL)
-            return "Refresh finished."
-        } catch {
-            return "Today refresh failed: \(error)"
-        }
+        return wrote ? .success : .failure("Today refresh failed: patch or write")
     }
 
     /// Quota-only refresh: run `tokens usage` and patch the existing summary. Keeps
@@ -291,10 +462,6 @@ final class MenuBarModel: ObservableObject {
     nonisolated private static func runQuotaRefresh(summaryURL: URL) -> String {
         guard let binary = tokensBinaryURL() else {
             return "Refresh failed: tokens command unavailable"
-        }
-        guard let existing = try? Data(contentsOf: summaryURL) else {
-            // No summary yet — a quota-only refresh has nothing to patch.
-            return "Refresh skipped: no summary yet"
         }
         let usage = runCapturing(
             executableURL: binary,
@@ -305,25 +472,14 @@ final class MenuBarModel: ObservableObject {
             return "Quota unavailable (kept previous)."
         }
         let nowISO = ISO8601DateFormatter().string(from: Date())
-        guard let patched = GraphCompanionAdapter.patchedQuota(
-            companionData: existing,
-            usageData: usageData,
-            quotaRefreshedAt: nowISO
-        ) else {
-            return "Quota unavailable (kept previous)."
+        let wrote = summaryMutations.mutate(summaryURL: summaryURL) { latest in
+            GraphCompanionAdapter.patchedQuota(
+                companionData: latest,
+                usageData: usageData,
+                quotaRefreshedAt: nowISO
+            )
         }
-        do {
-            try writeAtomic(patched, to: summaryURL)
-            return "Refresh finished."
-        } catch {
-            return "Refresh failed: \(error)"
-        }
-    }
-
-    nonisolated private static func writeAtomic(_ data: Data, to url: URL) throws {
-        let tmp = url.appendingPathExtension("tmp")
-        try data.write(to: tmp, options: .atomic)
-        _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+        return wrote ? "Refresh finished." : "Quota unavailable (kept previous)."
     }
 
     nonisolated private static func localDateString() -> String {
@@ -338,13 +494,31 @@ final class MenuBarModel: ObservableObject {
     /// installed (it folds in cross-machine history and scans the merged home),
     /// otherwise a plain local `graph --subagents`. Either way the output is the same
     /// graph JSON the adapter consumes, so the app stays portable without the wrapper.
-    nonisolated private static func graphCommand(binary: URL) -> (URL, [String]) {
-        let wrapper = FileManager.default.homeDirectoryForCurrentUser
+    nonisolated private static func graphCommands(binary: URL) -> [GraphCommand] {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        let wrapper =
+            home
             .appendingPathComponent(".local/bin/tokens-graph-merged", isDirectory: false)
-        if FileManager.default.isExecutableFile(atPath: wrapper.path) {
-            return (wrapper, [])
+        let mergedHome = home.appendingPathComponent(".cache/tokscale-merged", isDirectory: true)
+        var mergedHomeIsDirectory: ObjCBool = false
+        let canUseMergedWrapper =
+            FileManager.default.isExecutableFile(atPath: wrapper.path)
+            && FileManager.default.fileExists(
+                atPath: mergedHome.path,
+                isDirectory: &mergedHomeIsDirectory
+            )
+            && mergedHomeIsDirectory.boolValue
+        var commands: [GraphCommand] = []
+        if canUseMergedWrapper {
+            commands.append(GraphCommand(executableURL: wrapper, arguments: []))
         }
-        return (binary, ["graph", "--subagents", "--work-time", "--no-spinner"])
+        commands.append(
+            GraphCommand(
+                executableURL: binary,
+                arguments: ["graph", "--subagents", "--work-time", "--no-spinner"]
+            )
+        )
+        return commands
     }
 
     nonisolated private static func tokensBinaryURL() -> URL? {
@@ -415,10 +589,56 @@ final class MenuBarModel: ObservableObject {
         }
         return (box.data, true, nil)
     }
+
+    nonisolated private static func fetch(
+        _ url: URL,
+        timeout: TimeInterval
+    ) -> (data: Data?, ok: Bool) {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = timeout
+        request.cachePolicy = .reloadRevalidatingCacheData
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let finished = DispatchSemaphore(value: 0)
+        let box = NetworkBox()
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            box.data = data
+            box.statusCode = (response as? HTTPURLResponse)?.statusCode
+            box.failed = error != nil
+            finished.signal()
+        }
+        task.resume()
+        if finished.wait(timeout: .now() + timeout + 1) == .timedOut {
+            task.cancel()
+            return (nil, false)
+        }
+        return (box.data, !box.failed && box.statusCode == 200)
+    }
 }
 
 /// Reference box so the background read closure can hand the captured bytes back
 /// without a captured `var` data race.
 private final class DataBox: @unchecked Sendable {
     var data = Data()
+}
+
+private final class NetworkBox: @unchecked Sendable {
+    var data: Data?
+    var statusCode: Int?
+    var failed = false
+}
+
+private struct GraphCommand: Sendable {
+    let executableURL: URL
+    let arguments: [String]
+}
+
+private struct FullScanResult: Sendable {
+    let message: String
+    let succeeded: Bool
+
+    static let success = FullScanResult(message: "Refresh finished.", succeeded: true)
+
+    static func failure(_ message: String) -> FullScanResult {
+        FullScanResult(message: message, succeeded: false)
+    }
 }

--- a/packages/menubar/Sources/TokscaleMenuBar/TokensMenuBarApp.swift
+++ b/packages/menubar/Sources/TokscaleMenuBar/TokensMenuBarApp.swift
@@ -5,12 +5,15 @@ import SwiftUI
 struct TokensMenuBarApp: App {
     @StateObject private var model = MenuBarModel()
 
+    init() {
+        // Menu-bar-only app: keep the status item, stay out of the Dock.
+        NSApplication.shared.setActivationPolicy(.accessory)
+    }
+
     var body: some Scene {
         MenuBarExtra {
             TokensPopoverView(model: model)
-                .environment(\.panelVisible, model.isPanelVisible)
                 .onAppear {
-                    model.panelDidShow()
                     model.refreshOnOpenIfNeeded()
                 }
                 // onAppear only fires once for a MenuBarExtra(.window) — the content
@@ -20,36 +23,7 @@ struct TokensMenuBarApp: App {
                 .onReceive(
                     NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)
                 ) { _ in
-                    model.panelDidShow()
                     model.refreshOnOpenIfNeeded()
-                }
-                // Pause the looping animations whenever the panel goes away —
-                // resign-key fires when the popover closes from clicking
-                // elsewhere, will-close when it's dismissed outright.
-                .onReceive(
-                    NotificationCenter.default.publisher(for: NSWindow.didResignKeyNotification)
-                ) { _ in
-                    model.panelDidHide()
-                }
-                .onReceive(
-                    NotificationCenter.default.publisher(for: NSWindow.willCloseNotification)
-                ) { _ in
-                    model.panelDidHide()
-                }
-                // Key/close don't cover every dismissal path (toggling via the
-                // status item orders the panel out without closing it), but
-                // ordering in/out always flips occlusion. The status item's own
-                // window stays visible forever, so it never emits this.
-                .onReceive(
-                    NotificationCenter.default.publisher(
-                        for: NSWindow.didChangeOcclusionStateNotification)
-                ) { note in
-                    guard let window = note.object as? NSWindow else { return }
-                    if window.occlusionState.contains(.visible) {
-                        model.panelDidShow()
-                    } else {
-                        model.panelDidHide()
-                    }
                 }
         } label: {
             MenuBarLabelView(image: model.menuBarImage)

--- a/packages/menubar/Sources/TokscaleMenuBar/TokensPopoverView.swift
+++ b/packages/menubar/Sources/TokscaleMenuBar/TokensPopoverView.swift
@@ -2,22 +2,6 @@ import Foundation
 import SwiftUI
 import TokscaleMenuBarCore
 
-// Whether the menu bar panel is currently on screen. The content view outlives
-// the panel (MenuBarExtra(.window) keeps it alive across open/close), so
-// repeat-forever animations must stop while this is false or they keep burning
-// CPU at full frame rate with the panel closed. Defaults to true so previews
-// and tests behave as before.
-private struct PanelVisibleKey: EnvironmentKey {
-    static let defaultValue = true
-}
-
-extension EnvironmentValues {
-    var panelVisible: Bool {
-        get { self[PanelVisibleKey.self] }
-        set { self[PanelVisibleKey.self] = newValue }
-    }
-}
-
 struct TokensPopoverView: View {
     @ObservedObject var model: MenuBarModel
     // Observed so changing the theme re-renders the whole popover and the accent
@@ -44,15 +28,15 @@ struct TokensPopoverView: View {
                     EmptyContent(errorMessage: errorMessage)
                 }
             }
-            .padding(.horizontal, 16)
-            .padding(.top, 18)
-            .padding(.bottom, 14)
+            .padding(.horizontal, 14)
+            .padding(.top, 14)
+            .padding(.bottom, 12)
         }
-        .frame(width: 560, height: 920, alignment: .top)
-        .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+        .frame(width: 488, height: 720, alignment: .top)
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
-            RoundedRectangle(cornerRadius: 26, style: .continuous)
-                .stroke(companionOrange.opacity(0.28), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(companionBorderColor, lineWidth: 1)
         )
         .background {
             Button("Refresh") { model.refreshScan() }
@@ -169,7 +153,7 @@ private struct SummaryContent: View {
             }
 
             ScrollView(.vertical, showsIndicators: false) {
-                VStack(spacing: 8) {
+                LazyVStack(spacing: 8) {
                     if layout == .paged {
                         if page == 0 {
                             glanceSection
@@ -214,7 +198,7 @@ private struct SummaryContent: View {
             SubagentCard(subagents: subagents)
         }
 
-        ContributionHeatmap(days: summary.contribution)
+        ContributionHeatmap(days: summary.contribution, endDate: summary.today.date)
 
         Text("Dollar amounts are API-equivalent value, not subscription spend.")
             .font(.system(size: 9, weight: .medium))
@@ -241,11 +225,11 @@ private struct CompanionHeader: View {
     let onToggleSettings: () -> Void
 
     var body: some View {
-        HStack(spacing: 10) {
+        HStack(spacing: 9) {
             LiveDot(stale: summary.stale, active: isRefreshing)
             VStack(alignment: .leading, spacing: 1) {
                 Text("Tokens")
-                    .font(.system(size: 14, weight: .bold, design: .rounded))
+                    .font(.system(size: 14, weight: .semibold))
                 Text(headerSubtitle)
                     .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(.secondary)
@@ -275,7 +259,7 @@ private struct CompanionHeader: View {
                 )
             }
         }
-        .frame(height: 32)
+        .frame(height: 30)
     }
 
     private var headerSubtitle: String {
@@ -292,65 +276,89 @@ private struct TodayGlanceCard: View {
     let summary: TokscaleSummary
     let color: Color
 
-    private var days: Int { summary.totals.activeDays }
+    private var usesRollingBreakdown: Bool {
+        summary.accuracy.sourceKinds.contains("tokens-ci-rolling-breakdown")
+    }
+
+    private var days: Int {
+        usesRollingBreakdown
+            ? summary.history.filter { $0.tokens > 0 }.count
+            : summary.totals.activeDays
+    }
+
+    private var costTotal: Double {
+        usesRollingBreakdown
+            ? summary.history.reduce(0) { $0 + $1.costUsd }
+            : summary.totals.costUsd
+    }
+
+    private var tokenTotal: Double {
+        usesRollingBreakdown
+            ? summary.history.reduce(0) { $0 + Double($1.tokens) }
+            : Double(summary.totals.tokens)
+    }
+
+    private var averageLabel: String {
+        usesRollingBreakdown ? "last-year avg" : "account avg"
+    }
 
     var body: some View {
-        HStack(spacing: 14) {
+        HStack(spacing: 12) {
             stat(
                 value: formatUSD(summary.today.costUsd),
-                label: "Cost today",
+                label: "Local today cost",
                 tint: color,
-                momentum: momentum(today: summary.today.costUsd, total: summary.totals.costUsd)
+                momentum: momentum(today: summary.today.costUsd, total: costTotal)
             )
             Rectangle()
                 .fill(Color.primary.opacity(0.08))
-                .frame(width: 1, height: 56)
+                .frame(width: 1, height: 44)
             stat(
                 value: formatTokens(summary.today.tokens),
-                label: "Tokens today",
-                tint: providerColor("gemini"),
-                momentum: momentum(today: Double(summary.today.tokens), total: Double(summary.totals.tokens))
+                label: "Local today tokens",
+                tint: Color.primary,
+                momentum: momentum(today: Double(summary.today.tokens), total: tokenTotal)
             )
         }
-        .padding(16)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
         .frame(maxWidth: .infinity)
         .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(companionWarmGlassColor)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(color.opacity(0.20), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(companionBorderColor, lineWidth: 1)
         )
     }
 
-    // Today against the all-time daily average — a real reference so a single
-    // day's number isn't read in a vacuum. >=1x is a high-output day (highlighted).
+    // Local today against the matching account-history scope. >=1x is highlighted.
     private func momentum(today: Double, total: Double) -> (text: String, high: Bool)? {
         guard days > 0, total > 0, today > 0 else { return nil }
         let average = total / Double(days)
         guard average > 0 else { return nil }
         let ratio = today / average
         if ratio >= 1 {
-            return (String(format: "↑ %.1f× avg", ratio), true)
+            return (String(format: "↑ %.1f× %@", ratio, averageLabel), true)
         }
-        return (String(format: "%.0f%% of avg", ratio * 100), false)
+        return (String(format: "%.0f%% of %@", ratio * 100, averageLabel), false)
     }
 
     private func stat(value: String, label: String, tint: Color, momentum: (text: String, high: Bool)?) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             Text(value)
-                .font(.system(size: 30, weight: .heavy, design: .rounded))
+                .font(.system(size: 24, weight: .semibold, design: .rounded))
                 .monospacedDigit()
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
                 .foregroundStyle(tint)
             Text(label.uppercased())
-                .font(.system(size: 10, weight: .bold))
+                .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(.secondary)
             if let momentum {
                 Text(momentum.text)
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(momentum.high ? Color.green : Color.secondary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
@@ -368,30 +376,30 @@ private struct PageTabSwitcher: View {
     private let tabs = ["Glance", "History"]
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 3) {
             ForEach(Array(tabs.enumerated()), id: \.offset) { index, title in
                 Button(action: { onSelect(index) }) {
                     Text(title)
-                        .font(.system(size: 12, weight: .bold))
+                        .font(.system(size: 11, weight: .semibold))
                         .frame(maxWidth: .infinity)
-                        .frame(height: 30)
+                        .frame(height: 27)
                         .foregroundStyle(index == page ? Color.primary : Color.secondary)
                         .background(
-                            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                                .fill(index == page ? color.opacity(0.16) : Color.clear)
+                            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                .fill(index == page ? companionSelectedSurfaceColor : Color.clear)
                         )
                         .overlay(
-                            RoundedRectangle(cornerRadius: 9, style: .continuous)
-                                .stroke(index == page ? color.opacity(0.32) : Color.clear, lineWidth: 1)
+                            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                .stroke(index == page ? companionBorderStrongColor : Color.clear, lineWidth: 1)
                         )
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
             }
         }
-        .padding(4)
+        .padding(3)
         .background(
-            RoundedRectangle(cornerRadius: 12, style: .continuous)
+            RoundedRectangle(cornerRadius: 9, style: .continuous)
                 .fill(companionWarmGlassColor)
         )
     }
@@ -404,8 +412,8 @@ private struct QuotaBoardSection: View {
     var prominent: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            VStack(spacing: 9) {
+        VStack(alignment: .leading, spacing: 8) {
+            VStack(spacing: 7) {
                 if model.quotaBoardProviders.isEmpty {
                     CompactEmptyMessage(
                         title: "No live quota",
@@ -423,16 +431,15 @@ private struct QuotaBoardSection: View {
                 }
             }
         }
-        .padding(15)
+        .padding(10)
         .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(companionGlassPanelColor)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(companionOrange.opacity(0.18), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(companionBorderColor, lineWidth: 1)
         )
-        .shadow(color: companionOrange.opacity(0.09), radius: 18, x: 0, y: 8)
     }
 }
 
@@ -485,7 +492,7 @@ private struct ProviderQuotaRow: View {
                         .lineLimit(1)
                     Spacer(minLength: 0)
                 }
-                Text(focus.today)
+                Text("LOCAL TODAY · \(focus.today)")
                     .font(.system(size: 9, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -499,7 +506,7 @@ private struct ProviderQuotaRow: View {
             }
             .frame(width: 116, alignment: .leading)
 
-            VStack(spacing: 8) {
+            VStack(spacing: 7) {
                 if focus.quotaWindows.isEmpty {
                     QuotaUnavailableLine(providerColor: color)
                 } else {
@@ -629,18 +636,15 @@ private struct ProviderGlanceCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 14) {
+        VStack(alignment: .leading, spacing: 9) {
             HStack(spacing: 8) {
                 ProviderDot(color: color)
                 Text(focus.title)
-                    .font(.system(size: 16, weight: .bold))
+                    .font(.system(size: 13, weight: .semibold))
                     .lineLimit(1)
-                // This provider's own spend today, right next to its name — same
-                // size, full-strength color — so the three models aren't blurred
-                // into one combined number and it's readable at a glance.
-                Text(focus.today)
-                    .font(.system(size: 16, weight: .bold))
-                    .foregroundStyle(.primary)
+                Text("LOCAL TODAY · \(focus.today)")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.secondary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
                 Spacer(minLength: 6)
@@ -665,15 +669,15 @@ private struct ProviderGlanceCard: View {
             }
 
             if focus.workTime != "—" || focus.cacheHitPercent > 0.5 {
-                HStack(spacing: 8) {
+                HStack(spacing: 10) {
                     if focus.workTime != "—" {
                         HStack(spacing: 5) {
                             Image(systemName: "clock.fill")
-                                .font(.system(size: 12, weight: .bold))
+                                .font(.system(size: 10, weight: .semibold))
                                 .foregroundStyle(color)
                             Text("Active \(focus.workTime)")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundStyle(.primary)
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundStyle(.secondary)
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.7)
                         }
@@ -682,11 +686,11 @@ private struct ProviderGlanceCard: View {
                     if focus.cacheHitPercent > 0.5 {
                         HStack(spacing: 5) {
                             Image(systemName: "bolt.fill")
-                                .font(.system(size: 11, weight: .bold))
-                                .foregroundStyle(.green)
+                                .font(.system(size: 9, weight: .semibold))
+                                .foregroundStyle(color)
                             Text("Cache hit \(Int(focus.cacheHitPercent.rounded()))%")
-                                .font(.system(size: 13, weight: .semibold))
-                                .foregroundStyle(.primary)
+                                .font(.system(size: 10, weight: .medium))
+                                .foregroundStyle(.secondary)
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.7)
                         }
@@ -694,14 +698,15 @@ private struct ProviderGlanceCard: View {
                 }
             }
         }
-        .padding(15)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 10)
         .background(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
                 .fill(companionWarmGlassColor)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-                .stroke(color.opacity(0.22), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .stroke(companionBorderColor, lineWidth: 1)
         )
     }
 }
@@ -717,44 +722,43 @@ private struct GlanceQuotaLine: View {
         if let quota {
             let expired = resetIsExpired(quota.reset)
             let unavailable = isCached || expired
-            VStack(alignment: .leading, spacing: 7) {
-                HStack(alignment: .firstTextBaseline, spacing: 8) {
-                    Text(quota.title)
-                        .font(.system(size: 13, weight: .bold))
-                        .foregroundStyle(.secondary)
-                    Spacer(minLength: 0)
-                    Text(quotaValueText(quota: quota, displayMode: displayMode, isCached: isCached, expired: expired))
-                        .font(.system(size: 36, weight: .heavy, design: .rounded))
-                        .monospacedDigit()
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.5)
-                        .foregroundStyle(unavailable ? Color.secondary : Color.primary)
-                }
+            HStack(spacing: 8) {
+                Text(quota.title)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 42, alignment: .leading)
                 QuotaProgressBar(
                     progress: unavailable ? 0 : quota.progress(for: displayMode),
                     color: unavailable ? companionOrange : quotaHealthColor(quota)
                 )
-                .frame(height: 15)
-                Text(quotaDetailText(quota: quota, displayMode: displayMode, isCached: isCached, expired: expired))
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
-            }
-        } else {
-            VStack(alignment: .leading, spacing: 7) {
-                HStack(alignment: .firstTextBaseline) {
-                    Text(fallbackTitle)
-                        .font(.system(size: 13, weight: .bold))
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(quotaValueText(quota: quota, displayMode: displayMode, isCached: isCached, expired: expired))
+                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        .monospacedDigit()
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.65)
+                        .foregroundStyle(unavailable ? Color.secondary : Color.primary)
+                    Text(quotaDetailText(quota: quota, displayMode: displayMode, isCached: isCached, expired: expired))
+                        .font(.system(size: 8, weight: .medium))
                         .foregroundStyle(.secondary)
-                    Spacer(minLength: 0)
-                    Text("N/A")
-                        .font(.system(size: 36, weight: .heavy, design: .rounded))
-                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
                 }
-                QuotaProgressBar(progress: 0, color: .secondary)
-                    .frame(height: 15)
+                .frame(width: 92, alignment: .trailing)
             }
+            .frame(height: 28)
+        } else {
+            HStack(spacing: 8) {
+                Text(fallbackTitle)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 42, alignment: .leading)
+                QuotaProgressBar(progress: 0, color: .secondary)
+                Text("N/A")
+                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 92, alignment: .trailing)
+            }
+            .frame(height: 28)
         }
     }
 }
@@ -800,10 +804,9 @@ private struct QuotaProgressBar: View {
                 RoundedRectangle(cornerRadius: 5, style: .continuous)
                     .fill(color)
                     .frame(width: max(7, proxy.size.width * clampedProgress))
-                    .shadow(color: color.opacity(0.16), radius: 5, x: 0, y: 0)
             }
         }
-        .frame(height: 11)
+        .frame(height: 7)
     }
 }
 
@@ -935,7 +938,7 @@ private struct FocusHeroCard: View {
             let reset = resetLabel(primaryQuota.reset).map { " · reset \($0)" } ?? ""
             return "\(primaryQuota.detail)\(reset)"
         }
-        return focus.topModel
+        return focus.modelCostDetail
     }
 
     private var gaugeTitle: String {
@@ -1073,7 +1076,7 @@ private struct OverviewSection: View {
                     VisualMetricPill(
                         title: focus.title,
                         value: focus.today.replacingOccurrences(of: " today", with: ""),
-                        detail: focus.topModel,
+                        detail: providerMetricDetail(focus),
                         progress: focus.share,
                         color: providerColor(focus.id)
                     )
@@ -1150,14 +1153,14 @@ private struct HistorySection: View {
 
             HistoryBars(previousDays: model.previousWeekTrend, currentDays: model.currentWeekTrend)
         }
-        .padding(15)
+        .padding(12)
         .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(companionGlassPanelColor)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(companionOrange.opacity(0.16), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(companionBorderColor, lineWidth: 1)
         )
     }
 
@@ -1202,7 +1205,7 @@ private struct HistoryTotalCard: View {
         .padding(.vertical, 11)
         .background(
             RoundedRectangle(cornerRadius: 13, style: .continuous)
-                .fill(companionOrange.opacity(0.13))
+                .fill(companionWarmGlassColor)
         )
     }
 }
@@ -1902,26 +1905,30 @@ private struct SubagentCard: View {
                 }
             }
         }
-        .padding(15)
+        .padding(12)
         .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(companionGlassPanelColor)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(companionOrange.opacity(0.16), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(companionBorderColor, lineWidth: 1)
         )
     }
 }
 
 private struct ContributionHeatmap: View {
     let days: [TokscaleSummary.ContributionDay]
+    let endDate: String
 
     private let cell: CGFloat = 9
     private let spacing: CGFloat = 2
 
     var body: some View {
-        let grid = Self.buildGrid(days)
+        let grid = ContributionCalendarGrid.build(
+            days: days.map { (date: $0.date, costUsd: $0.costUsd) },
+            endDate: endDate
+        )
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 7) {
                 Image(systemName: "square.grid.3x3.fill")
@@ -1942,17 +1949,31 @@ private struct ContributionHeatmap: View {
                 )
             } else {
                 VStack(alignment: .leading, spacing: 6) {
-                    HStack(alignment: .top, spacing: spacing) {
-                        ForEach(Array(grid.enumerated()), id: \.offset) { _, week in
-                            VStack(spacing: spacing) {
-                                ForEach(Array(week.enumerated()), id: \.offset) { _, level in
-                                    RoundedRectangle(cornerRadius: 2, style: .continuous)
-                                        .fill(color(level))
-                                        .frame(width: cell, height: cell)
-                                }
+                    Canvas { context, size in
+                        let columnCount = max(grid.count, 1)
+                        let totalSpacing = CGFloat(columnCount - 1) * spacing
+                        let resolvedCell = max(
+                            1,
+                            min(cell, max(0, size.width - totalSpacing) / CGFloat(columnCount))
+                        )
+                        let gridHeight = resolvedCell * 7 + spacing * 6
+                        let top = max(0, (size.height - gridHeight) / 2)
+                        for (column, week) in grid.enumerated() {
+                            for (row, level) in week.enumerated() {
+                                let origin = CGPoint(
+                                    x: CGFloat(column) * (resolvedCell + spacing),
+                                    y: top + CGFloat(row) * (resolvedCell + spacing)
+                                )
+                                let rect = CGRect(origin: origin, size: CGSize(width: resolvedCell, height: resolvedCell))
+                                context.fill(
+                                    Path(roundedRect: rect, cornerRadius: min(2, resolvedCell / 3)),
+                                    with: .color(color(level))
+                                )
                             }
                         }
                     }
+                    .frame(height: 72)
+                    .accessibilityLabel("Activity over the last year")
                     HStack(spacing: 4) {
                         Text("Less").font(.system(size: 8)).foregroundStyle(.secondary)
                         ForEach(0...4, id: \.self) { level in
@@ -1965,14 +1986,14 @@ private struct ContributionHeatmap: View {
                 }
             }
         }
-        .padding(15)
+        .padding(12)
         .background(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(companionGlassPanelColor)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 18, style: .continuous)
-                .stroke(companionOrange.opacity(0.16), lineWidth: 1)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(companionBorderColor, lineWidth: 1)
         )
     }
 
@@ -1987,69 +2008,6 @@ private struct ContributionHeatmap: View {
         }
     }
 
-    // Calendar grid as columns of 7 (Sun..Sat). -1 pads days outside the data range,
-    // 0 is an in-range day with no usage, 1-4 are intensity buckets.
-    static func buildGrid(_ days: [TokscaleSummary.ContributionDay]) -> [[Int]] {
-        guard let firstDay = days.first, let lastDay = days.last else {
-            return []
-        }
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
-        let formatter = DateFormatter()
-        formatter.calendar = calendar
-        formatter.timeZone = calendar.timeZone
-        formatter.dateFormat = "yyyy-MM-dd"
-
-        let byDate = Dictionary(days.map { ($0.date, $0.costUsd) }, uniquingKeysWith: { first, _ in first })
-        // Bucket by quartiles of active-day cost so shades spread evenly instead of
-        // clumping at the faintest level under a few outlier days.
-        let sortedCosts = days.map(\.costUsd).filter { $0 > 0 }.sorted()
-        func bucket(_ cost: Double) -> Int {
-            guard cost > 0 else { return 0 }
-            guard !sortedCosts.isEmpty else { return 1 }
-            func threshold(_ p: Double) -> Double {
-                sortedCosts[min(sortedCosts.count - 1, Int((Double(sortedCosts.count) - 1) * p))]
-            }
-            if cost <= threshold(0.25) { return 1 }
-            if cost <= threshold(0.50) { return 2 }
-            if cost <= threshold(0.75) { return 3 }
-            return 4
-        }
-        guard let first = formatter.date(from: firstDay.date),
-            let last = formatter.date(from: lastDay.date)
-        else {
-            return []
-        }
-
-        let firstWeekday = calendar.component(.weekday, from: first) - 1
-        guard let gridStart = calendar.date(byAdding: .day, value: -firstWeekday, to: first) else {
-            return []
-        }
-
-        var columns: [[Int]] = []
-        var current: [Int] = []
-        var day = gridStart
-        while day <= last {
-            let weekday = calendar.component(.weekday, from: day) - 1
-            let level = day < first ? -1 : bucket(byDate[formatter.string(from: day)] ?? 0)
-            current.append(level)
-            if weekday == 6 {
-                columns.append(current)
-                current = []
-            }
-            guard let next = calendar.date(byAdding: .day, value: 1, to: day) else {
-                break
-            }
-            day = next
-        }
-        if !current.isEmpty {
-            while current.count < 7 {
-                current.append(-1)
-            }
-            columns.append(current)
-        }
-        return columns
-    }
 }
 
 private extension Array {
@@ -2068,15 +2026,7 @@ private struct UsageArcGauge: View {
     let centerSubtitle: String
     let active: Bool
 
-    @Environment(\.panelVisible) private var panelVisible
     @State private var visibleProgress = 0.0
-
-    // Repeat-forever animations are additive in SwiftUI — changing the driving
-    // value never cancels one that's already attached, so the render loop keeps
-    // ticking at full frame rate even with the panel closed. Hosting the loop in
-    // a separate child view and removing it from the tree is the only reliable
-    // teardown: the animation dies with the view's identity.
-    private var breathing: Bool { active && panelVisible }
 
     var body: some View {
         ZStack {
@@ -2094,10 +2044,6 @@ private struct UsageArcGauge: View {
             Circle()
                 .fill(color.opacity(active ? 0.09 : 0.045))
                 .frame(width: 64, height: 64)
-                .opacity(breathing ? 0 : 1)
-            if breathing {
-                BreathingHalo(color: color)
-            }
 
             VStack(spacing: 1) {
                 Text(centerTitle)
@@ -2118,22 +2064,6 @@ private struct UsageArcGauge: View {
                 visibleProgress = min(max(newValue, 0), 1)
             }
         }
-    }
-}
-
-private struct BreathingHalo: View {
-    let color: Color
-    @State private var grown = false
-
-    var body: some View {
-        Circle()
-            .fill(color.opacity(0.09))
-            .frame(width: grown ? 82 : 64, height: grown ? 82 : 64)
-            .onAppear {
-                withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
-                    grown = true
-                }
-            }
     }
 }
 
@@ -2254,42 +2184,16 @@ private struct StatusCapsule: View {
 private struct LiveDot: View {
     let stale: Bool
     let active: Bool
-    @Environment(\.panelVisible) private var panelVisible
 
     var body: some View {
-        ZStack {
-            // Same identity-teardown trick as BreathingHalo: the looping ring
-            // only exists in the tree while it's watchable, because removing
-            // the view is the only way to cancel its repeat-forever animation.
-            if active && panelVisible {
-                PulsingRing(color: dotColor)
-            }
-            Circle()
-                .fill(dotColor)
-                .frame(width: 8, height: 8)
-        }
+        Circle()
+            .fill(dotColor)
+            .frame(width: 8, height: 8)
         .frame(width: 19, height: 19)
     }
 
     private var dotColor: Color {
         active ? providerColor("openclaw") : (stale ? providerColor("claude") : providerColor("codex"))
-    }
-}
-
-private struct PulsingRing: View {
-    let color: Color
-    @State private var expanded = false
-
-    var body: some View {
-        Circle()
-            .stroke(color.opacity(0.35), lineWidth: 2)
-            .frame(width: expanded ? 19 : 9, height: expanded ? 19 : 9)
-            .opacity(expanded ? 0 : 1)
-            .onAppear {
-                withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: false)) {
-                    expanded = true
-                }
-            }
     }
 }
 
@@ -2300,7 +2204,6 @@ private struct ProviderDot: View {
         Circle()
             .fill(color)
             .frame(width: 7, height: 7)
-            .shadow(color: color.opacity(0.25), radius: 3)
     }
 }
 
@@ -2372,13 +2275,12 @@ private struct CompanionBackdrop: View {
 
             LinearGradient(
                 colors: [
-                    companionOrange.opacity(0.18),
-                    accent.opacity(0.06),
-                    companionPanelColor.opacity(0.44),
-                    companionSurfaceColor
+                    accent.opacity(0.055),
+                    companionPanelColor.opacity(0.30),
+                    companionSurfaceColor,
                 ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
+                startPoint: .top,
+                endPoint: .bottom
             )
         }
     }
@@ -2393,45 +2295,63 @@ private var companionOrange: Color {
 private let companionSurfaceColor = Color(
     nsColor: NSColor(name: nil) { appearance in
         if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            return NSColor(calibratedRed: 0.075, green: 0.062, blue: 0.052, alpha: 1.0)
+            return NSColor(calibratedRed: 0.030, green: 0.034, blue: 0.041, alpha: 1.0)
         }
-        return NSColor(calibratedRed: 0.985, green: 0.955, blue: 0.920, alpha: 1.0)
+        return NSColor(calibratedRed: 0.965, green: 0.969, blue: 0.975, alpha: 1.0)
     }
 )
 
 private let companionPanelColor = Color(
     nsColor: NSColor(name: nil) { appearance in
         if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            return NSColor(calibratedRed: 0.135, green: 0.112, blue: 0.095, alpha: 1.0)
+            return NSColor(calibratedRed: 0.060, green: 0.066, blue: 0.078, alpha: 1.0)
         }
-        return NSColor(calibratedRed: 1.0, green: 0.975, blue: 0.945, alpha: 1.0)
+        return NSColor(calibratedRed: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
     }
 )
 
 private let companionSelectedSurfaceColor = Color(
     nsColor: NSColor(name: nil) { appearance in
         if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            return NSColor(calibratedRed: 0.245, green: 0.158, blue: 0.110, alpha: 1.0)
+            return NSColor(calibratedRed: 0.120, green: 0.130, blue: 0.155, alpha: 1.0)
         }
-        return NSColor(calibratedRed: 1.0, green: 0.895, blue: 0.800, alpha: 1.0)
+        return NSColor(calibratedRed: 0.925, green: 0.934, blue: 0.950, alpha: 1.0)
     }
 )
 
 private let companionGlassPanelColor = Color(
     nsColor: NSColor(name: nil) { appearance in
         if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            return NSColor(calibratedRed: 0.155, green: 0.130, blue: 0.112, alpha: 0.92)
+            return NSColor(calibratedRed: 0.068, green: 0.075, blue: 0.090, alpha: 0.96)
         }
-        return NSColor(calibratedRed: 1.0, green: 0.972, blue: 0.938, alpha: 0.92)
+        return NSColor(calibratedRed: 1.0, green: 1.0, blue: 1.0, alpha: 0.94)
     }
 )
 
 private let companionWarmGlassColor = Color(
     nsColor: NSColor(name: nil) { appearance in
         if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
-            return NSColor(calibratedRed: 0.235, green: 0.172, blue: 0.125, alpha: 0.58)
+            return NSColor(calibratedRed: 0.082, green: 0.090, blue: 0.108, alpha: 0.96)
         }
-        return NSColor(calibratedRed: 1.0, green: 0.910, blue: 0.830, alpha: 0.58)
+        return NSColor(calibratedRed: 0.985, green: 0.987, blue: 0.992, alpha: 0.96)
+    }
+)
+
+private let companionBorderColor = Color(
+    nsColor: NSColor(name: nil) { appearance in
+        if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+            return NSColor.white.withAlphaComponent(0.075)
+        }
+        return NSColor.black.withAlphaComponent(0.085)
+    }
+)
+
+private let companionBorderStrongColor = Color(
+    nsColor: NSColor(name: nil) { appearance in
+        if appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua {
+            return NSColor.white.withAlphaComponent(0.14)
+        }
+        return NSColor.black.withAlphaComponent(0.14)
     }
 )
 
@@ -2444,6 +2364,13 @@ private func panelBackground(color: Color, intensity: Double) -> some View {
 
 private func formatToday(_ summary: TokscaleSummary) -> String {
     formatUSD(summary.today.costUsd)
+}
+
+private func providerMetricDetail(_ focus: TokscaleDashboardModel.ProviderFocus) -> String {
+    if focus.id.lowercased() == "grok", focus.primaryQuota != nil {
+        return "Shared credits"
+    }
+    return focus.modelCostDetail
 }
 
 private func formatUSD(_ value: Double) -> String {
@@ -2534,6 +2461,8 @@ private func providerColor(_ id: String) -> Color {
         return Color(hue: 0.40, saturation: 0.76, brightness: 0.84)
     case "gemini":
         return Color(hue: 0.60, saturation: 0.76, brightness: 0.96)
+    case "grok":
+        return Color(hue: 0.45, saturation: 0.82, brightness: 0.82)
     case "openclaw":
         return Color(hue: 0.74, saturation: 0.90, brightness: 0.96)
     case "copilot":

--- a/packages/menubar/Sources/TokscaleMenuBarCore/BackgroundScanPolicy.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/BackgroundScanPolicy.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+public enum BackgroundScanAction: Equatable, Sendable {
+    case full
+    case today
+    case none
+}
+
+public enum BackgroundScanPolicy {
+    public static let historyRefreshInterval: TimeInterval = 86_400
+    public static let historyRetryInterval: TimeInterval = 21_600
+    public static let todayRefreshInterval: TimeInterval = 600
+    public static let quotaOpenRefreshInterval: TimeInterval = 120
+
+    public static func nextAction(
+        now: Date,
+        lastHistorySuccess: Date,
+        lastHistoryAttempt: Date,
+        lastTodayScan: Date
+    ) -> BackgroundScanAction {
+        let historyDue = now.timeIntervalSince(lastHistorySuccess) >= historyRefreshInterval
+        let historyRetryDue = now.timeIntervalSince(lastHistoryAttempt) >= historyRetryInterval
+        if historyDue, historyRetryDue {
+            return .full
+        }
+        if now.timeIntervalSince(lastTodayScan) >= todayRefreshInterval {
+            return .today
+        }
+        return .none
+    }
+
+    public static func restoredScanDates(
+        generatedAt: String,
+        historyGeneratedAt: String?
+    ) -> (today: Date, history: Date)? {
+        guard let today = parseISODate(generatedAt) else { return nil }
+        let history = historyGeneratedAt.flatMap(parseISODate) ?? today
+        return (today, history)
+    }
+
+    public static func shouldRefreshQuotaOnOpen(
+        needsRefresh: Bool,
+        isRefreshing: Bool,
+        now: Date,
+        lastAttempt: Date
+    ) -> Bool {
+        needsRefresh && !isRefreshing
+            && now.timeIntervalSince(lastAttempt) >= quotaOpenRefreshInterval
+    }
+
+    public static func actionAfterRemoteHistorySync(succeeded: Bool) -> BackgroundScanAction {
+        succeeded ? .today : .full
+    }
+
+    private static func parseISODate(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) { return date }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
+    }
+}

--- a/packages/menubar/Sources/TokscaleMenuBarCore/ContributionCalendarGrid.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/ContributionCalendarGrid.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public enum ContributionCalendarGrid {
+    public static func build(
+        days: [(date: String, costUsd: Double)],
+        endDate: String
+    ) -> [[Int]] {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? .current
+        let formatter = DateFormatter()
+        formatter.calendar = calendar
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = calendar.timeZone
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        guard let end = formatter.date(from: endDate),
+            let cutoff = calendar.date(byAdding: .day, value: -364, to: end)
+        else { return [] }
+
+        var byDate: [String: Double] = [:]
+        for day in days {
+            guard let date = formatter.date(from: day.date), date >= cutoff, date <= end else {
+                continue
+            }
+            byDate[day.date] = max(byDate[day.date] ?? 0, day.costUsd)
+        }
+        let sortedCosts = byDate.values.filter { $0 > 0 }.sorted()
+        func bucket(_ cost: Double) -> Int {
+            guard cost > 0 else { return 0 }
+            guard !sortedCosts.isEmpty else { return 1 }
+            func threshold(_ percentile: Double) -> Double {
+                let index = Int((Double(sortedCosts.count) - 1) * percentile)
+                return sortedCosts[min(sortedCosts.count - 1, index)]
+            }
+            if cost <= threshold(0.25) { return 1 }
+            if cost <= threshold(0.50) { return 2 }
+            if cost <= threshold(0.75) { return 3 }
+            return 4
+        }
+
+        let leadingDays = calendar.component(.weekday, from: cutoff) - 1
+        let trailingDays = 7 - calendar.component(.weekday, from: end)
+        guard let gridStart = calendar.date(byAdding: .day, value: -leadingDays, to: cutoff),
+            let gridEnd = calendar.date(byAdding: .day, value: trailingDays, to: end)
+        else { return [] }
+
+        var columns: [[Int]] = []
+        var current: [Int] = []
+        var date = gridStart
+        while date <= gridEnd {
+            if date < cutoff || date > end {
+                current.append(-1)
+            } else {
+                current.append(bucket(byDate[formatter.string(from: date)] ?? 0))
+            }
+            if current.count == 7 {
+                columns.append(current)
+                current = []
+            }
+            guard let next = calendar.date(byAdding: .day, value: 1, to: date) else {
+                return []
+            }
+            date = next
+        }
+        return columns
+    }
+}

--- a/packages/menubar/Sources/TokscaleMenuBarCore/GraphCompanionAdapter.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/GraphCompanionAdapter.swift
@@ -35,26 +35,26 @@ public enum GraphCompanionAdapter {
             let models: [String]
         }
 
-        struct Contribution: Decodable {
+        struct Contribution: Codable {
             let date: String
             let intensity: Int
             let totals: Totals
             let clients: [Client]
 
-            struct Totals: Decodable {
+            struct Totals: Codable {
                 let tokens: Int64
                 let cost: Double
                 let messages: Int
             }
 
-            struct Client: Decodable {
+            struct Client: Codable {
                 let client: String
                 let modelId: String
                 let cost: Double
                 let messages: Int
                 let tokens: Tokens
 
-                struct Tokens: Decodable {
+                struct Tokens: Codable {
                     let input: Int64
                     let output: Int64
                     let cacheRead: Int64
@@ -117,6 +117,65 @@ public enum GraphCompanionAdapter {
         }
     }
 
+    private struct RemoteProfile: Decodable {
+        let stats: Stats
+        let clients: [String]
+        let models: [String]
+        let contributions: [Contribution]
+        let dateRange: DateRange?
+
+        struct Stats: Decodable {
+            let totalTokens: Int64
+            let totalCost: Double
+            let activeDays: Int
+        }
+
+        struct DateRange: Decodable {
+            let start: String?
+            let end: String?
+        }
+
+        struct Contribution: Decodable {
+            let date: String
+            let intensity: Int
+            let totals: Totals
+            let clients: [Client]
+
+            struct Totals: Decodable {
+                let tokens: Int64
+                let cost: Double
+                let messages: Int
+            }
+
+            struct Client: Decodable {
+                let client: String
+                let modelId: String?
+                let models: [String: Model]?
+                let tokens: Tokens
+                let cost: Double
+                let messages: Int
+
+                struct Model: Decodable {
+                    let cost: Double
+                    let input: Int64
+                    let output: Int64
+                    let messages: Int
+                    let cacheRead: Int64
+                    let reasoning: Int64
+                    let cacheWrite: Int64
+                }
+
+                struct Tokens: Decodable {
+                    let input: Int64
+                    let output: Int64
+                    let cacheRead: Int64
+                    let cacheWrite: Int64
+                    let reasoning: Int64
+                }
+            }
+        }
+    }
+
     /// Convert raw `graph`/`usage` stdout into the companion-summary JSON the menu
     /// bar's `TokscaleSummary` decodes. `usageData` may be nil/garbage (quota fetch
     /// failed) — quota is then empty and the caller can fall back to a prior value.
@@ -137,6 +196,28 @@ public enum GraphCompanionAdapter {
         let usage: [UsageProvider] =
             usageData.flatMap { try? JSONDecoder().decode([UsageProvider].self, from: $0) } ?? []
 
+        return try companionJSON(
+            graph: graph,
+            usage: usage,
+            todayDate: todayDate,
+            summaryPath: summaryPath,
+            lastScanDurationMs: lastScanDurationMs,
+            quotaRefreshedAt: quotaRefreshedAt
+        )
+    }
+
+    public static func isValidGraphData(_ data: Data) -> Bool {
+        (try? JSONDecoder().decode(Graph.self, from: data)) != nil
+    }
+
+    private static func companionJSON(
+        graph: Graph,
+        usage: [UsageProvider],
+        todayDate: String,
+        summaryPath: String,
+        lastScanDurationMs: Int,
+        quotaRefreshedAt: String?
+    ) throws -> Data {
         let today = graph.contributions.first { $0.date == todayDate }
         let todayCost = today?.totals.cost ?? 0
         let todayTokens = today?.totals.tokens ?? 0
@@ -172,6 +253,7 @@ public enum GraphCompanionAdapter {
             "health": [
                 "summaryPath": summaryPath,
                 "lastScanDurationMs": lastScanDurationMs,
+                "historyGeneratedAt": graph.meta.generatedAt,
                 "warnings": [String](),
             ] as [String: Any],
             // accuracy_report_for_graph is Rust-internal and not in graph JSON, so
@@ -181,6 +263,13 @@ public enum GraphCompanionAdapter {
                 "sourceKinds": ["local-scan"],
                 "warnings": [String](),
             ] as [String: Any],
+        ]
+        summary["localDaily"] = encodedContributions(graph.contributions)
+        summary["historyProvenance"] = [
+            "localCapturedAt": graph.meta.generatedAt,
+            "localTodayDate": todayDate,
+            "mergeRule": "local-full-scan",
+            "localSnapshotComplete": true,
         ]
 
         if var health = summary["health"] as? [String: Any], let quotaRefreshedAt {
@@ -219,10 +308,122 @@ public enum GraphCompanionAdapter {
         return try? JSONSerialization.data(withJSONObject: dict, options: [])
     }
 
-    /// Patch only today's figures into an existing companion summary, from a fast
-    /// today-only graph scan. All-time totals, history, top, and quota are left
-    /// untouched — they come from the slower full scan — so the menu bar can
-    /// refresh today's spend and work time cheaply without rescanning history.
+    /// Replace the expensive local history scan with the compact daily aggregates
+    /// already stored by tokens.ci. The existing summary remains the offline cache,
+    /// while its local today snapshot only replaces the device-local presentation.
+    public static func patchRemoteProfile(
+        companionData: Data,
+        profileData: Data,
+        todayDate: String,
+        syncedAt: String,
+        lastScanDurationMs: Int
+    ) -> Data? {
+        guard
+            let profile = try? JSONDecoder().decode(RemoteProfile.self, from: profileData),
+            var dict = (try? JSONSerialization.jsonObject(with: companionData)) as? [String: Any]
+        else { return nil }
+        guard profileTotalsAreConsistent(profile) else { return nil }
+
+        let localPresentation = dict
+        let localProvenance =
+            localPresentation["historyProvenance"] as? [String: Any] ?? [:]
+        let localTodayDate = localProvenance["localTodayDate"] as? String
+        let graph = graph(from: profile, generatedAt: syncedAt)
+        guard
+            let remoteData = try? companionJSON(
+                graph: graph,
+                usage: [],
+                todayDate: todayDate,
+                summaryPath: "",
+                lastScanDurationMs: lastScanDurationMs,
+                quotaRefreshedAt: nil
+            ),
+            let remote = (try? JSONSerialization.jsonObject(with: remoteData)) as? [String: Any]
+        else { return nil }
+
+        for key in ["today", "collapsed", "totals", "providers", "history", "contribution", "top"] {
+            dict[key] = remote[key]
+        }
+        let cachedTodayDate =
+            (localPresentation["today"] as? [String: Any])?["date"] as? String
+        let hasLocalToday = localTodayDate == todayDate && cachedTodayDate == todayDate
+        if hasLocalToday {
+            patchTodayPresentation(
+                in: &dict,
+                replacement: localPresentation,
+                updateGeneratedAt: false
+            )
+        }
+        dict["remoteDaily"] = encodedContributions(graph.contributions)
+        var historyProvenance: [String: Any] = [
+            "localCapturedAt":
+                localProvenance["localCapturedAt"]
+                ?? dict["generatedAt"]
+                ?? syncedAt,
+            "remoteSyncedAt": syncedAt,
+            "mergeRule": "remote-aggregates-local-today-presentation",
+        ]
+        if let localTodayDate {
+            historyProvenance["localTodayDate"] = localTodayDate
+        }
+        dict["historyProvenance"] = historyProvenance
+        if var health = dict["health"] as? [String: Any] {
+            health["historyGeneratedAt"] = syncedAt
+            health["lastScanDurationMs"] = lastScanDurationMs
+            health["historySource"] = "remote-profile"
+            dict["health"] = health
+        }
+        var sourceKinds = ["tokens-ci"]
+        if !profileWindowCoversAllTime(profile) {
+            sourceKinds.append("tokens-ci-rolling-breakdown")
+        }
+        if hasLocalToday { sourceKinds.append("local-today") }
+        dict["accuracy"] = [
+            "confidence": "high",
+            "sourceKinds": sourceKinds,
+            "warnings": [String](),
+        ] as [String: Any]
+        dict.removeValue(forKey: "subagents")
+
+        return try? JSONSerialization.data(withJSONObject: dict, options: [])
+    }
+
+    private static func profileTotalsAreConsistent(_ profile: RemoteProfile) -> Bool {
+        let tokens = profile.contributions.reduce(Int64(0)) { $0 + $1.totals.tokens }
+        let cost = profile.contributions.reduce(0.0) { $0 + $1.totals.cost }
+        let activeDays = profile.contributions.filter { $0.totals.tokens > 0 }.count
+        let costTolerance = max(0.01, abs(profile.stats.totalCost) * 0.000001)
+        guard profile.stats.totalTokens >= 0, profile.stats.totalCost.isFinite,
+            profile.stats.totalCost >= 0, profile.stats.activeDays >= 0,
+            profile.contributions.allSatisfy({
+                $0.totals.tokens >= 0 && $0.totals.cost.isFinite && $0.totals.cost >= 0
+            }),
+            Set(profile.contributions.map(\.date)).count == profile.contributions.count,
+            tokens <= profile.stats.totalTokens,
+            cost <= profile.stats.totalCost + costTolerance,
+            activeDays <= profile.stats.activeDays
+        else { return false }
+
+        if profileWindowCoversAllTime(profile) {
+            return tokens == profile.stats.totalTokens
+                && abs(cost - profile.stats.totalCost) <= costTolerance
+                && activeDays == profile.stats.activeDays
+        }
+        return true
+    }
+
+    private static func profileWindowCoversAllTime(_ profile: RemoteProfile) -> Bool {
+        if profile.stats.totalTokens == 0, profile.contributions.isEmpty {
+            return true
+        }
+        guard let allTimeStart = profile.dateRange?.start,
+            let firstContribution = profile.contributions.map(\.date).min()
+        else { return false }
+        return allTimeStart == firstContribution
+    }
+
+    /// Patch today's figures from a fast today-only graph scan. Remote account
+    /// aggregates remain untouched; a local-only cache reconciles its aggregates.
     public static func patchTodayData(
         companionData: Data,
         todayGraphData: Data,
@@ -242,32 +443,433 @@ public enum GraphCompanionAdapter {
             let todayDict = (try? JSONSerialization.jsonObject(with: todayData)) as? [String: Any]
         else { return nil }
 
-        // Today panel + glance come straight from the today-only scan.
-        if let today = todayDict["today"] { dict["today"] = today }
-        if let collapsed = todayDict["collapsed"] { dict["collapsed"] = collapsed }
-        if let generatedAt = todayDict["generatedAt"] { dict["generatedAt"] = generatedAt }
+        var localByDate = Dictionary(
+            uniqueKeysWithValues: decodedContributions(dict["localDaily"]).map { ($0.date, $0) }
+        )
+        localByDate.removeValue(forKey: todayDate)
+        for contribution in decodedContributions(todayDict["localDaily"])
+        where contribution.date == todayDate {
+            localByDate[contribution.date] = contribution
+        }
+        dict["localDaily"] = encodedContributions(Array(localByDate.values))
+        var provenance = dict["historyProvenance"] as? [String: Any] ?? [:]
+        provenance["localCapturedAt"] = todayDict["generatedAt"]
+        provenance["localTodayDate"] = todayDate
+        let usesRemoteHistory =
+            (dict["health"] as? [String: Any])?["historySource"] as? String
+            == "remote-profile"
+        provenance["mergeRule"] =
+            usesRemoteHistory
+            ? "remote-aggregates-local-today-presentation"
+            : "local-full-scan"
+        dict["historyProvenance"] = provenance
 
-        // Patch each provider's today-scoped fields (and work time) from the today
-        // scan; providers absent from today reset to zero. All-time costUsd/tokens/
-        // cacheHitPercent stay owned by the full scan.
-        if let realProviders = dict["providers"] as? [[String: Any]] {
-            var byClient: [String: [String: Any]] = [:]
-            for p in (todayDict["providers"] as? [[String: Any]]) ?? [] {
-                if let client = p["client"] as? String { byClient[client] = p }
-            }
-            dict["providers"] = realProviders.map { provider -> [String: Any] in
-                var provider = provider
-                let client = provider["client"] as? String ?? ""
-                let t = byClient[client]
-                provider["todayCostUsd"] = t?["todayCostUsd"] ?? 0
-                provider["todayTokens"] = t?["todayTokens"] ?? 0
-                provider["todayMessages"] = t?["todayMessages"] ?? 0
-                provider["workTimeMs"] = t?["workTimeMs"] ?? 0
-                return provider
-            }
+        if usesRemoteHistory {
+            patchTodayPresentation(
+                in: &dict,
+                replacement: todayDict,
+                updateGeneratedAt: true
+            )
+        } else {
+            let previousToday = dict["today"] as? [String: Any]
+            reconcileToday(
+                in: &dict,
+                previousToday: previousToday,
+                replacement: todayDict,
+                todayDate: todayDate,
+                updateGeneratedAt: true
+            )
         }
 
         return try? JSONSerialization.data(withJSONObject: dict, options: [])
+    }
+
+    private static func graph(from profile: RemoteProfile, generatedAt: String) -> Graph {
+        let contributions = profile.contributions.map { day in
+            let clients = day.clients.flatMap { client -> [Graph.Contribution.Client] in
+                if let models = client.models, !models.isEmpty {
+                    return models.map { modelId, model in
+                        Graph.Contribution.Client(
+                            client: client.client,
+                            modelId: modelId,
+                            cost: model.cost,
+                            messages: model.messages,
+                            tokens: Graph.Contribution.Client.Tokens(
+                                input: model.input,
+                                output: model.output,
+                                cacheRead: model.cacheRead,
+                                cacheWrite: model.cacheWrite,
+                                reasoning: model.reasoning
+                            )
+                        )
+                    }
+                }
+                return [
+                    Graph.Contribution.Client(
+                        client: client.client,
+                        modelId: client.modelId.flatMap { $0.isEmpty ? nil : $0 } ?? "unknown",
+                        cost: client.cost,
+                        messages: client.messages,
+                        tokens: Graph.Contribution.Client.Tokens(
+                            input: client.tokens.input,
+                            output: client.tokens.output,
+                            cacheRead: client.tokens.cacheRead,
+                            cacheWrite: client.tokens.cacheWrite,
+                            reasoning: client.tokens.reasoning
+                        )
+                    )
+                ]
+            }
+            return Graph.Contribution(
+                date: day.date,
+                intensity: day.intensity,
+                totals: Graph.Contribution.Totals(
+                    tokens: day.totals.tokens,
+                    cost: day.totals.cost,
+                    messages: day.totals.messages
+                ),
+                clients: clients
+            )
+        }
+        return Graph(
+            meta: Graph.Meta(generatedAt: generatedAt),
+            summary: Graph.Summary(
+                totalTokens: profile.stats.totalTokens,
+                totalCost: profile.stats.totalCost,
+                activeDays: profile.stats.activeDays,
+                clients: profile.clients,
+                models: profile.models
+            ),
+            contributions: contributions,
+            subagents: nil,
+            todayWorkTime: nil
+        )
+    }
+
+    private static func encodedContributions(
+        _ contributions: [Graph.Contribution]
+    ) -> [[String: Any]] {
+        guard let data = try? JSONEncoder().encode(contributions),
+            let rows = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]]
+        else { return [] }
+        return rows
+    }
+
+    private static func decodedContributions(_ value: Any?) -> [Graph.Contribution] {
+        guard let value, JSONSerialization.isValidJSONObject(value),
+            let data = try? JSONSerialization.data(withJSONObject: value),
+            let contributions = try? JSONDecoder().decode([Graph.Contribution].self, from: data)
+        else { return [] }
+        return contributions
+    }
+
+    private static func reconcileToday(
+        in dict: inout [String: Any],
+        previousToday: [String: Any]?,
+        replacement: [String: Any],
+        todayDate: String,
+        updateGeneratedAt: Bool
+    ) {
+        guard let nextToday = replacement["today"] as? [String: Any] else { return }
+        let prior = previousToday ?? [:]
+        let replacesSameDay = prior["date"] as? String == todayDate
+
+        if var totals = dict["totals"] as? [String: Any] {
+            totals["costUsd"] = max(
+                0,
+                doubleValue(totals["costUsd"])
+                    - (replacesSameDay ? doubleValue(prior["costUsd"]) : 0)
+                    + doubleValue(nextToday["costUsd"])
+            )
+            totals["tokens"] = max(
+                0,
+                int64Value(totals["tokens"])
+                    - (replacesSameDay ? int64Value(prior["tokens"]) : 0)
+                    + int64Value(nextToday["tokens"])
+            )
+            var activeDays = intValue(totals["activeDays"])
+            if replacesSameDay, int64Value(prior["tokens"]) > 0 { activeDays -= 1 }
+            if int64Value(nextToday["tokens"]) > 0 { activeDays += 1 }
+            totals["activeDays"] = max(0, activeDays)
+            dict["totals"] = totals
+        }
+
+        var history = (dict["history"] as? [[String: Any]] ?? [])
+            .filter { ($0["date"] as? String) != todayDate }
+        if int64Value(nextToday["tokens"]) > 0 || doubleValue(nextToday["costUsd"]) > 0 {
+            history.append([
+                "date": todayDate,
+                "costUsd": doubleValue(nextToday["costUsd"]),
+                "tokens": int64Value(nextToday["tokens"]),
+                "messages": intValue(nextToday["messages"]),
+            ])
+        }
+        dict["history"] = history.sorted {
+            ($0["date"] as? String ?? "") < ($1["date"] as? String ?? "")
+        }
+
+        var contributions = (dict["contribution"] as? [[String: Any]] ?? [])
+            .filter { ($0["date"] as? String) != todayDate }
+        if int64Value(nextToday["tokens"]) > 0 || doubleValue(nextToday["costUsd"]) > 0 {
+            contributions.append([
+                "date": todayDate,
+                "costUsd": doubleValue(nextToday["costUsd"]),
+                "intensity": 0,
+            ])
+        }
+        let maxCost = contributions.map { doubleValue($0["costUsd"]) }.max() ?? 0
+        dict["contribution"] = contributions.map { day -> [String: Any] in
+            var day = day
+            let cost = doubleValue(day["costUsd"])
+            day["intensity"] = contributionIntensity(cost: cost, maxCost: maxCost)
+            return day
+        }.sorted {
+            ($0["date"] as? String ?? "") < ($1["date"] as? String ?? "")
+        }
+
+        if let today = replacement["today"] { dict["today"] = today }
+        if let collapsed = replacement["collapsed"] { dict["collapsed"] = collapsed }
+        if updateGeneratedAt, let generatedAt = replacement["generatedAt"] {
+            dict["generatedAt"] = generatedAt
+        }
+        patchProviders(
+            in: &dict,
+            replacement: replacement,
+            reconcileLifetime: true,
+            replacesSameDay: replacesSameDay
+        )
+        refreshAggregateLabels(in: &dict)
+    }
+
+    private static func patchTodayPresentation(
+        in dict: inout [String: Any],
+        replacement: [String: Any],
+        updateGeneratedAt: Bool
+    ) {
+        if let today = replacement["today"] { dict["today"] = today }
+        if let collapsed = replacement["collapsed"] { dict["collapsed"] = collapsed }
+        if updateGeneratedAt, let generatedAt = replacement["generatedAt"] {
+            dict["generatedAt"] = generatedAt
+        }
+        patchProviders(
+            in: &dict,
+            replacement: replacement,
+            reconcileLifetime: false,
+            preserveLifetime: true
+        )
+    }
+
+    private static func patchProviders(
+        in dict: inout [String: Any],
+        replacement: [String: Any],
+        reconcileLifetime: Bool,
+        replacesSameDay: Bool = false,
+        preserveLifetime: Bool = false
+    ) {
+        let nextProviders = replacement["providers"] as? [[String: Any]] ?? []
+        let nextByClient = Dictionary(
+            uniqueKeysWithValues: nextProviders.compactMap { provider -> (String, [String: Any])? in
+                guard let client = provider["client"] as? String else { return nil }
+                return (client, provider)
+            }
+        )
+        var knownClients = Set<String>()
+        var providers = (dict["providers"] as? [[String: Any]] ?? []).map {
+            provider -> [String: Any] in
+            var provider = provider
+            let client = provider["client"] as? String ?? ""
+            knownClients.insert(client)
+            let next = nextByClient[client]
+            if reconcileLifetime {
+                provider["costUsd"] = max(
+                    0,
+                    doubleValue(provider["costUsd"])
+                        - (replacesSameDay ? doubleValue(provider["todayCostUsd"]) : 0)
+                        + doubleValue(next?["todayCostUsd"])
+                )
+                provider["tokens"] = max(
+                    0,
+                    int64Value(provider["tokens"])
+                        - (replacesSameDay ? int64Value(provider["todayTokens"]) : 0)
+                        + int64Value(next?["todayTokens"])
+                )
+                provider["messages"] = max(
+                    0,
+                    intValue(provider["messages"])
+                        - (replacesSameDay ? intValue(provider["todayMessages"]) : 0)
+                        + intValue(next?["todayMessages"])
+                )
+            }
+            provider["todayCostUsd"] = doubleValue(next?["todayCostUsd"])
+            provider["todayTokens"] = int64Value(next?["todayTokens"])
+            provider["todayMessages"] = intValue(next?["todayMessages"])
+            provider["workTimeMs"] = int64Value(next?["workTimeMs"])
+            provider["models"] = patchedModels(
+                provider["models"] as? [[String: Any]] ?? [],
+                replacement: next?["models"] as? [[String: Any]] ?? [],
+                reconcileLifetime: reconcileLifetime,
+                replacesSameDay: replacesSameDay,
+                preserveLifetime: preserveLifetime
+            )
+            if let topModel = (provider["models"] as? [[String: Any]])?.max(by: {
+                doubleValue($0["costUsd"]) < doubleValue($1["costUsd"])
+            })?["model"] {
+                provider["topModel"] = topModel
+            }
+            return provider
+        }
+
+        for next in nextProviders {
+            guard let client = next["client"] as? String, !knownClients.contains(client) else {
+                continue
+            }
+            providers.append(preserveLifetime ? presentationOnlyProvider(next) : next)
+        }
+        dict["providers"] = providers.filter {
+            int64Value($0["tokens"]) > 0 || doubleValue($0["costUsd"]) > 0
+                || intValue($0["messages"]) > 0
+                || int64Value($0["todayTokens"]) > 0
+                || doubleValue($0["todayCostUsd"]) > 0
+                || intValue($0["todayMessages"]) > 0
+        }.sorted {
+            let lhs = doubleValue($0["costUsd"])
+            let rhs = doubleValue($1["costUsd"])
+            if lhs == rhs {
+                return ($0["client"] as? String ?? "") < ($1["client"] as? String ?? "")
+            }
+            return lhs > rhs
+        }
+    }
+
+    private static func patchedModels(
+        _ models: [[String: Any]],
+        replacement: [[String: Any]],
+        reconcileLifetime: Bool,
+        replacesSameDay: Bool,
+        preserveLifetime: Bool
+    ) -> [[String: Any]] {
+        let nextByModel = Dictionary(
+            uniqueKeysWithValues: replacement.compactMap { model -> (String, [String: Any])? in
+                guard let id = model["model"] as? String else { return nil }
+                return (id, model)
+            }
+        )
+        var known = Set<String>()
+        var result = models.map { model -> [String: Any] in
+            var model = model
+            let id = model["model"] as? String ?? ""
+            known.insert(id)
+            let next = nextByModel[id]
+            if reconcileLifetime {
+                model["costUsd"] = max(
+                    0,
+                    doubleValue(model["costUsd"])
+                        - (replacesSameDay ? doubleValue(model["todayCostUsd"]) : 0)
+                        + doubleValue(next?["todayCostUsd"])
+                )
+                model["tokens"] = max(
+                    0,
+                    int64Value(model["tokens"])
+                        - (replacesSameDay ? int64Value(model["todayTokens"]) : 0)
+                        + int64Value(next?["todayTokens"])
+                )
+                model["messages"] = max(
+                    0,
+                    intValue(model["messages"])
+                        - (replacesSameDay ? intValue(model["todayMessages"]) : 0)
+                        + intValue(next?["todayMessages"])
+                )
+            }
+            model["todayCostUsd"] = doubleValue(next?["todayCostUsd"])
+            model["todayTokens"] = int64Value(next?["todayTokens"])
+            model["todayMessages"] = intValue(next?["todayMessages"])
+            return model
+        }
+        let newModels = replacement.filter { model in
+                guard let id = model["model"] as? String else { return false }
+                return !known.contains(id)
+            }
+        result.append(
+            contentsOf: preserveLifetime
+                ? newModels.map(presentationOnlyModel)
+                : newModels
+        )
+        return result.filter {
+            int64Value($0["tokens"]) > 0 || doubleValue($0["costUsd"]) > 0
+                || intValue($0["messages"]) > 0
+                || int64Value($0["todayTokens"]) > 0
+                || doubleValue($0["todayCostUsd"]) > 0
+                || intValue($0["todayMessages"]) > 0
+        }.sorted {
+            let lhs = doubleValue($0["costUsd"])
+            let rhs = doubleValue($1["costUsd"])
+            if lhs == rhs {
+                return ($0["model"] as? String ?? "") < ($1["model"] as? String ?? "")
+            }
+            return lhs > rhs
+        }
+    }
+
+    private static func presentationOnlyProvider(_ provider: [String: Any]) -> [String: Any] {
+        var provider = provider
+        provider["costUsd"] = 0.0
+        provider["tokens"] = Int64(0)
+        provider["messages"] = 0
+        provider["models"] = (provider["models"] as? [[String: Any]] ?? [])
+            .map(presentationOnlyModel)
+        return provider
+    }
+
+    private static func presentationOnlyModel(_ model: [String: Any]) -> [String: Any] {
+        var model = model
+        model["costUsd"] = 0.0
+        model["tokens"] = Int64(0)
+        model["messages"] = 0
+        return model
+    }
+
+    private static func refreshAggregateLabels(in dict: inout [String: Any]) {
+        let providers = dict["providers"] as? [[String: Any]] ?? []
+        if var totals = dict["totals"] as? [String: Any] {
+            totals["clients"] = providers.compactMap { $0["client"] as? String }.sorted()
+            let models = providers.flatMap { provider in
+                (provider["models"] as? [[String: Any]] ?? []).compactMap {
+                    $0["model"] as? String
+                }
+            }
+            totals["models"] = Set(models).count
+            dict["totals"] = totals
+        }
+        if let topProvider = providers.max(by: {
+            doubleValue($0["costUsd"]) < doubleValue($1["costUsd"])
+        }) {
+            var top: [String: Any] = [:]
+            if let client = topProvider["client"] { top["client"] = client }
+            if let model = topProvider["topModel"] { top["model"] = model }
+            dict["top"] = top
+        } else {
+            dict["top"] = [String: Any]()
+        }
+    }
+
+    private static func contributionIntensity(cost: Double, maxCost: Double) -> Int {
+        guard cost > 0, maxCost > 0 else { return 0 }
+        if cost <= maxCost * 0.25 { return 1 }
+        if cost <= maxCost * 0.5 { return 2 }
+        if cost <= maxCost * 0.75 { return 3 }
+        return 4
+    }
+
+    private static func doubleValue(_ value: Any?) -> Double {
+        (value as? NSNumber)?.doubleValue ?? value as? Double ?? 0
+    }
+
+    private static func int64Value(_ value: Any?) -> Int64 {
+        (value as? NSNumber)?.int64Value ?? value as? Int64 ?? 0
+    }
+
+    private static func intValue(_ value: Any?) -> Int {
+        (value as? NSNumber)?.intValue ?? value as? Int ?? 0
     }
 
     // MARK: - breakdowns (mirror companion_summary.rs from_graph)
@@ -283,7 +885,15 @@ public enum GraphCompanionAdapter {
             var cacheRead: Int64 = 0
             var freshInput: Int64 = 0
             var cacheWrite: Int64 = 0
-            var modelCosts: [String: Double] = [:]
+            var models: [String: ModelAcc] = [:]
+        }
+        struct ModelAcc {
+            var cost = 0.0
+            var tokens: Int64 = 0
+            var messages = 0
+            var todayCost = 0.0
+            var todayTokens: Int64 = 0
+            var todayMessages = 0
         }
         var providers: [String: Acc] = [:]
         for day in graph.contributions {
@@ -297,23 +907,51 @@ public enum GraphCompanionAdapter {
                 acc.cacheRead += client.tokens.cacheRead
                 acc.freshInput += client.tokens.input
                 acc.cacheWrite += client.tokens.cacheWrite
-                acc.modelCosts[client.modelId, default: 0] += client.cost
+                var model = acc.models[client.modelId] ?? ModelAcc()
+                model.cost += client.cost
+                model.tokens += tokenCount
+                model.messages += client.messages
                 if isToday {
                     acc.todayCost += client.cost
                     acc.todayTokens += tokenCount
                     acc.todayMessages += client.messages
+                    model.todayCost += client.cost
+                    model.todayTokens += tokenCount
+                    model.todayMessages += client.messages
                 }
+                acc.models[client.modelId] = model
                 providers[client.client] = acc
             }
         }
-        return providers
+        return
+            providers
             .map { client, acc -> [String: Any] in
-                let topModel = acc.modelCosts.max { $0.value < $1.value }?.key
+                let models = acc.models
+                    .map { model, totals -> [String: Any] in
+                        [
+                            "model": model,
+                            "costUsd": totals.cost,
+                            "tokens": totals.tokens,
+                            "messages": totals.messages,
+                            "todayCostUsd": totals.todayCost,
+                            "todayTokens": totals.todayTokens,
+                            "todayMessages": totals.todayMessages,
+                        ]
+                    }
+                    .sorted { lhs, rhs in
+                        let lc = lhs["costUsd"] as? Double ?? 0
+                        let rc = rhs["costUsd"] as? Double ?? 0
+                        if lc == rc {
+                            return (lhs["model"] as? String ?? "") < (rhs["model"] as? String ?? "")
+                        }
+                        return lc > rc
+                    }
                 // Prompt-cache hit rate: cache reads (hits) over everything first read
                 // this turn — fresh input plus first-time cache writes (both misses).
                 // Counting cacheWrite is what keeps Claude off a permanent ~100%.
                 let readTotal = acc.cacheRead + acc.freshInput + acc.cacheWrite
-                let cacheHitPercent = readTotal > 0
+                let cacheHitPercent =
+                    readTotal > 0
                     ? Double(acc.cacheRead) / Double(readTotal) * 100
                     : 0
                 var row: [String: Any] = [
@@ -327,6 +965,8 @@ public enum GraphCompanionAdapter {
                     "cacheHitPercent": cacheHitPercent,
                     "workTimeMs": graph.todayWorkTime?[client] ?? 0,
                 ]
+                row["models"] = models
+                let topModel = models.first?["model"] as? String
                 if let topModel { row["topModel"] = topModel }
                 return row
             }
@@ -417,19 +1057,20 @@ public enum GraphCompanionAdapter {
 
     private static func topBreakdown(_ graph: Graph) -> [String: Any] {
         var clientCosts: [String: Double] = [:]
-        var modelCosts: [String: Double] = [:]
+        var modelCostsByClient: [String: [String: Double]] = [:]
         for day in graph.contributions {
             for client in day.clients {
                 clientCosts[client.client, default: 0] += client.cost
-                modelCosts[client.modelId, default: 0] += client.cost
+                modelCostsByClient[client.client, default: [:]][client.modelId, default: 0] +=
+                    client.cost
             }
         }
         var top: [String: Any] = [:]
         if let client = clientCosts.max(by: { $0.value < $1.value })?.key {
             top["client"] = client
-        }
-        if let model = modelCosts.max(by: { $0.value < $1.value })?.key {
-            top["model"] = model
+            if let model = modelCostsByClient[client]?.max(by: { $0.value < $1.value })?.key {
+                top["model"] = model
+            }
         }
         return top
     }
@@ -444,8 +1085,63 @@ public enum GraphCompanionAdapter {
     }
 }
 
-private extension Double {
-    func clamped(_ lo: Double, _ hi: Double) -> Double {
+extension Double {
+    fileprivate func clamped(_ lo: Double, _ hi: Double) -> Double {
         Swift.min(Swift.max(self, lo), hi)
+    }
+}
+
+public final class SummaryMutationCoordinator: @unchecked Sendable {
+    private let queue: DispatchQueue
+    private let fileManager: FileManager
+
+    public init(
+        label: String = "tokens.menubar.summary-mutations",
+        fileManager: FileManager = .default
+    ) {
+        queue = DispatchQueue(label: label, qos: .utility)
+        self.fileManager = fileManager
+    }
+
+    public func mutate(
+        summaryURL: URL,
+        patch: @escaping @Sendable (Data) -> Data?
+    ) -> Bool {
+        queue.sync {
+            guard let latest = try? Data(contentsOf: summaryURL), !latest.isEmpty,
+                let patched = patch(latest)
+            else { return false }
+            return write(patched, to: summaryURL)
+        }
+    }
+
+    public func replace(summaryURL: URL, with data: Data) -> Bool {
+        queue.sync { write(data, to: summaryURL) }
+    }
+
+    private func write(_ data: Data, to url: URL) -> Bool {
+        var temporaryURL: URL?
+        do {
+            try fileManager.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let nextTemporaryURL = url.deletingLastPathComponent().appendingPathComponent(
+                ".\(url.lastPathComponent).\(UUID().uuidString).tmp"
+            )
+            temporaryURL = nextTemporaryURL
+            try data.write(to: nextTemporaryURL, options: .atomic)
+            if fileManager.fileExists(atPath: url.path) {
+                _ = try fileManager.replaceItemAt(url, withItemAt: nextTemporaryURL)
+            } else {
+                try fileManager.moveItem(at: nextTemporaryURL, to: url)
+            }
+            return true
+        } catch {
+            if let temporaryURL {
+                try? fileManager.removeItem(at: temporaryURL)
+            }
+            return false
+        }
     }
 }

--- a/packages/menubar/Sources/TokscaleMenuBarCore/LayoutMode.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/LayoutMode.swift
@@ -7,7 +7,7 @@ public enum LayoutMode: String, CaseIterable, Sendable {
     case single
     case paged
 
-    public static let `default`: LayoutMode = .single
+    public static let `default`: LayoutMode = .paged
     public static let storageKey = "popoverLayoutMode"
 
     public init(storedValue: String?) {

--- a/packages/menubar/Sources/TokscaleMenuBarCore/TokscaleSummary.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/TokscaleSummary.swift
@@ -106,6 +106,15 @@ public struct TokscaleSummary: Decodable, Equatable {
         if today.date != localDateString(now: now, calendar: calendar) {
             markStale(reason: "summary-date-mismatch")
         }
+        if let historyGeneratedAt = health.historyGeneratedAt {
+            guard let historyGeneratedAtDate = parseISODate(historyGeneratedAt) else {
+                markStale(reason: "invalid-history-generated-at")
+                return
+            }
+            if now.timeIntervalSince(historyGeneratedAtDate) > 26 * 60 * 60 {
+                markStale(reason: "history-older-than-26h")
+            }
+        }
     }
 
     public func needsRefreshOnOpen(
@@ -129,9 +138,9 @@ public struct TokscaleSummary: Decodable, Equatable {
 
     /// Whether locally-scanned usage (tokens, contribution, daily history) is stale
     /// enough to warrant a full re-scan when the popover opens. Unlike
-    /// `needsRefreshOnOpen`, this looks only at `generatedAt` and ignores quota-only
-    /// refreshes — those never re-scan usage, so frequent background quota updates
-    /// must not mask stale usage data.
+    /// `needsRefreshOnOpen`, this looks at the full-history scan timestamp and ignores
+    /// quota-only and today-only refreshes, so frequent lightweight updates must not
+    /// mask stale history data.
     public func needsScanOnOpen(
         now: Date = Date(),
         minimumInterval: TimeInterval = 60
@@ -139,7 +148,8 @@ public struct TokscaleSummary: Decodable, Equatable {
         if stale {
             return true
         }
-        guard let generatedAtDate = parseISODate(generatedAt) else {
+        let scanGeneratedAt = health.historyGeneratedAt ?? generatedAt
+        guard let generatedAtDate = parseISODate(scanGeneratedAt) else {
             return true
         }
         return now.timeIntervalSince(generatedAtDate) >= minimumInterval
@@ -215,7 +225,7 @@ public struct TokscaleDashboardModel: Equatable {
     private let quotaWasRefreshed: Bool
     private let providerDetailsById: [String: ProviderDetails]
 
-    private static let quotaBoardProviderIds = ["claude", "codex", "gemini"]
+    private static let quotaBoardProviderIds = ["claude", "codex", "gemini", "grok"]
 
     /// Live only when the quota was actually fetched recently; an old timestamp from a
     /// past success (e.g. later refreshes failing) must not keep reading as "Live".
@@ -230,11 +240,24 @@ public struct TokscaleDashboardModel: Equatable {
         let providerRows = Self.providerRows(summary: summary)
         let historyRows = Self.historyRows(summary: summary)
         let weekTrends = Self.weekTrends(historyRows: historyRows)
+        let usesRollingBreakdown = summary.accuracy.sourceKinds.contains(
+            "tokens-ci-rolling-breakdown"
+        )
+        let averageTotalCost = usesRollingBreakdown
+            ? historyRows.reduce(0) { $0 + $1.costUsd }
+            : summary.totals.costUsd
+        let averageActiveDays = usesRollingBreakdown
+            ? summary.history.filter { $0.tokens > 0 }.count
+            : summary.totals.activeDays
+        let averageScope = usesRollingBreakdown ? "last-year account" : "account"
+        let providerTotalCost = usesRollingBreakdown
+            ? providerRows.reduce(0) { $0 + $1.costUsd }
+            : summary.totals.costUsd
         let hasLiveQuotaRefresh = Self.isQuotaRefreshRecent(summary.health.quotaRefreshedAt, now: now)
         quotaWasRefreshed = hasLiveQuotaRefresh
         summaryStale = summary.stale
         clientLabels = providerRows.map { clientDisplayName($0.client) }
-        providers = Self.providerSummaries(rows: providerRows, totalCost: summary.totals.costUsd)
+        providers = Self.providerSummaries(rows: providerRows, totalCost: providerTotalCost)
         providerDetailsById = Dictionary(
             uniqueKeysWithValues: providerRows.map { row in
                 (
@@ -244,10 +267,11 @@ public struct TokscaleDashboardModel: Equatable {
                         title: clientDisplayName(row.client),
                         model: row.topModel ?? "No model data",
                         today: "\(formatUSD(row.todayCostUsd)) · \(formatTokens(row.todayTokens))",
-                        total: "\(formatUSD(row.costUsd)) total",
+                        total: "\(formatUSD(row.costUsd)) \(usesRollingBreakdown ? "last year" : "total")",
                         tokens: formatTokens(row.tokens),
                         messages: "\(row.messages) messages",
-                        share: Self.providerShare(row.costUsd, totalCost: summary.totals.costUsd),
+                        models: row.models,
+                        share: Self.providerShare(row.costUsd, totalCost: providerTotalCost),
                         hasLiveQuotaRefresh: hasLiveQuotaRefresh,
                         cacheHitPercent: row.cacheHitPercent,
                         workTimeMs: row.workTimeMs
@@ -259,8 +283,17 @@ public struct TokscaleDashboardModel: Equatable {
             title: summary.statusTitle,
             subtitle: "\(clientLabels.count) AI clients - local cache",
             state: summary.collapsed.state,
-            progress: Self.progressAgainstDailyAverage(summary: summary),
-            progressLabel: Self.progressLabelAgainstDailyAverage(summary: summary)
+            progress: Self.progressAgainstDailyAverage(
+                todayCost: summary.today.costUsd,
+                totalCost: averageTotalCost,
+                activeDays: averageActiveDays
+            ),
+            progressLabel: Self.progressLabelAgainstDailyAverage(
+                todayCost: summary.today.costUsd,
+                totalCost: averageTotalCost,
+                activeDays: averageActiveDays,
+                scope: averageScope
+            )
         )
         metrics = [
             Panel(
@@ -297,10 +330,16 @@ public struct TokscaleDashboardModel: Equatable {
             return left.costUsd < right.costUsd
         }
         spendHighlights = Self.spendHighlights(summary: summary, currentWeekTrend: weekTrends.current, previousWeekTrend: weekTrends.previous)
-        dailyAverage = Self.dailyAveragePanel(summary: summary)
+        dailyAverage = Self.dailyAveragePanel(
+            totalCost: averageTotalCost,
+            activeDays: averageActiveDays,
+            scope: averageScope
+        )
         allTimeCost = formatUSD(summary.totals.costUsd)
         allTimeTokens = formatTokens(summary.totals.tokens)
-        allTimeDays = "across \(summary.totals.activeDays) active days"
+        allTimeDays = usesRollingBreakdown
+            ? "\(averageActiveDays) active days in the last year"
+            : "across \(summary.totals.activeDays) active days"
         health = HealthStatus(
             title: summary.stale ? "Stale" : "Fresh",
             detail: "Last scan \(formatDuration(milliseconds: summary.health.lastScanDurationMs))",
@@ -327,6 +366,7 @@ public struct TokscaleDashboardModel: Equatable {
             total: "$0.00 total",
             tokens: "0",
             messages: "0 messages",
+            models: [],
             share: 0,
             hasLiveQuotaRefresh: false,
             cacheHitPercent: 0,
@@ -360,6 +400,7 @@ public struct TokscaleDashboardModel: Equatable {
                 total: "$0.00 total",
                 tokens: "0",
                 messages: "0 messages",
+                models: [],
                 share: 0,
                 hasLiveQuotaRefresh: quotaWasRefreshed,
                 cacheHitPercent: 0,
@@ -381,6 +422,7 @@ public struct TokscaleDashboardModel: Equatable {
             id: details.id,
             title: details.title,
             topModel: details.model,
+            modelCostDetail: Self.modelCostDetail(models: details.models, fallback: details.model),
             today: details.today,
             total: details.total,
             tokens: details.tokens,
@@ -414,7 +456,8 @@ public struct TokscaleDashboardModel: Equatable {
                 todayCostUsd: 0,
                 todayTokens: 0,
                 todayMessages: 0,
-                topModel: nil
+                topModel: nil,
+                models: []
             )
         }
     }
@@ -531,13 +574,16 @@ public struct TokscaleDashboardModel: Equatable {
         ]
     }
 
-    private static func dailyAveragePanel(summary: TokscaleSummary) -> Panel {
-        let days = max(summary.totals.activeDays, 1)
-        let average = summary.totals.costUsd / Double(days)
+    private static func dailyAveragePanel(
+        totalCost: Double,
+        activeDays: Int,
+        scope: String
+    ) -> Panel {
+        let average = activeDays > 0 ? totalCost / Double(activeDays) : 0
         return Panel(
             title: "Avg / day",
             value: formatUSD(average),
-            detail: "across \(summary.totals.activeDays) active days"
+            detail: "\(scope) · \(activeDays) active days"
         )
     }
 
@@ -552,27 +598,36 @@ public struct TokscaleDashboardModel: Equatable {
         return "\(percent)% vs prior 7d"
     }
 
-    private static func progressAgainstDailyAverage(summary: TokscaleSummary) -> Double {
-        guard summary.totals.activeDays > 0, summary.totals.costUsd > 0 else {
+    private static func progressAgainstDailyAverage(
+        todayCost: Double,
+        totalCost: Double,
+        activeDays: Int
+    ) -> Double {
+        guard activeDays > 0, totalCost > 0 else {
             return 0
         }
-        let dailyAverage = summary.totals.costUsd / Double(summary.totals.activeDays)
+        let dailyAverage = totalCost / Double(activeDays)
         guard dailyAverage > 0 else {
             return 0
         }
-        return min(summary.today.costUsd / dailyAverage / 2, 1)
+        return min(todayCost / dailyAverage / 2, 1)
     }
 
-    private static func progressLabelAgainstDailyAverage(summary: TokscaleSummary) -> String {
-        guard summary.totals.activeDays > 0, summary.totals.costUsd > 0 else {
+    private static func progressLabelAgainstDailyAverage(
+        todayCost: Double,
+        totalCost: Double,
+        activeDays: Int,
+        scope: String
+    ) -> String {
+        guard activeDays > 0, totalCost > 0 else {
             return "No daily average yet"
         }
-        let dailyAverage = summary.totals.costUsd / Double(summary.totals.activeDays)
+        let dailyAverage = totalCost / Double(activeDays)
         guard dailyAverage > 0 else {
             return "No daily average yet"
         }
-        let percent = Int((summary.today.costUsd / dailyAverage * 100).rounded())
-        return "\(percent)% of daily average"
+        let percent = Int((todayCost / dailyAverage * 100).rounded())
+        return "\(percent)% of \(scope) avg"
     }
 
     private static func focusedModelTimeLabel(providerId: String, model: String) -> String {
@@ -580,6 +635,38 @@ public struct TokscaleDashboardModel: Equatable {
             return "Sonnet-only unavailable"
         }
         return "Model time unavailable"
+    }
+
+    private static func modelCostDetail(models: [TokscaleSummary.ProviderModel], fallback: String) -> String {
+        let activeToday = models
+            .filter { $0.todayCostUsd > 0 || $0.todayTokens > 0 || $0.todayMessages > 0 }
+            .sorted { left, right in
+                if left.todayCostUsd == right.todayCostUsd {
+                    return left.model < right.model
+                }
+                return left.todayCostUsd > right.todayCostUsd
+            }
+        guard let first = activeToday.first else {
+            return fallback
+        }
+        if activeToday.count == 1 {
+            return modelDisplayName(first.model)
+        }
+        return activeToday
+            .prefix(3)
+            .map { "\(modelDisplayName($0.model)) \(formatUSD($0.todayCostUsd))" }
+            .joined(separator: " / ")
+    }
+
+    private static func modelDisplayName(_ model: String) -> String {
+        let normalized = model.lowercased()
+        if normalized.contains("composer") {
+            return "composer"
+        }
+        if normalized == "grok-build" {
+            return "grok"
+        }
+        return model
     }
 }
 
@@ -699,6 +786,7 @@ public extension TokscaleDashboardModel {
         public let total: String
         public let tokens: String
         public let messages: String
+        public let models: [TokscaleSummary.ProviderModel]
         public let share: Double
         public let hasLiveQuotaRefresh: Bool
         public let cacheHitPercent: Double
@@ -709,6 +797,7 @@ public extension TokscaleDashboardModel {
         public let id: String
         public let title: String
         public let topModel: String
+        public let modelCostDetail: String
         public let today: String
         public let total: String
         public let tokens: String
@@ -797,12 +886,13 @@ public extension TokscaleSummary {
         public let todayTokens: Int64
         public let todayMessages: Int
         public let topModel: String?
+        public let models: [ProviderModel]
         public let cacheHitPercent: Double
         public let workTimeMs: Int64
 
         enum CodingKeys: String, CodingKey {
             case client, costUsd, tokens, messages
-            case todayCostUsd, todayTokens, todayMessages, topModel, cacheHitPercent
+            case todayCostUsd, todayTokens, todayMessages, topModel, models, cacheHitPercent
             case workTimeMs
         }
 
@@ -816,6 +906,7 @@ public extension TokscaleSummary {
             todayTokens = try c.decode(Int64.self, forKey: .todayTokens)
             todayMessages = try c.decode(Int.self, forKey: .todayMessages)
             topModel = try c.decodeIfPresent(String.self, forKey: .topModel)
+            models = try c.decodeIfPresent([ProviderModel].self, forKey: .models) ?? []
             cacheHitPercent = try c.decodeIfPresent(Double.self, forKey: .cacheHitPercent) ?? 0
             workTimeMs = try c.decodeIfPresent(Int64.self, forKey: .workTimeMs) ?? 0
         }
@@ -829,6 +920,7 @@ public extension TokscaleSummary {
             todayTokens: Int64,
             todayMessages: Int,
             topModel: String?,
+            models: [ProviderModel] = [],
             cacheHitPercent: Double = 0,
             workTimeMs: Int64 = 0
         ) {
@@ -840,8 +932,37 @@ public extension TokscaleSummary {
             self.todayTokens = todayTokens
             self.todayMessages = todayMessages
             self.topModel = topModel
+            self.models = models
             self.cacheHitPercent = cacheHitPercent
             self.workTimeMs = workTimeMs
+        }
+    }
+
+    struct ProviderModel: Decodable, Equatable {
+        public let model: String
+        public let costUsd: Double
+        public let tokens: Int64
+        public let messages: Int
+        public let todayCostUsd: Double
+        public let todayTokens: Int64
+        public let todayMessages: Int
+
+        public init(
+            model: String,
+            costUsd: Double,
+            tokens: Int64,
+            messages: Int,
+            todayCostUsd: Double,
+            todayTokens: Int64,
+            todayMessages: Int
+        ) {
+            self.model = model
+            self.costUsd = costUsd
+            self.tokens = tokens
+            self.messages = messages
+            self.todayCostUsd = todayCostUsd
+            self.todayTokens = todayTokens
+            self.todayMessages = todayMessages
         }
     }
 
@@ -886,6 +1007,7 @@ public extension TokscaleSummary {
     struct Health: Decodable, Equatable {
         public let summaryPath: String
         public let lastScanDurationMs: Int
+        public let historyGeneratedAt: String?
         public let quotaRefreshedAt: String?
         public let warnings: [String]
     }

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/BackgroundScanPolicyTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/BackgroundScanPolicyTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+
+@testable import TokscaleMenuBarCore
+
+final class BackgroundScanPolicyTests: XCTestCase {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func testRunsFullScanWhenHistoryIsDueAndRetryWindowElapsed() {
+        XCTAssertEqual(
+            BackgroundScanPolicy.nextAction(
+                now: now,
+                lastHistorySuccess: now.addingTimeInterval(-86_400),
+                lastHistoryAttempt: now.addingTimeInterval(-21_600),
+                lastTodayScan: now
+            ),
+            .full
+        )
+    }
+
+    func testRunsTodayScanWhileFailedFullScanIsBackingOff() {
+        XCTAssertEqual(
+            BackgroundScanPolicy.nextAction(
+                now: now,
+                lastHistorySuccess: now.addingTimeInterval(-86_400),
+                lastHistoryAttempt: now.addingTimeInterval(-60),
+                lastTodayScan: now.addingTimeInterval(-600)
+            ),
+            .today
+        )
+    }
+
+    func testFailedHistoryRefreshBacksOffForSixHours() {
+        XCTAssertEqual(
+            BackgroundScanPolicy.nextAction(
+                now: now,
+                lastHistorySuccess: now.addingTimeInterval(-86_400),
+                lastHistoryAttempt: now.addingTimeInterval(-21_599),
+                lastTodayScan: now
+            ),
+            .none
+        )
+    }
+
+    func testDoesNothingWhenNeitherScanIsDue() {
+        XCTAssertEqual(
+            BackgroundScanPolicy.nextAction(
+                now: now,
+                lastHistorySuccess: now,
+                lastHistoryAttempt: now,
+                lastTodayScan: now
+            ),
+            .none
+        )
+    }
+
+    func testRestoresTodayAndHistoryDatesFromSummary() throws {
+        let restored = try XCTUnwrap(
+            BackgroundScanPolicy.restoredScanDates(
+                generatedAt: "2026-07-13T03:01:02.123Z",
+                historyGeneratedAt: "2026-07-13T02:00:00Z"
+            )
+        )
+
+        XCTAssertEqual(restored.today.timeIntervalSince1970, 1_783_911_662.123, accuracy: 0.001)
+        XCTAssertEqual(restored.history.timeIntervalSince1970, 1_783_908_000, accuracy: 0.001)
+    }
+
+    func testRestoredHistoryFallsBackToGeneratedAtForLegacySummary() throws {
+        let restored = try XCTUnwrap(
+            BackgroundScanPolicy.restoredScanDates(
+                generatedAt: "2026-07-13T03:01:02Z",
+                historyGeneratedAt: nil
+            )
+        )
+
+        XCTAssertEqual(restored.history, restored.today)
+    }
+
+    func testQuotaOpenRefreshCoalescesRapidOpenEvents() {
+        XCTAssertTrue(
+            BackgroundScanPolicy.shouldRefreshQuotaOnOpen(
+                needsRefresh: true,
+                isRefreshing: false,
+                now: now,
+                lastAttempt: .distantPast
+            )
+        )
+        for seconds in 1...10 {
+            XCTAssertFalse(
+                BackgroundScanPolicy.shouldRefreshQuotaOnOpen(
+                    needsRefresh: true,
+                    isRefreshing: false,
+                    now: now.addingTimeInterval(TimeInterval(seconds)),
+                    lastAttempt: now
+                )
+            )
+        }
+        XCTAssertTrue(
+            BackgroundScanPolicy.shouldRefreshQuotaOnOpen(
+                needsRefresh: true,
+                isRefreshing: false,
+                now: now.addingTimeInterval(120),
+                lastAttempt: now
+            )
+        )
+    }
+
+    func testRemoteHistoryFailureFallsBackToFullLocalScan() {
+        XCTAssertEqual(
+            BackgroundScanPolicy.actionAfterRemoteHistorySync(succeeded: false),
+            .full
+        )
+    }
+
+    func testRemoteHistorySuccessOnlyNeedsTodayScan() {
+        XCTAssertEqual(
+            BackgroundScanPolicy.actionAfterRemoteHistorySync(succeeded: true),
+            .today
+        )
+    }
+}

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/ContributionCalendarGridTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/ContributionCalendarGridTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import TokscaleMenuBarCore
+
+final class ContributionCalendarGridTests: XCTestCase {
+    func testBuildsExactly365CalendarDaysEndingAtExplicitDate() throws {
+        let grid = ContributionCalendarGrid.build(
+            days: [
+                (date: "2025-07-13", costUsd: 999),
+                (date: "2025-07-14", costUsd: 1),
+                (date: "2026-07-13", costUsd: 100),
+                (date: "2026-07-14", costUsd: 999),
+            ],
+            endDate: "2026-07-13"
+        )
+        let cells = grid.flatMap { $0 }
+
+        XCTAssertEqual(grid.count, 53)
+        XCTAssertTrue(grid.allSatisfy { $0.count == 7 })
+        XCTAssertEqual(cells.count, 371)
+        XCTAssertEqual(cells[0], -1)
+        XCTAssertEqual(cells[1], 1)
+        XCTAssertEqual(cells[365], 4)
+        XCTAssertEqual(Array(cells[366...370]), [-1, -1, -1, -1, -1])
+    }
+
+    func testEndDateDoesNotCollapseToLastActiveDay() {
+        let grid = ContributionCalendarGrid.build(
+            days: [(date: "2026-07-03", costUsd: 10)],
+            endDate: "2026-07-13"
+        )
+        let cells = grid.flatMap { $0 }
+
+        XCTAssertEqual(cells[355], 1)
+        XCTAssertEqual(cells[365], 0)
+        XCTAssertEqual(Array(cells.suffix(5)), [-1, -1, -1, -1, -1])
+    }
+}

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/GraphCompanionAdapterTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/GraphCompanionAdapterTests.swift
@@ -75,6 +75,135 @@ final class GraphCompanionAdapterTests: XCTestCase {
         return try TokscaleSummary.decode(companion)
     }
 
+    private func remoteProfile(dayOneTokens: Int64, dayTwoTokens: Int64) -> Data {
+        let total = dayOneTokens + dayTwoTokens
+        let dayOneCost = Double(dayOneTokens) / 100
+        let dayTwoCost = Double(dayTwoTokens) / 100
+        let totalCost = dayOneCost + dayTwoCost
+        return Data(
+            """
+            {
+              "stats": { "totalTokens": \(total), "totalCost": \(totalCost), "activeDays": 2 },
+              "dateRange": { "start": "2026-06-06", "end": "2026-06-07" },
+              "clients": ["claude"], "models": ["remote-model"],
+              "contributions": [
+                {
+                  "date": "2026-06-06", "intensity": 2,
+                  "totals": { "tokens": \(dayOneTokens), "cost": \(dayOneCost), "messages": 0 },
+                  "clients": [{
+                    "client": "claude", "modelId": "", "cost": \(dayOneCost), "messages": 4,
+                    "tokens": { "input": \(dayOneTokens), "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 },
+                    "models": { "remote-model": { "cost": \(dayOneCost), "input": \(dayOneTokens), "output": 0, "messages": 4, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }
+                  }]
+                },
+                {
+                  "date": "2026-06-07", "intensity": 4,
+                  "totals": { "tokens": \(dayTwoTokens), "cost": \(dayTwoCost), "messages": 0 },
+                  "clients": [{
+                    "client": "claude", "modelId": "", "cost": \(dayTwoCost), "messages": 5,
+                    "tokens": { "input": \(dayTwoTokens), "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 },
+                    "models": { "remote-model": { "cost": \(dayTwoCost), "input": \(dayTwoTokens), "output": 0, "messages": 5, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }
+                  }]
+                }
+              ]
+            }
+            """.utf8
+        )
+    }
+
+    private func remoteProfileData(
+        days: [(date: String, tokens: Int64)],
+        allTime: (tokens: Int64, cost: Double, activeDays: Int)? = nil,
+        allTimeStart: String? = nil
+    ) throws -> Data {
+        let contributions: [[String: Any]] = days.map { day in
+            let cost = Double(day.tokens) / 100
+            return [
+                "date": day.date,
+                "intensity": day.tokens > 0 ? 2 : 0,
+                "totals": ["tokens": day.tokens, "cost": cost, "messages": 0],
+                "clients": [[
+                    "client": "claude",
+                    "modelId": "",
+                    "cost": cost,
+                    "messages": day.tokens > 0 ? 1 : 0,
+                    "tokens": [
+                        "input": day.tokens, "output": 0, "cacheRead": 0,
+                        "cacheWrite": 0, "reasoning": 0,
+                    ],
+                    "models": [
+                        "remote-model": [
+                            "cost": cost, "input": day.tokens, "output": 0,
+                            "messages": day.tokens > 0 ? 1 : 0, "cacheRead": 0,
+                            "cacheWrite": 0, "reasoning": 0,
+                        ]
+                    ],
+                ]],
+            ]
+        }
+        let rollingTokens = days.reduce(Int64(0)) { $0 + $1.tokens }
+        let rollingCost = days.reduce(0.0) { $0 + Double($1.tokens) / 100 }
+        let rollingActiveDays = days.filter { $0.tokens > 0 }.count
+        let windowStart = try XCTUnwrap(allTimeStart ?? days.first?.date)
+        let windowEnd = try XCTUnwrap(days.last?.date)
+        return try JSONSerialization.data(withJSONObject: [
+            "stats": [
+                "totalTokens": allTime?.tokens ?? rollingTokens,
+                "totalCost": allTime?.cost ?? rollingCost,
+                "activeDays": allTime?.activeDays ?? rollingActiveDays,
+            ],
+            "dateRange": [
+                "start": windowStart,
+                "end": windowEnd,
+            ],
+            "clients": ["claude"],
+            "models": ["remote-model"],
+            "contributions": contributions,
+        ])
+    }
+
+    private func replacingLocalDailyTokens(
+        in companion: Data,
+        with values: [String: Int64]
+    ) throws -> Data {
+        var dict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: companion) as? [String: Any]
+        )
+        var localDaily = try XCTUnwrap(dict["localDaily"] as? [[String: Any]])
+        for index in localDaily.indices {
+            guard let date = localDaily[index]["date"] as? String,
+                let tokens = values[date],
+                var totals = localDaily[index]["totals"] as? [String: Any]
+            else { continue }
+            totals["tokens"] = tokens
+            localDaily[index]["totals"] = totals
+        }
+        dict["localDaily"] = localDaily
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+
+    private func addingLocalBaseline(
+        to companion: Data,
+        dates: [String],
+        tokens: Int64
+    ) throws -> Data {
+        var dict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: companion) as? [String: Any]
+        )
+        var localDaily = try XCTUnwrap(dict["localDaily"] as? [[String: Any]])
+        let template = try XCTUnwrap(localDaily.first)
+        for date in dates {
+            var row = template
+            row["date"] = date
+            var totals = try XCTUnwrap(row["totals"] as? [String: Any])
+            totals["tokens"] = tokens
+            row["totals"] = totals
+            localDaily.append(row)
+        }
+        dict["localDaily"] = localDaily
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+
     func testTotalsPassThroughFromGraphSummary() throws {
         let summary = try makeSummary(usage: Data(usageJSON.utf8))
         XCTAssertEqual(summary.totals.tokens, 3500)
@@ -82,6 +211,12 @@ final class GraphCompanionAdapterTests: XCTestCase {
         XCTAssertEqual(summary.totals.activeDays, 2)
         XCTAssertEqual(summary.totals.models, 2)
         XCTAssertEqual(summary.totals.clients, ["claude", "codex"])
+        XCTAssertEqual(summary.health.historyGeneratedAt, "2026-06-07T03:00:00+00:00")
+    }
+
+    func testGraphValidationRejectsMalformedWrapperOutput() {
+        XCTAssertTrue(GraphCompanionAdapter.isValidGraphData(Data(graphJSON.utf8)))
+        XCTAssertFalse(GraphCompanionAdapter.isValidGraphData(Data(#"{"status":"ok"}"#.utf8)))
     }
 
     func testTodayPicksTheRightDay() throws {
@@ -105,6 +240,64 @@ final class GraphCompanionAdapterTests: XCTestCase {
         XCTAssertEqual(claude.topModel, "claude-opus-4-8")
         XCTAssertEqual(summary.providers[1].client, "codex")
         XCTAssertEqual(summary.providers[1].costUsd, 5.0, accuracy: 0.001)
+    }
+
+    func testProvidersExposePerModelBreakdown() throws {
+        let graphJSON = """
+        {
+          "meta": { "generatedAt": "2026-06-07T03:00:00+00:00", "version": "3.0.3",
+                    "dateRange": { "start": "2026-06-06", "end": "2026-06-07" } },
+          "summary": {
+            "totalTokens": 2500, "totalCost": 2.5, "activeDays": 2,
+            "averagePerDay": 1.25, "maxCostInSingleDay": 1.75,
+            "clients": ["grok"],
+            "models": ["grok-build", "grok-composer-2.5-fast"]
+          },
+          "years": [],
+          "contributions": [
+            {
+              "date": "2026-06-06", "intensity": 2,
+              "totals": { "tokens": 1000, "cost": 0.75, "messages": 4 },
+              "clients": [
+                { "client": "grok", "modelId": "grok-build", "providerId": "xai",
+                  "cost": 0.75, "messages": 4,
+                  "tokens": { "input": 1000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }
+              ]
+            },
+            {
+              "date": "2026-06-07", "intensity": 4,
+              "totals": { "tokens": 1500, "cost": 1.75, "messages": 9 },
+              "clients": [
+                { "client": "grok", "modelId": "grok-build", "providerId": "xai",
+                  "cost": 1.25, "messages": 6,
+                  "tokens": { "input": 1000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } },
+                { "client": "grok", "modelId": "grok-composer-2.5-fast", "providerId": "xai",
+                  "cost": 0.5, "messages": 3,
+                  "tokens": { "input": 500, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }
+              ]
+            }
+          ]
+        }
+        """
+        let companion = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 123,
+            quotaRefreshedAt: nil
+        )
+
+        let summary = try TokscaleSummary.decode(companion)
+        let grok = try XCTUnwrap(summary.providers.first)
+
+        XCTAssertEqual(grok.client, "grok")
+        XCTAssertEqual(grok.topModel, "grok-build")
+        XCTAssertEqual(grok.models.map(\.model), ["grok-build", "grok-composer-2.5-fast"])
+        XCTAssertEqual(grok.models[0].costUsd, 2.0, accuracy: 0.001)
+        XCTAssertEqual(grok.models[0].todayCostUsd, 1.25, accuracy: 0.001)
+        XCTAssertEqual(grok.models[1].costUsd, 0.5, accuracy: 0.001)
+        XCTAssertEqual(grok.models[1].todayCostUsd, 0.5, accuracy: 0.001)
     }
 
     func testQuotaFromUsageDropsEmptyProviders() throws {
@@ -133,6 +326,51 @@ final class GraphCompanionAdapterTests: XCTestCase {
 
     func testTopClientByCost() throws {
         let summary = try makeSummary(usage: Data(usageJSON.utf8))
+        XCTAssertEqual(summary.top.client, "claude")
+        XCTAssertEqual(summary.top.model, "claude-opus-4-8")
+    }
+
+    func testTopModelBelongsToTopClient() throws {
+        let graph = """
+            {
+              "meta": { "generatedAt": "2026-06-07T03:00:00+00:00", "version": "3.0.3",
+                        "dateRange": { "start": "2026-06-07", "end": "2026-06-07" } },
+              "summary": {
+                "totalTokens": 2200, "totalCost": 220.0, "activeDays": 1,
+                "averagePerDay": 220.0, "maxCostInSingleDay": 220.0,
+                "clients": ["claude", "codex"],
+                "models": ["claude-opus-4-8", "claude-fable-5", "gpt-5.5"]
+              },
+              "years": [],
+              "contributions": [
+                {
+                  "date": "2026-06-07", "intensity": 4,
+                  "totals": { "tokens": 2200, "cost": 220.0, "messages": 22 },
+                  "clients": [
+                    { "client": "claude", "modelId": "claude-opus-4-8", "providerId": "anthropic",
+                      "cost": 70.0, "messages": 7,
+                      "tokens": { "input": 700, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } },
+                    { "client": "claude", "modelId": "claude-fable-5", "providerId": "anthropic",
+                      "cost": 50.0, "messages": 5,
+                      "tokens": { "input": 500, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } },
+                    { "client": "codex", "modelId": "gpt-5.5", "providerId": "openai",
+                      "cost": 100.0, "messages": 10,
+                      "tokens": { "input": 1000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }
+                  ]
+                }
+              ]
+            }
+            """
+        let companion = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graph.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let summary = try TokscaleSummary.decode(companion)
+
         XCTAssertEqual(summary.top.client, "claude")
         XCTAssertEqual(summary.top.model, "claude-opus-4-8")
     }
@@ -180,6 +418,655 @@ final class GraphCompanionAdapterTests: XCTestCase {
         XCTAssertEqual(summary.quota.count, 1)
         XCTAssertEqual(summary.quota[0].provider, "Claude")
         XCTAssertEqual(summary.health.quotaRefreshedAt, "2026-06-07T04:00:00+00:00")
+    }
+
+    func testRemoteProfileKeepsAccountAggregatesWhileLocalTodayWinsPresentation() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: Data(usageJSON.utf8),
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 123,
+            quotaRefreshedAt: "2026-06-07T03:01:00+00:00"
+        )
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: remoteProfile(dayOneTokens: 1600, dayTwoTokens: 2200),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+
+        XCTAssertEqual(summary.totals.tokens, 3800)
+        XCTAssertEqual(summary.totals.costUsd, 38, accuracy: 0.001)
+        XCTAssertEqual(summary.history.map(\.tokens), [1600, 2200])
+        XCTAssertEqual(summary.today.tokens, 2000)
+        XCTAssertEqual(summary.providers.first?.tokens, 3800)
+        XCTAssertEqual(summary.providers.first?.todayTokens, 2000)
+        XCTAssertEqual(summary.quota.count, 1)
+        XCTAssertEqual(summary.health.historyGeneratedAt, "2026-06-07T04:00:00Z")
+        XCTAssertEqual(summary.accuracy.sourceKinds, ["tokens-ci", "local-today"])
+        XCTAssertNil(summary.subagents)
+    }
+
+    func testRepeatedRemoteSyncDoesNotPromoteRemoteTodayToLocalPresentation() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let first = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: try remoteProfileData(days: [
+                    ("2026-06-06", 1600), ("2026-06-08", 2200),
+                ]),
+                todayDate: "2026-06-08",
+                syncedAt: "2026-06-08T01:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let second = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: first,
+                profileData: try remoteProfileData(days: [
+                    ("2026-06-06", 1600), ("2026-06-08", 3300),
+                ]),
+                todayDate: "2026-06-08",
+                syncedAt: "2026-06-08T02:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let summary = try TokscaleSummary.decode(second)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: second) as? [String: Any]
+        )
+        let provenance = try XCTUnwrap(json["historyProvenance"] as? [String: Any])
+
+        XCTAssertEqual(summary.today.tokens, 3300)
+        XCTAssertEqual(summary.totals.tokens, 4900)
+        XCTAssertEqual(summary.history.map(\.tokens), [1600, 3300])
+        XCTAssertEqual(summary.accuracy.sourceKinds, ["tokens-ci"])
+        XCTAssertEqual(provenance["localTodayDate"] as? String, "2026-06-07")
+    }
+
+    func testRemoteProfileAcceptsAccountTotalsFarAboveLocalDevice() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 123,
+            quotaRefreshedAt: nil
+        )
+        let adjustedTotals = try replacingLocalDailyTokens(
+            in: full,
+            with: ["2026-06-06": 800_000_000, "2026-06-07": 987_000_000]
+        )
+        let adjusted = try addingLocalBaseline(
+            to: adjustedTotals,
+            dates: ["2026-06-01", "2026-06-02", "2026-06-03", "2026-06-04", "2026-06-05"],
+            tokens: 1_000_000_000
+        )
+
+        XCTAssertNotNil(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: adjusted,
+                profileData: try remoteProfileData(days: [
+                    ("2026-06-01", 1_000_000_000), ("2026-06-02", 1_000_000_000),
+                    ("2026-06-03", 1_000_000_000), ("2026-06-04", 1_000_000_000),
+                    ("2026-06-05", 1_000_000_000), ("2026-06-06", 5_700_000_000),
+                    ("2026-06-07", 14_500_000_000),
+                ]),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+    }
+
+    func testRemoteProfileAllowsPlausibleMultiDeviceOverlap() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let adjusted = try replacingLocalDailyTokens(
+            in: full,
+            with: ["2026-06-06": 100_000_000, "2026-06-07": 100_000_000]
+        )
+
+        XCTAssertNotNil(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: adjusted,
+                profileData: try remoteProfileData(days: [
+                    ("2026-06-06", 700_000_000), ("2026-06-07", 700_000_000),
+                ]),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+    }
+
+    func testRemoteProfileReplacesWindowAndDropsAgedOutDay() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let first = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: try remoteProfileData(days: [
+                    ("2026-06-05", 500), ("2026-06-06", 1500), ("2026-06-07", 2000),
+                ]),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let second = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: first,
+                profileData: try remoteProfileData(days: [
+                    ("2026-06-06", 1500), ("2026-06-07", 2000),
+                ], allTime: (tokens: 4000, cost: 40, activeDays: 3),
+                    allTimeStart: "2026-06-05"),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-08T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let summary = try TokscaleSummary.decode(second)
+
+        XCTAssertEqual(summary.history.map(\.date), ["2026-06-06", "2026-06-07"])
+        XCTAssertEqual(summary.history.map(\.tokens), [1500, 2000])
+        XCTAssertEqual(summary.totals.tokens, 4000)
+    }
+
+    func testRemoteProfileReplacementDoesNotKeepDeletedMiddleDay() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let first = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: try remoteProfileData(days: [
+                    ("2026-06-05", 500), ("2026-06-06", 1500), ("2026-06-07", 2000),
+                ]),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let second = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: first,
+                profileData: try remoteProfileData(
+                    days: [("2026-06-05", 500), ("2026-06-07", 2000)]
+                ),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-08T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let summary = try TokscaleSummary.decode(second)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: second) as? [String: Any]
+        )
+        let remoteDaily = try XCTUnwrap(json["remoteDaily"] as? [[String: Any]])
+
+        XCTAssertEqual(summary.history.map(\.date), ["2026-06-05", "2026-06-07"])
+        XCTAssertEqual(remoteDaily.compactMap { $0["date"] as? String }, [
+            "2026-06-05", "2026-06-07",
+        ])
+    }
+
+    func testRemoteProfileDoesNotMixUnsubmittedLocalYesterdayIntoAccountHistory() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: try remoteProfileData(days: [("2026-06-06", 1600)]),
+                todayDate: "2026-06-08",
+                syncedAt: "2026-06-08T00:05:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+
+        XCTAssertEqual(summary.history.map(\.date), ["2026-06-06"])
+        XCTAssertEqual(summary.history.map(\.tokens), [1600])
+        XCTAssertEqual(summary.today.date, "2026-06-08")
+        XCTAssertEqual(summary.today.tokens, 0)
+        XCTAssertEqual(summary.totals.tokens, 1600)
+        XCTAssertEqual(summary.totals.activeDays, 1)
+        XCTAssertEqual(summary.accuracy.sourceKinds, ["tokens-ci"])
+    }
+
+    func testRemoteProfileDoesNotCompareIndividualDaysAgainstLocalDevice() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let adjustedTotals = try replacingLocalDailyTokens(
+            in: full,
+            with: ["2026-06-06": 800_000_000, "2026-06-07": 1_000_000_000]
+        )
+        let adjusted = try addingLocalBaseline(
+            to: adjustedTotals,
+            dates: ["2026-06-01", "2026-06-02", "2026-06-03", "2026-06-04", "2026-06-05"],
+            tokens: 1_000_000_000
+        )
+
+        XCTAssertNotNil(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: adjusted,
+                profileData: try remoteProfileData(days: [
+                    ("2026-06-01", 1_000_000_000), ("2026-06-02", 1_000_000_000),
+                    ("2026-06-03", 1_000_000_000), ("2026-06-04", 1_000_000_000),
+                    ("2026-06-05", 1_000_000_000), ("2026-06-06", 5_700_000_000),
+                    ("2026-06-07", 0),
+                ]),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+    }
+
+    func testRemoteProfileUsesAllTimeStatsWithRollingContributions() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: try remoteProfileData(
+                    days: [("2026-06-06", 1600), ("2026-06-07", 2200)],
+                    allTime: (tokens: 10_000, cost: 100, activeDays: 2),
+                    allTimeStart: "2025-01-01"
+                ),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+        let dashboard = TokscaleDashboardModel(summary: summary)
+
+        XCTAssertEqual(summary.totals.tokens, 10_000)
+        XCTAssertEqual(summary.totals.costUsd, 100, accuracy: 0.001)
+        XCTAssertEqual(summary.totals.activeDays, 2)
+        XCTAssertEqual(summary.history.map(\.tokens), [1600, 2200])
+        XCTAssertTrue(summary.accuracy.sourceKinds.contains("tokens-ci-rolling-breakdown"))
+        XCTAssertTrue(dashboard.providerFocus(for: "claude").total.contains("last year"))
+        XCTAssertEqual(dashboard.allTimeDays, "2 active days in the last year")
+        XCTAssertEqual(dashboard.dailyAverage.value, "$19.00")
+        XCTAssertEqual(dashboard.dailyAverage.detail, "last-year account · 2 active days")
+        XCTAssertEqual(dashboard.hero.progressLabel, "105% of last-year account avg")
+    }
+
+    func testRemoteProfileRejectsRollingTotalsAboveAllTimeStats() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+
+        XCTAssertNil(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: try remoteProfileData(
+                    days: [("2026-06-06", 1500)],
+                    allTime: (tokens: 1499, cost: 14.99, activeDays: 2)
+                ),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+    }
+
+    func testRemoteProfileAcceptsLegacyCacheWithoutLocalSnapshotMarker() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        var dict = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: full) as? [String: Any]
+        )
+        var provenance = try XCTUnwrap(dict["historyProvenance"] as? [String: Any])
+        provenance.removeValue(forKey: "localSnapshotComplete")
+        dict["historyProvenance"] = provenance
+
+        XCTAssertNotNil(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: try JSONSerialization.data(withJSONObject: dict),
+                profileData: remoteProfile(dayOneTokens: 1600, dayTwoTokens: 2200),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+    }
+
+    func testRemoteProfileRejectsStatsContributionMismatch() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        var profile = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: try remoteProfileData(days: [("2026-06-06", 1500)])
+            ) as? [String: Any]
+        )
+        var stats = try XCTUnwrap(profile["stats"] as? [String: Any])
+        stats["totalTokens"] = 1501
+        profile["stats"] = stats
+
+        XCTAssertNil(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: try JSONSerialization.data(withJSONObject: profile),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+    }
+
+    func testSummaryMutationCoordinatorPreservesConcurrentPatches() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let summaryURL = directory.appendingPathComponent("summary.json")
+        let coordinator = SummaryMutationCoordinator(label: "test.summary-mutations")
+        XCTAssertTrue(
+            coordinator.replace(
+                summaryURL: summaryURL,
+                with: Data(#"{"today":0,"quota":0}"#.utf8)
+            )
+        )
+        let group = DispatchGroup()
+        group.enter()
+        DispatchQueue.global().async {
+            _ = coordinator.mutate(summaryURL: summaryURL) { latest in
+                guard var dict = try? JSONSerialization.jsonObject(with: latest) as? [String: Any]
+                else { return nil }
+                dict["today"] = 42
+                return try? JSONSerialization.data(withJSONObject: dict)
+            }
+            group.leave()
+        }
+        group.enter()
+        DispatchQueue.global().async {
+            _ = coordinator.mutate(summaryURL: summaryURL) { latest in
+                guard var dict = try? JSONSerialization.jsonObject(with: latest) as? [String: Any]
+                else { return nil }
+                dict["quota"] = 88
+                return try? JSONSerialization.data(withJSONObject: dict)
+            }
+            group.leave()
+        }
+        XCTAssertEqual(group.wait(timeout: .now() + 5), .success)
+        let final = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: summaryURL)) as? [String: Any]
+        )
+
+        XCTAssertEqual(final["today"] as? Int, 42)
+        XCTAssertEqual(final["quota"] as? Int, 88)
+    }
+
+    func testTodayPatchUpdatesPresentationWithoutChangingRemoteAggregates() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 123,
+            quotaRefreshedAt: nil
+        )
+        let remote = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: remoteProfile(dayOneTokens: 1600, dayTwoTokens: 2200),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T04:00:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let todayGraph = Data(
+            """
+            {
+              "meta": { "generatedAt": "2026-06-07T09:00:00Z" },
+              "summary": { "totalTokens": 5000, "totalCost": 50, "activeDays": 1, "clients": ["claude"], "models": ["remote-model"] },
+              "contributions": [{
+                "date": "2026-06-07", "intensity": 4,
+                "totals": { "tokens": 5000, "cost": 50, "messages": 10 },
+                "clients": [{ "client": "claude", "modelId": "remote-model", "cost": 50, "messages": 10, "tokens": { "input": 5000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }]
+              }]
+            }
+            """.utf8
+        )
+        _ = try GraphCompanionAdapter.companionJSON(
+            graphData: todayGraph,
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "",
+            lastScanDurationMs: 0,
+            quotaRefreshedAt: nil
+        )
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchTodayData(
+                companionData: remote,
+                todayGraphData: todayGraph,
+                todayDate: "2026-06-07"
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+        let patchedJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: patched) as? [String: Any]
+        )
+        let localDaily = try XCTUnwrap(patchedJSON["localDaily"] as? [[String: Any]])
+        let localToday = try XCTUnwrap(
+            localDaily.first { ($0["date"] as? String) == "2026-06-07" }
+        )
+        let localTodayTotals = try XCTUnwrap(localToday["totals"] as? [String: Any])
+
+        XCTAssertEqual(summary.today.tokens, 5000)
+        XCTAssertEqual(summary.totals.tokens, 3800)
+        XCTAssertEqual(summary.history.map(\.tokens), [1600, 2200])
+        XCTAssertEqual(summary.providers.first?.tokens, 3800)
+        XCTAssertEqual(summary.providers.first?.todayTokens, 5000)
+        XCTAssertEqual((localTodayTotals["tokens"] as? NSNumber)?.int64Value, 5000)
+    }
+
+    func testTodayPatchAcrossMidnightKeepsRemoteAggregatesAndAddsLocalPresentation() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 123,
+            quotaRefreshedAt: nil
+        )
+        let remote = try XCTUnwrap(
+            GraphCompanionAdapter.patchRemoteProfile(
+                companionData: full,
+                profileData: remoteProfile(dayOneTokens: 1600, dayTwoTokens: 2200),
+                todayDate: "2026-06-07",
+                syncedAt: "2026-06-07T23:59:00Z",
+                lastScanDurationMs: 20
+            )
+        )
+        let nextDayGraph = Data(
+            """
+            {
+              "meta": { "generatedAt": "2026-06-08T00:10:00Z" },
+              "summary": { "totalTokens": 5000, "totalCost": 50, "activeDays": 1, "clients": ["codex"], "models": ["gpt-local"] },
+              "contributions": [{
+                "date": "2026-06-08", "intensity": 4,
+                "totals": { "tokens": 5000, "cost": 50, "messages": 10 },
+                "clients": [{ "client": "codex", "modelId": "gpt-local", "cost": 50, "messages": 10, "tokens": { "input": 5000, "output": 0, "cacheRead": 0, "cacheWrite": 0, "reasoning": 0 } }]
+              }],
+              "todayWorkTime": { "codex": 3600000 }
+            }
+            """.utf8
+        )
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchTodayData(
+                companionData: remote,
+                todayGraphData: nextDayGraph,
+                todayDate: "2026-06-08"
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+        let remoteProvider = try XCTUnwrap(
+            summary.providers.first { $0.client == "claude" }
+        )
+        let localProvider = try XCTUnwrap(
+            summary.providers.first { $0.client == "codex" }
+        )
+        let localModel = try XCTUnwrap(
+            localProvider.models.first { $0.model == "gpt-local" }
+        )
+
+        XCTAssertEqual(summary.today.date, "2026-06-08")
+        XCTAssertEqual(summary.today.tokens, 5000)
+        XCTAssertEqual(summary.totals.tokens, 3800)
+        XCTAssertEqual(summary.totals.costUsd, 38, accuracy: 0.001)
+        XCTAssertEqual(summary.totals.activeDays, 2)
+        XCTAssertEqual(summary.history.map(\.date), ["2026-06-06", "2026-06-07"])
+        XCTAssertEqual(summary.history.map(\.tokens), [1600, 2200])
+        XCTAssertEqual(remoteProvider.tokens, 3800)
+        XCTAssertEqual(remoteProvider.todayTokens, 0)
+        XCTAssertEqual(localProvider.tokens, 0)
+        XCTAssertEqual(localProvider.todayTokens, 5000)
+        XCTAssertEqual(localProvider.workTimeMs, 3_600_000)
+        XCTAssertEqual(localModel.tokens, 0)
+        XCTAssertEqual(localModel.todayTokens, 5000)
+    }
+
+    func testTodayPatchCanClearSameDayWithoutLeavingLocalGhost() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let emptyToday = Data(
+            """
+            {
+              "meta": { "generatedAt": "2026-06-07T10:00:00Z" },
+              "summary": { "totalTokens": 0, "totalCost": 0, "activeDays": 0, "clients": [], "models": [] },
+              "contributions": []
+            }
+            """.utf8
+        )
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchTodayData(
+                companionData: full,
+                todayGraphData: emptyToday,
+                todayDate: "2026-06-07"
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: patched) as? [String: Any]
+        )
+        let localDaily = try XCTUnwrap(json["localDaily"] as? [[String: Any]])
+
+        XCTAssertEqual(summary.today.tokens, 0)
+        XCTAssertEqual(summary.totals.tokens, 1500)
+        XCTAssertEqual(summary.totals.activeDays, 1)
+        XCTAssertEqual(summary.history.map(\.date), ["2026-06-06"])
+        XCTAssertFalse(localDaily.contains { ($0["date"] as? String) == "2026-06-07" })
+    }
+
+    func testEmptyTodayPatchRecordsLocalProvenanceOnNewDay() throws {
+        let full = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let emptyToday = Data(
+            """
+            {
+              "meta": { "generatedAt": "2026-06-08T00:10:00Z" },
+              "summary": { "totalTokens": 0, "totalCost": 0, "activeDays": 0, "clients": [], "models": [] },
+              "contributions": []
+            }
+            """.utf8
+        )
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchTodayData(
+                companionData: full,
+                todayGraphData: emptyToday,
+                todayDate: "2026-06-08"
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: patched) as? [String: Any]
+        )
+        let provenance = try XCTUnwrap(json["historyProvenance"] as? [String: Any])
+
+        XCTAssertEqual(summary.today.date, "2026-06-08")
+        XCTAssertEqual(summary.today.tokens, 0)
+        XCTAssertEqual(provenance["localTodayDate"] as? String, "2026-06-08")
     }
 
     // Claude pattern: almost every token is cache (reads + first-time writes), fresh
@@ -275,10 +1162,9 @@ final class GraphCompanionAdapterTests: XCTestCase {
         XCTAssertEqual(dashboard.providerFocus(for: "codex").workTime, "45m")
     }
 
-    // The menu bar's cheap "today" refresh: a today-only scan patches today's
-    // spend + work time over the existing summary, leaving all-time totals,
-    // per-provider lifetime cost, and quota owned by the slow full scan.
-    func testPatchTodayDataRefreshesTodayButKeepsHistory() throws {
+    // The menu bar's cheap "today" refresh replaces the same calendar day in every
+    // aggregate while preserving older history and quota.
+    func testPatchTodayDataRefreshesTodayAndKeepsHistoryConsistent() throws {
         let full = try GraphCompanionAdapter.companionJSON(
             graphData: Data(graphJSON.utf8),
             usageData: Data(usageJSON.utf8),
@@ -318,16 +1204,24 @@ final class GraphCompanionAdapterTests: XCTestCase {
         )
         let summary = try TokscaleSummary.decode(patched)
         // Today panel refreshed to the today-only numbers.
+        XCTAssertEqual(summary.generatedAt, "2026-06-07T09:00:00+00:00")
+        XCTAssertEqual(summary.health.historyGeneratedAt, "2026-06-07T03:00:00+00:00")
         XCTAssertEqual(summary.today.costUsd, 50.0, accuracy: 0.001)
         XCTAssertEqual(summary.today.tokens, 5000)
-        // All-time totals untouched (still the full scan's 3500 / 35).
-        XCTAssertEqual(summary.totals.tokens, 3500)
-        XCTAssertEqual(summary.totals.costUsd, 35.0, accuracy: 0.001)
-        // Claude: today refreshed + work time set; lifetime cost preserved (30).
+        XCTAssertEqual(summary.totals.tokens, 6500)
+        XCTAssertEqual(summary.totals.costUsd, 65.0, accuracy: 0.001)
+        XCTAssertEqual(summary.history.map(\.tokens), [1500, 5000])
         let claude = try XCTUnwrap(summary.providers.first { $0.client == "claude" })
         XCTAssertEqual(claude.todayCostUsd, 50.0, accuracy: 0.001)
         XCTAssertEqual(claude.workTimeMs, 3_600_000)
-        XCTAssertEqual(claude.costUsd, 30.0, accuracy: 0.001)
+        XCTAssertEqual(claude.costUsd, 60.0, accuracy: 0.001)
+        let claudeModel = try XCTUnwrap(claude.models.first)
+        XCTAssertEqual(claudeModel.costUsd, 60.0, accuracy: 0.001)
+        XCTAssertEqual(claudeModel.todayCostUsd, 50.0, accuracy: 0.001)
+        let codex = try XCTUnwrap(summary.providers.first { $0.client == "codex" })
+        XCTAssertEqual(codex.todayCostUsd, 0, accuracy: 0.001)
+        let codexModel = try XCTUnwrap(codex.models.first)
+        XCTAssertEqual(codexModel.todayCostUsd, 0, accuracy: 0.001)
         // Quota preserved from the full scan.
         XCTAssertEqual(summary.quota.count, 1)
     }

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/LayoutModeTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/LayoutModeTests.swift
@@ -2,10 +2,10 @@ import XCTest
 @testable import TokscaleMenuBarCore
 
 final class LayoutModeTests: XCTestCase {
-    func testDefaultsToSingle() {
-        XCTAssertEqual(LayoutMode.default, .single)
-        XCTAssertEqual(LayoutMode(storedValue: nil), .single)
-        XCTAssertEqual(LayoutMode(storedValue: "bogus"), .single)
+    func testDefaultsToPaged() {
+        XCTAssertEqual(LayoutMode.default, .paged)
+        XCTAssertEqual(LayoutMode(storedValue: nil), .paged)
+        XCTAssertEqual(LayoutMode(storedValue: "bogus"), .paged)
     }
 
     func testRoundTripsKnownValues() {

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/TokscaleSummaryTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/TokscaleSummaryTests.swift
@@ -144,6 +144,23 @@ final class TokscaleSummaryTests: XCTestCase {
         XCTAssertEqual(summary.collapsed.state, "stale")
     }
 
+    func testFreshTodayDoesNotMaskStaleHistory() throws {
+        let data = sampleSummaryJSON(
+            generatedAt: "2026-06-04T02:59:00Z",
+            topJSON: #""client":"codex","model":"gpt-5.5""#,
+            accuracyJSON: #""confidence":"medium","sourceKinds":["local-scan"],"warnings":[]"#,
+            healthExtraJSON: #", "historyGeneratedAt":"2026-06-02T23:00:00Z""#
+        ).data(using: .utf8)!
+        var summary = try TokscaleSummary.decode(data)
+        let now = try isoDate("2026-06-04T03:00:00Z")
+
+        XCTAssertTrue(summary.needsScanOnOpen(now: now, minimumInterval: 60))
+        summary.refreshFreshness(now: now)
+
+        XCTAssertTrue(summary.stale)
+        XCTAssertEqual(summary.staleReason, "history-older-than-26h")
+    }
+
     func testSummaryRequestsOpenRefreshWhenStaleOrOlderThanMinimumInterval() throws {
         var staleSummary = try TokscaleSummary.decode(sampleSummaryData())
         staleSummary.refreshFreshness(now: try isoDate("2026-06-04T04:26:00Z"))
@@ -257,7 +274,7 @@ final class TokscaleSummaryTests: XCTestCase {
 
         XCTAssertEqual(dashboard.hero.title, "$399")
         XCTAssertEqual(dashboard.hero.subtitle, "4 AI clients - local cache")
-        XCTAssertEqual(dashboard.hero.progressLabel, "199% of daily average")
+        XCTAssertEqual(dashboard.hero.progressLabel, "199% of account avg")
         XCTAssertEqual(dashboard.hero.progress, 0.99, accuracy: 0.01)
         XCTAssertEqual(dashboard.clientLabels, ["Codex", "Claude", "Gemini", "OpenClaw"])
         XCTAssertEqual(dashboard.metrics[0], .init(title: "Today", value: "$398.56", detail: "522.6M tokens - 2501 messages"))
@@ -281,6 +298,7 @@ final class TokscaleSummaryTests: XCTestCase {
         XCTAssertEqual(dashboard.providers[0].share, 0.50, accuracy: 0.01)
         XCTAssertEqual(dashboard.providerDetails(for: "codex").title, "Codex")
         XCTAssertEqual(dashboard.providerDetails(for: "codex").model, "gpt-5.5")
+        XCTAssertEqual(dashboard.providerFocus(for: "codex").modelCostDetail, "gpt-5.5 $280.00 / composer $70.00")
         XCTAssertEqual(dashboard.providerDetails(for: "claude").title, "Claude")
     }
 
@@ -293,6 +311,7 @@ final class TokscaleSummaryTests: XCTestCase {
         XCTAssertEqual(claude.id, "claude")
         XCTAssertEqual(claude.title, "Claude")
         XCTAssertEqual(claude.topModel, "claude-sonnet")
+        XCTAssertEqual(claude.modelCostDetail, "claude-fable-5")
         XCTAssertEqual(claude.today, "$30.00 · 20M")
         XCTAssertEqual(claude.quotaWindows.map(\.title), ["5h", "Week"])
         XCTAssertEqual(claude.primaryQuota?.title, "5h")
@@ -328,6 +347,121 @@ final class TokscaleSummaryTests: XCTestCase {
         XCTAssertEqual(primaryQuota.detail(for: .used), "28% left")
         XCTAssertEqual(primaryQuota.progress(for: .used), 0.72, accuracy: 0.01)
         XCTAssertEqual(claude.weeklyQuota?.title, "Week")
+    }
+
+    func testDashboardModelIncludesGrokQuotaOnBoard() throws {
+        let data = sampleSummaryJSON(
+            topJSON: #""client":"codex","model":"gpt-5.5""#,
+            accuracyJSON: #""confidence":"medium","sourceKinds":["local-scan"],"warnings":[]"#,
+            quotaJSON: """
+            [
+              {
+                "provider": "Grok",
+                "plan": "SuperGrok",
+                "windows": [
+                  {
+                    "label": "Credits",
+                    "usedPercent": 15.0,
+                    "remainingPercent": 85.0,
+                    "remainingLabel": "85.0% left",
+                    "resetsAt": "2026-07-01T00:00:00+00:00"
+                  }
+                ]
+              }
+            ]
+            """
+        ).data(using: .utf8)!
+        let summary = try TokscaleSummary.decode(data)
+
+        let grok = try XCTUnwrap(TokscaleDashboardModel(summary: summary).quotaBoardProviders.first { $0.id == "grok" })
+
+        XCTAssertEqual(grok.title, "Grok")
+        XCTAssertEqual(grok.primaryQuota?.title, "Credits")
+        XCTAssertEqual(grok.primaryQuota?.value(for: .remaining), "85.0% left")
+        XCTAssertEqual(grok.primaryQuota?.detail(for: .remaining), "15% used")
+    }
+
+    func testDashboardModelUsesSingleSharedGrokCreditQuota() throws {
+        let data = """
+        {
+          "version": 1,
+          "generatedAt": "2026-06-16T02:00:00Z",
+          "stale": false,
+          "collapsed": {"metric": "todayCost", "label": "$4.00", "state": "normal"},
+          "today": {"date": "2026-06-16", "costUsd": 4.0, "tokens": 4000, "messages": 12},
+          "totals": {
+            "costUsd": 12.0,
+            "tokens": 12000,
+            "activeDays": 1,
+            "clients": ["grok"],
+            "models": 2
+          },
+          "providers": [
+            {
+              "client": "grok",
+              "costUsd": 12.0,
+              "tokens": 12000,
+              "messages": 36,
+              "todayCostUsd": 4.0,
+              "todayTokens": 4000,
+              "todayMessages": 12,
+              "topModel": "grok-build",
+              "models": [
+                {
+                  "model": "grok-build",
+                  "costUsd": 8.0,
+                  "tokens": 8000,
+                  "messages": 24,
+                  "todayCostUsd": 3.0,
+                  "todayTokens": 3000,
+                  "todayMessages": 9
+                },
+                {
+                  "model": "grok-composer-2.5-fast",
+                  "costUsd": 4.0,
+                  "tokens": 4000,
+                  "messages": 12,
+                  "todayCostUsd": 1.0,
+                  "todayTokens": 1000,
+                  "todayMessages": 3
+                }
+              ]
+            }
+          ],
+          "quota": [
+            {
+              "provider": "Grok",
+              "plan": "SuperGrok",
+              "windows": [
+                {
+                  "label": "Credits",
+                  "usedPercent": 20.0,
+                  "remainingPercent": 80.0,
+                  "remainingLabel": "80.0% left",
+                  "resetsAt": "2026-07-01T00:00:00+00:00"
+                }
+              ]
+            }
+          ],
+          "history": [],
+          "top": {"client": "grok", "model": "grok-build"},
+          "health": {
+            "summaryPath": "/tmp/summary.json",
+            "lastScanDurationMs": 100,
+            "quotaRefreshedAt": "2026-06-16T02:00:00Z",
+            "warnings": []
+          },
+          "accuracy": {"confidence": "high", "sourceKinds": ["local-scan"], "warnings": []}
+        }
+        """.data(using: .utf8)!
+        let summary = try TokscaleSummary.decode(data)
+
+        let grok = try XCTUnwrap(TokscaleDashboardModel(summary: summary).quotaBoardProviders.first { $0.id == "grok" })
+
+        XCTAssertEqual(grok.quotaWindows.count, 1)
+        XCTAssertEqual(grok.primaryQuota?.title, "Credits")
+        XCTAssertEqual(grok.primaryQuota?.value(for: .remaining), "80.0% left")
+        XCTAssertEqual(grok.modelCostDetail, "grok $3.00 / composer $1.00")
     }
 
     func testDashboardTreatsQuotaRefreshAsLiveWhenHistoryIsStale() throws {
@@ -491,7 +625,27 @@ final class TokscaleSummaryTests: XCTestCase {
               "todayCostUsd": 350.0,
               "todayTokens": 500000000,
               "todayMessages": 2400,
-              "topModel": "gpt-5.5"
+              "topModel": "gpt-5.5",
+              "models": [
+                {
+                  "model": "gpt-5.5",
+                  "costUsd": 9000.0,
+                  "tokens": 12000000000,
+                  "messages": 40000,
+                  "todayCostUsd": 280.0,
+                  "todayTokens": 400000000,
+                  "todayMessages": 1900
+                },
+                {
+                  "model": "codex-composer",
+                  "costUsd": 3000.0,
+                  "tokens": 4000000000,
+                  "messages": 12000,
+                  "todayCostUsd": 70.0,
+                  "todayTokens": 100000000,
+                  "todayMessages": 500
+                }
+              ]
             },
             {
               "client": "claude",
@@ -501,7 +655,27 @@ final class TokscaleSummaryTests: XCTestCase {
               "todayCostUsd": 30.0,
               "todayTokens": 20000000,
               "todayMessages": 90,
-              "topModel": "claude-sonnet"
+              "topModel": "claude-sonnet",
+              "models": [
+                {
+                  "model": "claude-sonnet",
+                  "costUsd": 5900.0,
+                  "tokens": 8500000000,
+                  "messages": 27000,
+                  "todayCostUsd": 0.0,
+                  "todayTokens": 0,
+                  "todayMessages": 0
+                },
+                {
+                  "model": "claude-fable-5",
+                  "costUsd": 100.0,
+                  "tokens": 500000000,
+                  "messages": 1000,
+                  "todayCostUsd": 0.0,
+                  "todayTokens": 20000000,
+                  "todayMessages": 90
+                }
+              ]
             },
             {
               "client": "gemini",


### PR DESCRIPTION
## Summary

- rebuild the menubar as a cold-neutral compact paged Glance and History dashboard
- keep remote account totals and full compact history separate from explicitly labeled local-today activity
- add history=all for the menubar while leaving the default web profile window unchanged
- serialize cache updates with atomic replacement and store only compact daily/provider/model aggregates
- use bounded background scan fallbacks, validate wrapper output, and render a true 365-day heatmap without looping animations

## Verification

- Swift tests: 82/82
- frontend route tests: 7/7
- Swift warnings-as-errors build passed
- app bundle build passed
- git diff --check passed
- runtime/browser and idle performance checks completed before merge