### PR TITLE
fix(menubar): correct provider status and improve readability

### DIFF
--- a/crates/tokscale-cli/src/commands/usage/claude.rs
+++ b/crates/tokscale-cli/src/commands/usage/claude.rs
@@ -7,13 +7,13 @@ use super::{UsageMetric, UsageOutput};
 const CLIENT_ID: &str = "9d1c250a-e61b-44d9-88ed-5944d1962f5e";
 const BETA_HEADER: &str = "oauth-2025-04-20";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct Credentials {
     #[serde(rename = "claudeAiOauth")]
     claude_ai_oauth: Option<Oauth>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 struct Oauth {
     #[serde(rename = "accessToken")]
     access_token: Option<String>,
@@ -44,10 +44,16 @@ struct TokenRefresh {
     refresh_token: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CredentialSource {
     File,
     Keychain,
+}
+
+#[derive(Debug, Clone)]
+struct CredentialCandidate {
+    source: CredentialSource,
+    oauth: Oauth,
 }
 
 fn read_keychain() -> Result<String> {
@@ -60,19 +66,41 @@ pub fn has_credentials() -> bool {
         || super::helpers::read_keychain("Claude Code-credentials").is_ok()
 }
 
-fn read_credentials() -> Result<(Credentials, CredentialSource)> {
+fn credential_candidates_from_raw(
+    keychain: Option<&str>,
+    file: Option<&str>,
+) -> Vec<CredentialCandidate> {
+    let mut seen = std::collections::HashSet::new();
+    [
+        (CredentialSource::Keychain, keychain),
+        (CredentialSource::File, file),
+    ]
+    .into_iter()
+    .filter_map(|(source, raw)| {
+        let creds = serde_json::from_str::<Credentials>(raw?).ok()?;
+        let oauth = creds.claude_ai_oauth?;
+        let access_token = oauth.access_token.as_deref()?.trim();
+        let refresh_token = oauth.refresh_token.as_deref().map(str::trim);
+        if access_token.is_empty()
+            || !seen.insert((access_token.to_string(), refresh_token.map(str::to_string)))
+        {
+            return None;
+        }
+        Some(CredentialCandidate { source, oauth })
+    })
+    .collect()
+}
+
+fn read_credential_candidates() -> Result<Vec<CredentialCandidate>> {
     let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
     let path = home.join(".claude").join(".credentials.json");
-    if path.exists() {
-        if let Ok(content) = std::fs::read_to_string(&path) {
-            if let Ok(creds) = serde_json::from_str::<Credentials>(&content) {
-                return Ok((creds, CredentialSource::File));
-            }
-        }
+    let keychain = read_keychain().ok();
+    let file = std::fs::read_to_string(path).ok();
+    let candidates = credential_candidates_from_raw(keychain.as_deref(), file.as_deref());
+    if candidates.is_empty() {
+        anyhow::bail!("NEEDS_AUTH");
     }
-    let content = read_keychain()?;
-    let creds: Credentials = serde_json::from_str(&content)?;
-    Ok((creds, CredentialSource::Keychain))
+    Ok(candidates)
 }
 
 fn save_credentials(
@@ -139,8 +167,11 @@ async fn fetch_usage(client: &reqwest::Client, token: &str) -> Result<UsageRespo
     if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
         anyhow::bail!("NEEDS_AUTH");
     }
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+        anyhow::bail!("RATE_LIMITED");
+    }
     if !status.is_success() {
-        anyhow::bail!("Claude usage request failed (HTTP {status})");
+        anyhow::bail!("UNAVAILABLE");
     }
     Ok(resp.json().await?)
 }
@@ -161,68 +192,155 @@ pub fn fetch() -> Result<UsageOutput> {
         .enable_all()
         .build()?;
     rt.block_on(async {
-        let (creds, _source) = read_credentials()?;
-        let oauth = creds.claude_ai_oauth.ok_or_else(|| {
-            anyhow::anyhow!("No Claude OAuth credentials. Run 'claude' to log in.")
-        })?;
-        let access_token = oauth
-            .access_token
-            .clone()
-            .ok_or_else(|| anyhow::anyhow!("No Claude access token."))?;
-        let plan = oauth.subscription_type.as_ref().map(|s| {
-            let tier = oauth
-                .rate_limit_tier
-                .as_deref()
-                .and_then(|t| t.rsplit('_').next());
-            match tier {
-                Some(mult) => format!("{} {}", capitalize(s), mult),
-                None => capitalize(s),
-            }
-        });
-
         let client = reqwest::Client::new();
-        let resp = match fetch_usage(&client, &access_token).await {
-            Ok(r) => r,
-            Err(e) if e.to_string().contains("NEEDS_AUTH") => {
-                let rt = oauth
-                    .refresh_token
-                    .as_ref()
-                    .ok_or_else(|| anyhow::anyhow!("No refresh token."))?;
-                let refreshed = refresh_token(&client, rt).await?;
-                let new = refreshed
-                    .access_token
-                    .clone()
-                    .ok_or_else(|| anyhow::anyhow!("Refresh returned no token."))?;
-                if let Some(new_rt) = refreshed.refresh_token.as_deref() {
-                    save_credentials(
-                        &new,
-                        new_rt,
-                        oauth.subscription_type.as_deref(),
-                        oauth.rate_limit_tier.as_deref(),
-                    );
+        let mut saw_rate_limit = false;
+        let mut saw_auth_failure = false;
+        for candidate in read_credential_candidates()? {
+            let Some(access_token) = candidate.oauth.access_token.as_deref() else {
+                continue;
+            };
+            let mut response = fetch_usage(&client, access_token).await;
+            if response
+                .as_ref()
+                .is_err_and(|error| error.to_string().contains("NEEDS_AUTH"))
+            {
+                saw_auth_failure = true;
+                if let Some(refresh) = candidate.oauth.refresh_token.as_deref() {
+                    if let Ok(refreshed) = refresh_token(&client, refresh).await {
+                        if let Some(new_access) = refreshed.access_token.as_deref() {
+                            if candidate.source == CredentialSource::File {
+                                save_credentials(
+                                    new_access,
+                                    refreshed.refresh_token.as_deref().unwrap_or(refresh),
+                                    candidate.oauth.subscription_type.as_deref(),
+                                    candidate.oauth.rate_limit_tier.as_deref(),
+                                );
+                            }
+                            response = fetch_usage(&client, new_access).await;
+                        }
+                    }
                 }
-                fetch_usage(&client, &new).await?
             }
-            Err(e) => return Err(e),
-        };
-
-        let mut metrics = Vec::new();
-        if let Some(ref w) = resp.five_hour {
-            metrics.push(window_metric("Session", w));
+            let resp = match response {
+                Ok(response) => response,
+                Err(error) => {
+                    let marker = error.to_string();
+                    saw_rate_limit |= marker.contains("RATE_LIMITED");
+                    saw_auth_failure |= marker.contains("NEEDS_AUTH");
+                    continue;
+                }
+            };
+            let plan = candidate
+                .oauth
+                .subscription_type
+                .as_ref()
+                .map(|subscription| {
+                    let tier = candidate
+                        .oauth
+                        .rate_limit_tier
+                        .as_deref()
+                        .and_then(|value| value.rsplit('_').next());
+                    match tier {
+                        Some(multiplier) => format!("{} {}", capitalize(subscription), multiplier),
+                        None => capitalize(subscription),
+                    }
+                });
+            let mut metrics = Vec::new();
+            if let Some(ref window) = resp.five_hour {
+                metrics.push(window_metric("Session", window));
+            }
+            if let Some(ref window) = resp.seven_day {
+                metrics.push(window_metric("Weekly", window));
+            }
+            if let Some(ref window) = resp.seven_day_opus {
+                metrics.push(window_metric("Opus", window));
+            }
+            return Ok(UsageOutput {
+                provider: "Claude".into(),
+                account: None,
+                plan,
+                email: None,
+                metrics,
+            });
         }
-        if let Some(ref w) = resp.seven_day {
-            metrics.push(window_metric("Weekly", w));
+        if saw_rate_limit {
+            anyhow::bail!("RATE_LIMITED");
         }
-        if let Some(ref w) = resp.seven_day_opus {
-            metrics.push(window_metric("Opus", w));
+        if saw_auth_failure {
+            anyhow::bail!("NEEDS_AUTH");
         }
-
-        Ok(UsageOutput {
-            provider: "Claude".into(),
-            account: None,
-            plan,
-            email: None,
-            metrics,
-        })
+        anyhow::bail!("UNAVAILABLE")
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEYCHAIN: &str = r#"{
+        "claudeAiOauth": {
+            "accessToken": "keychain-token",
+            "refreshToken": "keychain-refresh",
+            "subscriptionType": "max"
+        }
+    }"#;
+    const FILE: &str = r#"{
+        "claudeAiOauth": {
+            "accessToken": "file-token",
+            "refreshToken": "file-refresh",
+            "subscriptionType": "pro"
+        }
+    }"#;
+
+    #[test]
+    fn credential_candidates_prefer_keychain_then_file() {
+        let candidates = credential_candidates_from_raw(Some(KEYCHAIN), Some(FILE));
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].source, CredentialSource::Keychain);
+        assert_eq!(candidates[1].source, CredentialSource::File);
+        assert_eq!(
+            candidates[0].oauth.access_token.as_deref(),
+            Some("keychain-token")
+        );
+        assert_eq!(
+            candidates[1].oauth.access_token.as_deref(),
+            Some("file-token")
+        );
+    }
+
+    #[test]
+    fn credential_candidates_use_file_when_keychain_is_invalid() {
+        let candidates = credential_candidates_from_raw(Some("not-json"), Some(FILE));
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].source, CredentialSource::File);
+    }
+
+    #[test]
+    fn credential_candidates_dedupe_identical_tokens_preferring_keychain() {
+        let candidates = credential_candidates_from_raw(Some(KEYCHAIN), Some(KEYCHAIN));
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].source, CredentialSource::Keychain);
+    }
+
+    #[test]
+    fn credential_candidates_keep_distinct_refresh_fallbacks() {
+        let file = KEYCHAIN.replace("keychain-refresh", "file-refresh");
+        let candidates = credential_candidates_from_raw(Some(KEYCHAIN), Some(&file));
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].source, CredentialSource::Keychain);
+        assert_eq!(candidates[1].source, CredentialSource::File);
+    }
+
+    #[test]
+    fn credential_candidates_skip_missing_access_token() {
+        let missing = r#"{"claudeAiOauth":{"refreshToken":"refresh-only"}}"#;
+        let candidates = credential_candidates_from_raw(Some(missing), Some(FILE));
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].source, CredentialSource::File);
+    }
 }

--- a/crates/tokscale-cli/src/commands/usage/grok.rs
+++ b/crates/tokscale-cli/src/commands/usage/grok.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use anyhow::Result;
-use chrono::{TimeZone, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use serde_json::Value;
 
 use super::{UsageMetric, UsageOutput};
@@ -50,28 +50,53 @@ fn read_credentials() -> Result<Vec<Credentials>> {
 }
 
 fn credential_candidates_from_value(doc: &Value) -> Result<Vec<Credentials>> {
+    credential_candidates_from_value_at(doc, Utc::now())
+}
+
+fn credential_candidates_from_value_at(
+    doc: &Value,
+    now: DateTime<Utc>,
+) -> Result<Vec<Credentials>> {
     let entries = doc
         .as_object()
         .ok_or_else(|| anyhow::anyhow!("Grok auth.json must contain an object."))?;
 
-    let mut candidates: Vec<_> = entries
-        .iter()
-        .filter_map(|(scope, value)| {
-            let entry = value.as_object()?;
-            let token = entry
-                .get("key")
-                .and_then(Value::as_str)
-                .filter(|value| !value.is_empty())?
-                .to_string();
-            let email = entry
-                .get("email")
-                .and_then(Value::as_str)
-                .filter(|value| !value.is_empty())
-                .map(ToString::to_string);
-            let priority = if scope.contains("auth.x.ai") { 0 } else { 1 };
-            Some((priority, Credentials { token, email }))
-        })
-        .collect();
+    let mut candidates = Vec::new();
+    let mut expired_count = 0;
+    for (scope, value) in entries {
+        let Some(entry) = value.as_object() else {
+            continue;
+        };
+        let Some(token) = entry
+            .get("key")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        let expired = entry
+            .get("expires_at")
+            .and_then(Value::as_str)
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .is_some_and(|expires_at| expires_at.with_timezone(&Utc) <= now);
+        if expired {
+            expired_count += 1;
+            continue;
+        }
+        let email = entry
+            .get("email")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string);
+        let priority = if scope.contains("auth.x.ai") { 0 } else { 1 };
+        candidates.push((
+            priority,
+            Credentials {
+                token: token.to_string(),
+                email,
+            },
+        ));
+    }
 
     candidates.sort_by_key(|(priority, _)| *priority);
     let credentials: Vec<_> = candidates
@@ -80,6 +105,9 @@ fn credential_candidates_from_value(doc: &Value) -> Result<Vec<Credentials>> {
         .collect();
 
     if credentials.is_empty() {
+        if expired_count > 0 {
+            anyhow::bail!("AUTH_EXPIRED");
+        }
         anyhow::bail!("No Grok token found. Run 'grok login'.");
     }
     Ok(credentials)
@@ -794,6 +822,47 @@ mod tests {
             credentials[1].email.as_deref(),
             Some("secondary@example.com")
         );
+    }
+
+    #[test]
+    fn rejects_auth_file_when_every_credential_is_expired() {
+        let value = serde_json::json!({
+            "https://auth.x.ai": {
+                "key": "expired-token",
+                "expires_at": "2026-07-09T23:53:15Z"
+            }
+        });
+
+        let error = credential_candidates_from_value_at(
+            &value,
+            Utc.with_ymd_and_hms(2026, 7, 13, 0, 0, 0).unwrap(),
+        )
+        .expect_err("expired credentials must fail");
+
+        assert_eq!(error.to_string(), "AUTH_EXPIRED");
+    }
+
+    #[test]
+    fn keeps_unexpired_credentials_and_skips_expired_candidates() {
+        let value = serde_json::json!({
+            "https://auth.x.ai::old": {
+                "key": "expired-token",
+                "expires_at": "2026-07-09T23:53:15Z"
+            },
+            "https://auth.x.ai::current": {
+                "key": "current-token",
+                "expires_at": "2026-07-20T23:53:15Z"
+            }
+        });
+
+        let credentials = credential_candidates_from_value_at(
+            &value,
+            Utc.with_ymd_and_hms(2026, 7, 13, 0, 0, 0).unwrap(),
+        )
+        .expect("one credential is current");
+
+        assert_eq!(credentials.len(), 1);
+        assert_eq!(credentials[0].token, "current-token");
     }
 
     #[test]

--- a/crates/tokscale-cli/src/commands/usage/mod.rs
+++ b/crates/tokscale-cli/src/commands/usage/mod.rs
@@ -163,6 +163,27 @@ pub fn load_cache() -> Option<Vec<UsageOutput>> {
 
 type UsageProvider = (&'static str, fn() -> bool, fn() -> Result<Vec<UsageOutput>>);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum UsageFailureStatus {
+    AuthExpired,
+    NeedsAuth,
+    RateLimited,
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct UsageFailure {
+    provider: String,
+    status: UsageFailureStatus,
+}
+
+#[derive(Debug, Default)]
+struct UsageFetchReport {
+    outputs: Vec<UsageOutput>,
+    failures: Vec<UsageFailure>,
+}
+
 fn fetch_amp() -> Result<Vec<UsageOutput>> {
     amp::fetch().map(|output| vec![output])
 }
@@ -199,8 +220,8 @@ fn fetch_zai() -> Result<Vec<UsageOutput>> {
     zai::fetch().map(|output| vec![output])
 }
 
-pub fn fetch_all() -> Vec<UsageOutput> {
-    let providers: Vec<UsageProvider> = vec![
+fn usage_providers() -> Vec<UsageProvider> {
+    vec![
         ("Claude", claude::has_credentials, fetch_claude),
         ("Codex", codex::has_credentials, codex::fetch_all),
         ("Gemini", gemini::has_credentials, fetch_gemini),
@@ -211,24 +232,83 @@ pub fn fetch_all() -> Vec<UsageOutput> {
         ("Kimi", kimi::has_credentials, fetch_kimi),
         ("MiniMax", minimax::has_credentials, fetch_minimax),
         ("Warp/Oz", warp::has_credentials, fetch_warp),
-    ];
+    ]
+}
 
-    let active: Vec<_> = providers.into_iter().filter(|(_, has, _)| has()).collect();
+fn classify_provider_failure(_provider: &str, error: &str) -> UsageFailureStatus {
+    if error.contains("AUTH_EXPIRED") {
+        UsageFailureStatus::AuthExpired
+    } else if error.contains("RATE_LIMITED") || error.contains("HTTP 429") {
+        UsageFailureStatus::RateLimited
+    } else if error.contains("NEEDS_AUTH") {
+        UsageFailureStatus::NeedsAuth
+    } else {
+        UsageFailureStatus::Unavailable
+    }
+}
+
+fn fetch_report() -> UsageFetchReport {
+    let active: Vec<_> = usage_providers()
+        .into_iter()
+        .filter(|(_, has, _)| has())
+        .collect();
 
     if active.is_empty() {
-        return vec![];
+        return UsageFetchReport::default();
     }
 
     std::thread::scope(|s| {
-        active
+        let handles = active
             .into_iter()
-            .map(|(_, _, fetch)| s.spawn(move || fetch().ok()))
-            .collect::<Vec<_>>()
-            .into_iter()
-            .filter_map(|h| h.join().ok().flatten())
-            .flatten()
-            .collect()
+            .map(|(provider, _, fetch)| (provider, s.spawn(fetch)))
+            .collect::<Vec<_>>();
+        let mut report = UsageFetchReport::default();
+        for (provider, handle) in handles {
+            match handle.join() {
+                Ok(Ok(outputs)) => report.outputs.extend(outputs),
+                Ok(Err(error)) => report.failures.push(UsageFailure {
+                    provider: provider.to_string(),
+                    status: classify_provider_failure(provider, &error.to_string()),
+                }),
+                Err(_) => report.failures.push(UsageFailure {
+                    provider: provider.to_string(),
+                    status: UsageFailureStatus::Unavailable,
+                }),
+            }
+        }
+        report
     })
+}
+
+pub fn fetch_all() -> Vec<UsageOutput> {
+    fetch_report().outputs
+}
+
+fn usage_json(report: &UsageFetchReport, include_status: bool) -> Result<String> {
+    if !include_status {
+        return Ok(serde_json::to_string_pretty(&report.outputs)?);
+    }
+    let mut rows = report
+        .outputs
+        .iter()
+        .map(|output| {
+            let mut value = serde_json::to_value(output)?;
+            if let Some(object) = value.as_object_mut() {
+                object.insert("status".to_string(), serde_json::json!("live"));
+            }
+            Ok::<serde_json::Value, serde_json::Error>(value)
+        })
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    rows.extend(report.failures.iter().map(|failure| {
+        serde_json::json!({
+            "provider": failure.provider,
+            "plan": null,
+            "email": null,
+            "metrics": [],
+            "status": failure.status,
+        })
+    }));
+    Ok(serde_json::to_string_pretty(&rows)?)
 }
 
 // ── Light-mode rendering ──
@@ -283,12 +363,19 @@ fn render_light(output: &UsageOutput) {
     println!("╰{}╯", "─".repeat(CARD_WIDTH));
 }
 
-pub fn run(json: bool, _light: bool) -> Result<()> {
-    let outputs = fetch_all();
-    if json {
-        println!("{}", serde_json::to_string_pretty(&outputs)?);
+pub fn run(json: bool, _light: bool, include_status: bool) -> Result<()> {
+    let report = if include_status {
+        fetch_report()
     } else {
-        for o in &outputs {
+        UsageFetchReport {
+            outputs: fetch_all(),
+            failures: Vec::new(),
+        }
+    };
+    if json {
+        println!("{}", usage_json(&report, include_status)?);
+    } else {
+        for o in &report.outputs {
             render_light(o);
         }
     }
@@ -363,6 +450,56 @@ mod tests {
 
         assert!(output.account.is_none());
         assert_eq!(output.display_name(), "Codex");
+        Ok(())
+    }
+
+    #[test]
+    fn provider_failure_statuses_are_classified_without_raw_errors() {
+        assert_eq!(
+            classify_provider_failure("Grok Build", "AUTH_EXPIRED token=secret"),
+            UsageFailureStatus::AuthExpired
+        );
+        assert_eq!(
+            classify_provider_failure("Claude", "RATE_LIMITED bearer=secret"),
+            UsageFailureStatus::RateLimited
+        );
+        assert_eq!(
+            classify_provider_failure("Claude", "NEEDS_AUTH refresh=secret"),
+            UsageFailureStatus::NeedsAuth
+        );
+        assert_eq!(
+            classify_provider_failure("Grok Build", "network token=secret"),
+            UsageFailureStatus::Unavailable
+        );
+    }
+
+    #[test]
+    fn status_json_keeps_successes_and_safe_failure_placeholders() -> Result<()> {
+        let report = UsageFetchReport {
+            outputs: vec![UsageOutput {
+                provider: "Codex".to_string(),
+                account: None,
+                plan: Some("Plus".to_string()),
+                email: None,
+                metrics: vec![],
+            }],
+            failures: vec![UsageFailure {
+                provider: "Grok Build".to_string(),
+                status: UsageFailureStatus::AuthExpired,
+            }],
+        };
+
+        let json = usage_json(&report, true)?;
+        let value: serde_json::Value = serde_json::from_str(&json)?;
+        let rows = value.as_array().expect("top-level usage array");
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["provider"], "Codex");
+        assert_eq!(rows[0]["status"], "live");
+        assert_eq!(rows[1]["provider"], "Grok Build");
+        assert_eq!(rows[1]["status"], "auth-expired");
+        assert_eq!(rows[1]["metrics"], serde_json::json!([]));
+        assert!(!json.contains("secret"));
         Ok(())
     }
 }

--- a/crates/tokscale-cli/src/main.rs
+++ b/crates/tokscale-cli/src/main.rs
@@ -307,6 +307,8 @@ enum Commands {
         json: bool,
         #[arg(long, help = "Light terminal output (no TUI)")]
         light: bool,
+        #[arg(long, hide = true)]
+        include_status: bool,
     },
     #[command(about = "Codex account integration commands")]
     Codex {
@@ -809,9 +811,13 @@ fn main() -> Result<()> {
             reject_unsupported_home_override(&cli.home, "antigravity")?;
             run_antigravity_command(subcommand)
         }
-        Some(Commands::Usage { json, light }) => {
+        Some(Commands::Usage {
+            json,
+            light,
+            include_status,
+        }) => {
             reject_unsupported_home_override(&cli.home, "usage")?;
-            commands::usage::run(json, light)
+            commands::usage::run(json, light, include_status)
         }
         Some(Commands::Codex { subcommand }) => {
             reject_unsupported_home_override(&cli.home, "codex")?;

--- a/packages/menubar/Sources/TokscaleMenuBar/MenuBarModel.swift
+++ b/packages/menubar/Sources/TokscaleMenuBar/MenuBarModel.swift
@@ -334,11 +334,7 @@ final class MenuBarModel: ObservableObject {
         guard let graphData else {
             return .failure("Refresh failed: \(graphFailure)")
         }
-        let usage = runCapturing(
-            executableURL: binary,
-            arguments: ["usage", "--json"],
-            timeout: 45
-        )
+        let usage = runUsageCapturing(binary: binary)
         let usageData = (usage.ok ? usage.data : nil).flatMap { $0.isEmpty ? nil : $0 }
         let scanMs = Int(Date().timeIntervalSince(started) * 1000)
         let nowISO = ISO8601DateFormatter().string(from: Date())
@@ -457,11 +453,7 @@ final class MenuBarModel: ObservableObject {
         guard let binary = tokensBinaryURL() else {
             return "Refresh failed: tokens command unavailable"
         }
-        let usage = runCapturing(
-            executableURL: binary,
-            arguments: ["usage", "--json"],
-            timeout: 45
-        )
+        let usage = runUsageCapturing(binary: binary)
         guard usage.ok, let usageData = usage.data, !usageData.isEmpty else {
             return "Quota unavailable (kept previous)."
         }
@@ -470,7 +462,8 @@ final class MenuBarModel: ObservableObject {
             GraphCompanionAdapter.patchedQuota(
                 companionData: latest,
                 usageData: usageData,
-                quotaRefreshedAt: nowISO
+                quotaRefreshedAt: nowISO,
+                authoritative: usage.authoritative
             )
         }
         return wrote ? "Refresh finished." : "Quota unavailable (kept previous)."
@@ -534,6 +527,47 @@ final class MenuBarModel: ObservableObject {
     nonisolated private static func dedupePaths(_ paths: [String]) -> [String] {
         var seen = Set<String>()
         return paths.filter { seen.insert($0).inserted }
+    }
+
+    nonisolated private static func runUsageCapturing(
+        binary: URL
+    ) -> UsageCapture {
+        let detailed = runCapturing(
+            executableURL: binary,
+            arguments: ["usage", "--json", "--include-status"],
+            timeout: 45
+        )
+        if detailed.ok {
+            return UsageCapture(
+                data: detailed.data,
+                ok: true,
+                message: detailed.message,
+                authoritative: true
+            )
+        }
+        let message = detailed.message?.lowercased() ?? ""
+        guard message.contains("--include-status"),
+            message.contains("unexpected argument") || message.contains("unknown argument")
+                || message.contains("unrecognized option")
+        else {
+            return UsageCapture(
+                data: detailed.data,
+                ok: false,
+                message: detailed.message,
+                authoritative: false
+            )
+        }
+        let legacy = runCapturing(
+            executableURL: binary,
+            arguments: ["usage", "--json"],
+            timeout: 45
+        )
+        return UsageCapture(
+            data: legacy.data,
+            ok: legacy.ok,
+            message: legacy.message,
+            authoritative: false
+        )
     }
 
     nonisolated private static func runCapturing(
@@ -619,6 +653,13 @@ private final class NetworkBox: @unchecked Sendable {
     var data: Data?
     var statusCode: Int?
     var failed = false
+}
+
+private struct UsageCapture: Sendable {
+    let data: Data?
+    let ok: Bool
+    let message: String?
+    let authoritative: Bool
 }
 
 private struct GraphCommand: Sendable {

--- a/packages/menubar/Sources/TokscaleMenuBar/TokensPopoverView.swift
+++ b/packages/menubar/Sources/TokscaleMenuBar/TokensPopoverView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SwiftUI
 import TokscaleMenuBarCore
@@ -32,7 +33,7 @@ struct TokensPopoverView: View {
             .padding(.top, 14)
             .padding(.bottom, 12)
         }
-        .frame(width: 488, height: 720, alignment: .top)
+        .frame(width: popoverSize.width, height: popoverSize.height, alignment: .top)
         .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 18, style: .continuous)
@@ -75,6 +76,14 @@ struct TokensPopoverView: View {
             return providerColor(provider.id)
         }
         return providerColor("gemini")
+    }
+
+    private var popoverSize: CGSize {
+        let visible = NSScreen.main?.visibleFrame.size ?? CGSize(width: 632, height: 896)
+        return CGSize(
+            width: min(600, max(420, visible.width - 32)),
+            height: min(864, max(560, visible.height - 32))
+        )
     }
 }
 
@@ -200,8 +209,8 @@ private struct SummaryContent: View {
 
         ContributionHeatmap(days: summary.contribution, endDate: summary.today.date)
 
-        Text("Dollar amounts are API-equivalent value, not subscription spend.")
-            .font(.system(size: 9, weight: .medium))
+        Text("Est. API-equivalent value · not subscription spend")
+            .font(.system(size: 11, weight: .medium))
             .foregroundStyle(.secondary)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.bottom, 4)
@@ -229,9 +238,9 @@ private struct CompanionHeader: View {
             LiveDot(stale: summary.stale, active: isRefreshing)
             VStack(alignment: .leading, spacing: 1) {
                 Text("Tokens")
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(.system(size: 17, weight: .semibold))
                 Text(headerSubtitle)
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -259,7 +268,7 @@ private struct CompanionHeader: View {
                 )
             }
         }
-        .frame(height: 30)
+        .frame(height: 40)
     }
 
     private var headerSubtitle: String {
@@ -312,7 +321,7 @@ private struct TodayGlanceCard: View {
             )
             Rectangle()
                 .fill(Color.primary.opacity(0.08))
-                .frame(width: 1, height: 44)
+                .frame(width: 1, height: 54)
             stat(
                 value: formatTokens(summary.today.tokens),
                 label: "Local today tokens",
@@ -321,7 +330,7 @@ private struct TodayGlanceCard: View {
             )
         }
         .padding(.horizontal, 14)
-        .padding(.vertical, 12)
+        .padding(.vertical, 14)
         .frame(maxWidth: .infinity)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -348,20 +357,20 @@ private struct TodayGlanceCard: View {
     private func stat(value: String, label: String, tint: Color, momentum: (text: String, high: Bool)?) -> some View {
         VStack(alignment: .leading, spacing: 3) {
             Text(value)
-                .font(.system(size: 24, weight: .semibold, design: .rounded))
+                .font(.system(size: 30, weight: .semibold, design: .rounded))
                 .monospacedDigit()
                 .lineLimit(1)
-                .minimumScaleFactor(0.5)
+                .minimumScaleFactor(0.8)
                 .foregroundStyle(tint)
             Text(label.uppercased())
-                .font(.system(size: 9, weight: .semibold))
+                .font(.system(size: 11, weight: .semibold))
                 .foregroundStyle(.secondary)
             if let momentum {
                 Text(momentum.text)
-                    .font(.system(size: 9, weight: .semibold))
+                    .font(.system(size: 11, weight: .semibold))
                     .foregroundStyle(momentum.high ? Color.green : Color.secondary)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.7)
+                    .minimumScaleFactor(0.8)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -380,9 +389,9 @@ private struct PageTabSwitcher: View {
             ForEach(Array(tabs.enumerated()), id: \.offset) { index, title in
                 Button(action: { onSelect(index) }) {
                     Text(title)
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: 13, weight: .semibold))
                         .frame(maxWidth: .infinity)
-                        .frame(height: 27)
+                        .frame(height: 34)
                         .foregroundStyle(index == page ? Color.primary : Color.secondary)
                         .background(
                             RoundedRectangle(cornerRadius: 7, style: .continuous)
@@ -452,9 +461,9 @@ private struct QuotaModeToggle: View {
             ForEach(TokscaleDashboardModel.QuotaDisplayMode.allCases, id: \.self) { option in
                 Button(action: { onChange(option) }) {
                     Text(option.title)
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: 12, weight: .bold))
                         .lineLimit(1)
-                        .frame(width: 46, height: 26)
+                        .frame(width: 56, height: 32)
                         .foregroundStyle(option == mode ? Color.primary : Color.secondary)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -488,27 +497,31 @@ private struct ProviderQuotaRow: View {
                 HStack(spacing: 6) {
                     ProviderDot(color: color)
                     Text(focus.title)
-                        .font(.system(size: prominent ? 14 : 12, weight: .bold))
+                        .font(.system(size: prominent ? 17 : 15, weight: .bold))
                         .lineLimit(1)
                     Spacer(minLength: 0)
                 }
                 Text("LOCAL TODAY · \(focus.today)")
-                    .font(.system(size: 9, weight: .medium))
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.72)
+                    .minimumScaleFactor(0.8)
                 Text("\(focus.total) · \(focus.tokens)")
-                    .font(.system(size: 8, weight: .medium))
+                    .font(.system(size: 10, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.64)
+                    .minimumScaleFactor(0.8)
                 QuotaSourceBadge(status: focus.quotaStatus, color: color)
             }
-            .frame(width: 116, alignment: .leading)
+            .frame(width: 145, alignment: .leading)
 
             VStack(spacing: 7) {
                 if focus.quotaWindows.isEmpty {
-                    QuotaUnavailableLine(providerColor: color)
+                    QuotaUnavailableLine(
+                        status: focus.quotaStatus,
+                        detail: focus.quotaStatusDetail,
+                        providerColor: color
+                    )
                 } else {
                     ForEach(Array(focus.quotaWindows.enumerated()), id: \.offset) { _, window in
                         QuotaBarLine(
@@ -518,6 +531,12 @@ private struct ProviderQuotaRow: View {
                             isCached: focus.quotaStatus == "Cached",
                             prominent: prominent
                         )
+                    }
+                    if focus.quotaStatus != "Live" {
+                        Text(focus.quotaStatusDetail)
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(2)
                     }
                 }
             }
@@ -548,41 +567,41 @@ private struct QuotaBarLine: View {
             let unavailable = isCached || expired
             HStack(spacing: 8) {
                 Text(quota.title)
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .foregroundStyle(.secondary)
-                    .frame(width: 38, alignment: .leading)
+                    .frame(width: 52, alignment: .leading)
                 QuotaProgressBar(
-                    progress: unavailable ? 0 : quota.progress(for: displayMode),
+                    progress: expired ? 0 : quota.progress(for: displayMode),
                     color: unavailable ? companionOrange : quotaHealthColor(quota)
                 )
                 VStack(alignment: .trailing, spacing: 1) {
                     Text(quotaValueText(quota: quota, displayMode: displayMode, isCached: isCached, expired: expired))
-                        .font(.system(size: prominent ? 21 : 15, weight: .bold, design: .rounded))
+                        .font(.system(size: prominent ? 23 : 18, weight: .bold, design: .rounded))
                         .monospacedDigit()
                         .lineLimit(1)
-                        .minimumScaleFactor(0.72)
+                        .minimumScaleFactor(0.8)
                     Text(quotaDetailText(quota: quota, displayMode: displayMode, isCached: isCached, expired: expired))
-                        .font(.system(size: prominent ? 9 : 8, weight: .medium))
+                        .font(.system(size: prominent ? 11 : 10, weight: .medium))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
-                        .minimumScaleFactor(0.70)
+                        .minimumScaleFactor(0.8)
                 }
-                .frame(width: prominent ? 106 : 92, alignment: .trailing)
+                .frame(width: prominent ? 128 : 112, alignment: .trailing)
             }
-            .frame(height: prominent ? 34 : 28)
+            .frame(height: prominent ? 40 : 36)
         } else {
             HStack(spacing: 8) {
                 Text(fallbackTitle)
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .foregroundStyle(.secondary)
-                    .frame(width: 38, alignment: .leading)
+                    .frame(width: 52, alignment: .leading)
                 QuotaProgressBar(progress: 0, color: .secondary)
                 Text("N/A")
-                    .font(.system(size: 12, weight: .bold, design: .rounded))
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
                     .foregroundStyle(.secondary)
-                    .frame(width: 92, alignment: .trailing)
+                    .frame(width: 112, alignment: .trailing)
             }
-            .frame(height: 28)
+            .frame(height: 36)
         }
     }
 }
@@ -605,7 +624,7 @@ private func quotaValueText(
         return "Expired"
     }
     if isCached {
-        return "Cached"
+        return stripQuotaWord(quota.value(for: displayMode))
     }
     return stripQuotaWord(quota.value(for: displayMode))
 }
@@ -620,7 +639,7 @@ private func quotaDetailText(
         return "refresh needed"
     }
     if isCached {
-        return "refresh for live"
+        return "last snapshot"
     }
     return stripQuotaWord(resetLabel(quota.reset) ?? quota.detail(for: displayMode))
 }
@@ -636,23 +655,29 @@ private struct ProviderGlanceCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack(spacing: 8) {
-                ProviderDot(color: color)
-                Text(focus.title)
-                    .font(.system(size: 13, weight: .semibold))
-                    .lineLimit(1)
+        VStack(alignment: .leading, spacing: 11) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    ProviderDot(color: color)
+                    Text(focus.title)
+                        .font(.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                    Spacer(minLength: 8)
+                    QuotaSourceBadge(status: focus.quotaStatus, color: color)
+                }
                 Text("LOCAL TODAY · \(focus.today)")
-                    .font(.system(size: 11, weight: .medium))
+                    .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.6)
-                Spacer(minLength: 6)
-                QuotaSourceBadge(status: focus.quotaStatus, color: color)
+                    .minimumScaleFactor(0.8)
             }
 
             if focus.quotaWindows.isEmpty {
-                QuotaUnavailableLine(providerColor: color)
+                QuotaUnavailableLine(
+                    status: focus.quotaStatus,
+                    detail: focus.quotaStatusDetail,
+                    providerColor: color
+                )
             } else {
                 // Render every quota window the provider actually exposes — Claude/
                 // Codex have Session + Weekly; Gemini has per-tier daily limits
@@ -666,6 +691,12 @@ private struct ProviderGlanceCard: View {
                         color: color
                     )
                 }
+                if focus.quotaStatus != "Live" {
+                    Label(focus.quotaStatusDetail, systemImage: "exclamationmark.circle.fill")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
             }
 
             if focus.workTime != "—" || focus.cacheHitPercent > 0.5 {
@@ -673,40 +704,40 @@ private struct ProviderGlanceCard: View {
                     if focus.workTime != "—" {
                         HStack(spacing: 5) {
                             Image(systemName: "clock.fill")
-                                .font(.system(size: 10, weight: .semibold))
+                                .font(.system(size: 12, weight: .semibold))
                                 .foregroundStyle(color)
                             Text("Active \(focus.workTime)")
-                                .font(.system(size: 10, weight: .medium))
+                                .font(.system(size: 12, weight: .medium))
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
-                                .minimumScaleFactor(0.7)
+                                .minimumScaleFactor(0.8)
                         }
                     }
                     Spacer(minLength: 4)
                     if focus.cacheHitPercent > 0.5 {
                         HStack(spacing: 5) {
                             Image(systemName: "bolt.fill")
-                                .font(.system(size: 9, weight: .semibold))
+                                .font(.system(size: 11, weight: .semibold))
                                 .foregroundStyle(color)
-                            Text("Cache hit \(Int(focus.cacheHitPercent.rounded()))%")
-                                .font(.system(size: 10, weight: .medium))
+                            Text("Today cache hit \(Int(focus.cacheHitPercent.rounded()))%")
+                                .font(.system(size: 12, weight: .medium))
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
-                                .minimumScaleFactor(0.7)
+                                .minimumScaleFactor(0.8)
                         }
                     }
                 }
             }
         }
-        .padding(.horizontal, 11)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 13)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(companionWarmGlassColor)
+                .fill(color.opacity(0.055))
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .stroke(companionBorderColor, lineWidth: 1)
+                .stroke(color.opacity(0.24), lineWidth: 1)
         )
     }
 }
@@ -724,65 +755,67 @@ private struct GlanceQuotaLine: View {
             let unavailable = isCached || expired
             HStack(spacing: 8) {
                 Text(quota.title)
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
-                    .frame(width: 42, alignment: .leading)
+                    .frame(width: 52, alignment: .leading)
                 QuotaProgressBar(
-                    progress: unavailable ? 0 : quota.progress(for: displayMode),
+                    progress: expired ? 0 : quota.progress(for: displayMode),
                     color: unavailable ? companionOrange : quotaHealthColor(quota)
                 )
                 VStack(alignment: .trailing, spacing: 1) {
                     Text(quotaValueText(quota: quota, displayMode: displayMode, isCached: isCached, expired: expired))
-                        .font(.system(size: 17, weight: .semibold, design: .rounded))
+                        .font(.system(size: 21, weight: .semibold, design: .rounded))
                         .monospacedDigit()
                         .lineLimit(1)
-                        .minimumScaleFactor(0.65)
+                        .minimumScaleFactor(0.8)
                         .foregroundStyle(unavailable ? Color.secondary : Color.primary)
                     Text(quotaDetailText(quota: quota, displayMode: displayMode, isCached: isCached, expired: expired))
-                        .font(.system(size: 8, weight: .medium))
+                        .font(.system(size: 10, weight: .medium))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
                 }
-                .frame(width: 92, alignment: .trailing)
+                .frame(width: 118, alignment: .trailing)
             }
-            .frame(height: 28)
+            .frame(height: 36)
         } else {
             HStack(spacing: 8) {
                 Text(fallbackTitle)
-                    .font(.system(size: 10, weight: .semibold))
+                    .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(.secondary)
-                    .frame(width: 42, alignment: .leading)
+                    .frame(width: 52, alignment: .leading)
                 QuotaProgressBar(progress: 0, color: .secondary)
                 Text("N/A")
-                    .font(.system(size: 12, weight: .semibold, design: .rounded))
+                    .font(.system(size: 15, weight: .semibold, design: .rounded))
                     .foregroundStyle(.secondary)
-                    .frame(width: 92, alignment: .trailing)
+                    .frame(width: 118, alignment: .trailing)
             }
-            .frame(height: 28)
+            .frame(height: 36)
         }
     }
 }
 
 private struct QuotaUnavailableLine: View {
+    let status: String
+    let detail: String
     let providerColor: Color
 
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "lock.open.trianglebadge.exclamationmark")
-                .font(.system(size: 13, weight: .bold))
+                .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(providerColor)
             VStack(alignment: .leading, spacing: 1) {
-                Text("No live quota")
-                    .font(.system(size: 11, weight: .bold))
-                Text("Local usage is available, official 5h/Week limits are not.")
-                    .font(.system(size: 9, weight: .medium))
+                Text(status)
+                    .font(.system(size: 14, weight: .bold))
+                Text(detail)
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
             }
             Spacer(minLength: 0)
         }
-        .frame(height: 59)
+        .frame(minHeight: 72)
         .padding(.horizontal, 9)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -806,7 +839,7 @@ private struct QuotaProgressBar: View {
                     .frame(width: max(7, proxy.size.width * clampedProgress))
             }
         }
-        .frame(height: 7)
+        .frame(height: 9)
     }
 }
 
@@ -816,10 +849,10 @@ private struct QuotaSourceBadge: View {
 
     var body: some View {
         Text(status)
-            .font(.system(size: 8, weight: .bold))
+            .font(.system(size: 10, weight: .bold))
             .lineLimit(1)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
             .foregroundStyle(status == "No live quota" ? Color.secondary : color)
             .background(
                 Capsule()
@@ -1122,13 +1155,13 @@ private struct HistorySection: View {
         VStack(alignment: .leading, spacing: 11) {
             HStack(spacing: 7) {
                 Image(systemName: "chart.bar.fill")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(companionOrange)
                 Text("History")
-                    .font(.system(size: 15, weight: .bold))
+                    .font(.system(size: 18, weight: .bold))
                 Spacer(minLength: 0)
-                Text("est. API value")
-                    .font(.system(size: 11, weight: .medium))
+                Text("Est. API equivalent")
+                    .font(.system(size: 13, weight: .medium))
                     .foregroundStyle(.secondary)
             }
 
@@ -1174,31 +1207,31 @@ private struct HistoryTotalCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             Text("All-time")
-                .font(.system(size: 10, weight: .bold))
+                .font(.system(size: 12, weight: .bold))
                 .foregroundStyle(.secondary)
             HStack(alignment: .firstTextBaseline, spacing: 14) {
                 Text(cost)
-                    .font(.system(size: 28, weight: .bold, design: .rounded))
+                    .font(.system(size: 34, weight: .bold, design: .rounded))
                     .monospacedDigit()
                     .foregroundStyle(companionOrange)
                     .lineLimit(1)
-                    .minimumScaleFactor(0.6)
+                    .minimumScaleFactor(0.8)
                 HStack(alignment: .firstTextBaseline, spacing: 3) {
                     Text(tokens)
-                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
                         .monospacedDigit()
                         .lineLimit(1)
-                        .minimumScaleFactor(0.6)
+                        .minimumScaleFactor(0.8)
                     Text("tokens")
-                        .font(.system(size: 11, weight: .semibold))
+                        .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(.secondary)
                 }
             }
             Text(days)
-                .font(.system(size: 10, weight: .medium))
+                .font(.system(size: 12, weight: .medium))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .minimumScaleFactor(0.72)
+                .minimumScaleFactor(0.8)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 13)
@@ -1218,18 +1251,18 @@ private struct HistoryStatPill: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 3) {
             Text(title)
-                .font(.system(size: 10, weight: .bold))
+                .font(.system(size: 12, weight: .bold))
                 .foregroundStyle(.secondary)
             Text(value)
-                .font(.system(size: 23, weight: .bold, design: .rounded))
+                .font(.system(size: 28, weight: .bold, design: .rounded))
                 .monospacedDigit()
                 .lineLimit(1)
-                .minimumScaleFactor(0.70)
+                .minimumScaleFactor(0.8)
             Text(detail)
-                .font(.system(size: 9, weight: .medium))
+                .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(.secondary)
                 .lineLimit(1)
-                .minimumScaleFactor(0.72)
+                .minimumScaleFactor(0.8)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 9)
@@ -1327,10 +1360,10 @@ private struct QuotaModeRow: View {
         HStack(spacing: 7) {
             HStack(spacing: 6) {
                 Image(systemName: "percent")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(color)
                 Text("Quota shows")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
@@ -1357,10 +1390,10 @@ private struct LayoutModeRow: View {
         HStack(spacing: 7) {
             HStack(spacing: 6) {
                 Image(systemName: "rectangle.split.1x2")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(color)
                 Text("Layout")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
@@ -1392,10 +1425,10 @@ private struct RefreshCadenceRow: View {
         HStack(spacing: 7) {
             HStack(spacing: 6) {
                 Image(systemName: "clock.arrow.circlepath")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(color)
                 Text("Refresh on open")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
@@ -1422,9 +1455,9 @@ private struct RefreshCadenceToggle: View {
             ForEach(RefreshCadence.allCases, id: \.self) { option in
                 Button(action: { onChange(option) }) {
                     Text(option.title)
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: 12, weight: .bold))
                         .lineLimit(1)
-                        .frame(width: 46, height: 24)
+                        .frame(width: 56, height: 32)
                         .foregroundStyle(option == selected ? Color.primary : Color.secondary)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -1455,10 +1488,10 @@ private struct AutoRefreshRow: View {
         HStack(spacing: 7) {
             HStack(spacing: 6) {
                 Image(systemName: "arrow.triangle.2.circlepath")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(color)
                 Text("Auto-refresh")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
@@ -1490,10 +1523,10 @@ private struct ThemeRow: View {
         HStack(spacing: 7) {
             HStack(spacing: 6) {
                 Image(systemName: "paintpalette.fill")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(color)
                 Text("Theme")
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
@@ -1524,9 +1557,9 @@ private struct SettingsSegment: View {
             ForEach(Array(titles.enumerated()), id: \.offset) { index, title in
                 Button(action: { onSelect(index) }) {
                     Text(title)
-                        .font(.system(size: 10, weight: .bold))
+                        .font(.system(size: 12, weight: .bold))
                         .lineLimit(1)
-                        .frame(width: 44, height: 24)
+                        .frame(width: 54, height: 32)
                         .foregroundStyle(index == selectedIndex ? Color.primary : Color.secondary)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -1555,10 +1588,10 @@ private struct SettingsStatusPill: View {
             ProviderDot(color: color)
             VStack(alignment: .leading, spacing: 1) {
                 Text(title)
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 12, weight: .bold))
                     .lineLimit(1)
                 Text(value)
-                    .font(.system(size: 9, weight: .medium))
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
             }
@@ -1585,8 +1618,8 @@ private struct HeaderIconButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: systemName)
-                .font(.system(size: 12, weight: .bold))
-                .frame(width: 26, height: 26)
+                .font(.system(size: 14, weight: .bold))
+                .frame(width: 34, height: 34)
                 .foregroundStyle(disabled ? .secondary.opacity(0.5) : tint)
                 .background(Circle().fill(tint.opacity(active ? 0.14 : 0.075)))
                 .contentShape(Rectangle())
@@ -1606,8 +1639,8 @@ private struct ToolbarIconButton: View {
     var body: some View {
         Button(action: action) {
             Image(systemName: systemName)
-                .font(.system(size: 12, weight: .bold))
-                .frame(width: 28, height: 28)
+                .font(.system(size: 14, weight: .bold))
+                .frame(width: 34, height: 34)
                 .foregroundStyle(tint)
                 .background(
                     RoundedRectangle(cornerRadius: 9, style: .continuous)
@@ -1714,16 +1747,16 @@ private struct CompactEmptyMessage: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: icon)
-                .font(.system(size: 13, weight: .bold))
+                .font(.system(size: 16, weight: .bold))
                 .foregroundStyle(.secondary)
             VStack(alignment: .leading, spacing: 1) {
                 Text(title)
-                    .font(.system(size: 10, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                 Text(detail)
-                    .font(.system(size: 9, weight: .medium))
+                    .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.8)
             }
             Spacer(minLength: 0)
         }
@@ -1794,12 +1827,12 @@ private struct HistoryBars: View {
                             bar(previous?.costUsd ?? 0, maxCost: maxCost, color: lastWeekColor)
                             bar(day.costUsd, maxCost: maxCost, color: companionOrange)
                         }
-                        .frame(maxHeight: 96, alignment: .bottom)
+                        .frame(maxHeight: 112, alignment: .bottom)
                         Text(String(day.date.suffix(2)))
-                            .font(.system(size: 10, weight: .bold))
+                            .font(.system(size: 12, weight: .bold))
                             .foregroundStyle(.secondary)
                     }
-                    .frame(maxWidth: .infinity, maxHeight: 116, alignment: .bottom)
+                    .frame(maxWidth: .infinity, maxHeight: 136, alignment: .bottom)
                     .help(historyHelp(day: day, previous: previous))
                 }
             }
@@ -1809,7 +1842,7 @@ private struct HistoryBars: View {
     private func bar(_ cost: Double, maxCost: Double, color: Color) -> some View {
         RoundedRectangle(cornerRadius: 3, style: .continuous)
             .fill(color)
-            .frame(width: 13, height: max(3, 96 * min(max(cost / maxCost, 0), 1)))
+            .frame(width: 13, height: max(3, 112 * min(max(cost / maxCost, 0), 1)))
     }
 
     private func legend(color: Color, label: String) -> some View {
@@ -1818,7 +1851,7 @@ private struct HistoryBars: View {
                 .fill(color)
                 .frame(width: 9, height: 9)
             Text(label)
-                .font(.system(size: 10, weight: .semibold))
+                .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.secondary)
         }
     }
@@ -1856,13 +1889,13 @@ private struct SubagentCard: View {
         VStack(alignment: .leading, spacing: 11) {
             HStack(spacing: 7) {
                 Image(systemName: "rectangle.stack.person.crop.fill")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(companionOrange)
                 Text("Subagents")
-                    .font(.system(size: 13, weight: .bold))
+                    .font(.system(size: 16, weight: .bold))
                 Spacer(minLength: 0)
                 Text("\(Int((subagents.share * 100).rounded()))% of all tokens")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
             }
 
@@ -1892,12 +1925,12 @@ private struct SubagentCard: View {
                                 .fill(companionOrange.opacity(0.7))
                                 .frame(width: 5, height: 5)
                             Text(agent.name)
-                                .font(.system(size: 11, weight: .semibold))
+                                .font(.system(size: 13, weight: .semibold))
                                 .lineLimit(1)
                                 .minimumScaleFactor(0.8)
                             Spacer(minLength: 6)
                             Text("\(formatTokens(agent.tokens)) · \(agent.invocations) runs")
-                                .font(.system(size: 10, weight: .medium))
+                                .font(.system(size: 12, weight: .medium))
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                         }
@@ -1932,13 +1965,13 @@ private struct ContributionHeatmap: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 7) {
                 Image(systemName: "square.grid.3x3.fill")
-                    .font(.system(size: 11, weight: .bold))
+                    .font(.system(size: 13, weight: .bold))
                     .foregroundStyle(companionOrange)
                 Text("Activity")
-                    .font(.system(size: 13, weight: .bold))
+                    .font(.system(size: 16, weight: .bold))
                 Spacer(minLength: 0)
                 Text("\(days.count) active days")
-                    .font(.system(size: 10, weight: .medium))
+                    .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(.secondary)
             }
             if grid.isEmpty {
@@ -1972,16 +2005,16 @@ private struct ContributionHeatmap: View {
                             }
                         }
                     }
-                    .frame(height: 72)
+                    .frame(height: 84)
                     .accessibilityLabel("Activity over the last year")
                     HStack(spacing: 4) {
-                        Text("Less").font(.system(size: 8)).foregroundStyle(.secondary)
+                        Text("Less").font(.system(size: 10)).foregroundStyle(.secondary)
                         ForEach(0...4, id: \.self) { level in
                             RoundedRectangle(cornerRadius: 2, style: .continuous)
                                 .fill(color(level))
                                 .frame(width: 8, height: 8)
                         }
-                        Text("More").font(.system(size: 8)).foregroundStyle(.secondary)
+                        Text("More").font(.system(size: 10)).foregroundStyle(.secondary)
                     }
                 }
             }
@@ -2169,14 +2202,14 @@ private struct StatusCapsule: View {
     var body: some View {
         HStack(spacing: 5) {
             Image(systemName: icon)
-                .font(.system(size: 10, weight: .bold))
+                .font(.system(size: 12, weight: .bold))
             Text(title)
-                .font(.system(size: 10, weight: .bold))
+                .font(.system(size: 12, weight: .bold))
                 .lineLimit(1)
         }
         .foregroundStyle(color)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 5)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
         .background(Capsule().fill(color.opacity(0.12)))
     }
 }

--- a/packages/menubar/Sources/TokscaleMenuBarCore/GraphCompanionAdapter.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/GraphCompanionAdapter.swift
@@ -97,8 +97,18 @@ public enum GraphCompanionAdapter {
 
     private struct UsageProvider: Decodable {
         let provider: String
+        let account: Account?
         let plan: String?
         let metrics: [Metric]
+        let status: String?
+
+        struct Account: Decodable {
+            let isActive: Bool
+
+            enum CodingKeys: String, CodingKey {
+                case isActive = "is_active"
+            }
+        }
 
         struct Metric: Decodable {
             let label: String
@@ -291,7 +301,8 @@ public enum GraphCompanionAdapter {
     public static func patchedQuota(
         companionData: Data,
         usageData: Data,
-        quotaRefreshedAt: String
+        quotaRefreshedAt: String,
+        authoritative: Bool = false
     ) -> Data? {
         guard var dict = (try? JSONSerialization.jsonObject(with: companionData)) as? [String: Any],
             let usage = try? JSONDecoder().decode([UsageProvider].self, from: usageData)
@@ -299,8 +310,31 @@ public enum GraphCompanionAdapter {
             return nil
         }
         let quota = quotaBreakdown(usage)
-        guard !quota.isEmpty else { return nil }
-        dict["quota"] = quota
+        let hasDetailedStatus = !usage.isEmpty && usage.allSatisfy { $0.status != nil }
+        let isAuthoritative = authoritative || hasDetailedStatus
+        guard isAuthoritative || !quota.isEmpty else { return nil }
+        var previous = [String: [String: Any]]()
+        for row in dict["quota"] as? [[String: Any]] ?? [] {
+            guard let provider = row["provider"] as? String else { continue }
+            previous[canonicalQuotaProviderID(provider)] = row
+        }
+        var merged = isAuthoritative ? [:] : previous
+        for refreshed in quota {
+            guard let provider = refreshed["provider"] as? String else { continue }
+            let id = canonicalQuotaProviderID(provider)
+            let status = refreshed["status"] as? String
+            let windows = refreshed["windows"] as? [[String: Any]] ?? []
+            if status != nil, windows.isEmpty, var cached = previous[id] {
+                cached["provider"] = quotaProviderDisplayName(provider)
+                cached["status"] = status
+                merged[id] = cached
+            } else {
+                merged[id] = refreshed
+            }
+        }
+        dict["quota"] = merged.values.sorted {
+            ($0["provider"] as? String ?? "") < ($1["provider"] as? String ?? "")
+        }
         if var health = dict["health"] as? [String: Any] {
             health["quotaRefreshedAt"] = quotaRefreshedAt
             dict["health"] = health
@@ -703,6 +737,7 @@ public enum GraphCompanionAdapter {
             provider["todayCostUsd"] = doubleValue(next?["todayCostUsd"])
             provider["todayTokens"] = int64Value(next?["todayTokens"])
             provider["todayMessages"] = intValue(next?["todayMessages"])
+            provider["todayCacheHitPercent"] = doubleValue(next?["todayCacheHitPercent"])
             provider["workTimeMs"] = int64Value(next?["workTimeMs"])
             provider["models"] = patchedModels(
                 provider["models"] as? [[String: Any]] ?? [],
@@ -815,6 +850,7 @@ public enum GraphCompanionAdapter {
         provider["costUsd"] = 0.0
         provider["tokens"] = Int64(0)
         provider["messages"] = 0
+        provider["cacheHitPercent"] = 0.0
         provider["models"] = (provider["models"] as? [[String: Any]] ?? [])
             .map(presentationOnlyModel)
         return provider
@@ -885,6 +921,9 @@ public enum GraphCompanionAdapter {
             var cacheRead: Int64 = 0
             var freshInput: Int64 = 0
             var cacheWrite: Int64 = 0
+            var todayCacheRead: Int64 = 0
+            var todayFreshInput: Int64 = 0
+            var todayCacheWrite: Int64 = 0
             var models: [String: ModelAcc] = [:]
         }
         struct ModelAcc {
@@ -915,6 +954,9 @@ public enum GraphCompanionAdapter {
                     acc.todayCost += client.cost
                     acc.todayTokens += tokenCount
                     acc.todayMessages += client.messages
+                    acc.todayCacheRead += client.tokens.cacheRead
+                    acc.todayFreshInput += client.tokens.input
+                    acc.todayCacheWrite += client.tokens.cacheWrite
                     model.todayCost += client.cost
                     model.todayTokens += tokenCount
                     model.todayMessages += client.messages
@@ -954,6 +996,12 @@ public enum GraphCompanionAdapter {
                     readTotal > 0
                     ? Double(acc.cacheRead) / Double(readTotal) * 100
                     : 0
+                let todayReadTotal =
+                    acc.todayCacheRead + acc.todayFreshInput + acc.todayCacheWrite
+                let todayCacheHitPercent =
+                    todayReadTotal > 0
+                    ? Double(acc.todayCacheRead) / Double(todayReadTotal) * 100
+                    : 0
                 var row: [String: Any] = [
                     "client": client,
                     "costUsd": acc.cost,
@@ -963,6 +1011,7 @@ public enum GraphCompanionAdapter {
                     "todayTokens": acc.todayTokens,
                     "todayMessages": acc.todayMessages,
                     "cacheHitPercent": cacheHitPercent,
+                    "todayCacheHitPercent": todayCacheHitPercent,
                     "workTimeMs": graph.todayWorkTime?[client] ?? 0,
                 ]
                 row["models"] = models
@@ -981,7 +1030,16 @@ public enum GraphCompanionAdapter {
     }
 
     private static func quotaBreakdown(_ usage: [UsageProvider]) -> [[String: Any]] {
-        usage
+        var selected = [String: UsageProvider]()
+        for output in usage {
+            let id = canonicalQuotaProviderID(output.provider)
+            if selected[id] == nil
+                || (output.account?.isActive == true && selected[id]?.account?.isActive != true)
+            {
+                selected[id] = output
+            }
+        }
+        return selected.values
             .compactMap { output -> [String: Any]? in
                 let windows: [[String: Any]] = output.metrics.map { metric in
                     var window: [String: Any] = [
@@ -997,15 +1055,31 @@ public enum GraphCompanionAdapter {
                     }
                     return window
                 }
-                if windows.isEmpty { return nil }
+                let status = output.status == "live" ? nil : output.status
+                if windows.isEmpty, status == nil { return nil }
                 var provider: [String: Any] = [
-                    "provider": output.provider,
+                    "provider": quotaProviderDisplayName(output.provider),
                     "windows": windows,
                 ]
                 if let plan = output.plan { provider["plan"] = plan }
+                if let status { provider["status"] = status }
                 return provider
             }
             .sorted { ($0["provider"] as? String ?? "") < ($1["provider"] as? String ?? "") }
+    }
+
+    private static func canonicalQuotaProviderID(_ provider: String) -> String {
+        let normalized = provider.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized == "grok build" || normalized == "grok" {
+            return "grok"
+        }
+        return normalized
+    }
+
+    private static func quotaProviderDisplayName(_ provider: String) -> String {
+        canonicalQuotaProviderID(provider) == "grok"
+            ? "Grok"
+            : provider.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private static func historyBreakdown(_ graph: Graph) -> [[String: Any]] {

--- a/packages/menubar/Sources/TokscaleMenuBarCore/TokscaleSummary.swift
+++ b/packages/menubar/Sources/TokscaleMenuBarCore/TokscaleSummary.swift
@@ -224,6 +224,7 @@ public struct TokscaleDashboardModel: Equatable {
     private let summaryStale: Bool
     private let quotaWasRefreshed: Bool
     private let providerDetailsById: [String: ProviderDetails]
+    private let quotaProviders: [TokscaleSummary.QuotaProvider]
 
     private static let quotaBoardProviderIds = ["claude", "codex", "gemini", "grok"]
 
@@ -256,6 +257,7 @@ public struct TokscaleDashboardModel: Equatable {
         let hasLiveQuotaRefresh = Self.isQuotaRefreshRecent(summary.health.quotaRefreshedAt, now: now)
         quotaWasRefreshed = hasLiveQuotaRefresh
         summaryStale = summary.stale
+        quotaProviders = summary.quota
         clientLabels = providerRows.map { clientDisplayName($0.client) }
         providers = Self.providerSummaries(rows: providerRows, totalCost: providerTotalCost)
         providerDetailsById = Dictionary(
@@ -273,7 +275,7 @@ public struct TokscaleDashboardModel: Equatable {
                         models: row.models,
                         share: Self.providerShare(row.costUsd, totalCost: providerTotalCost),
                         hasLiveQuotaRefresh: hasLiveQuotaRefresh,
-                        cacheHitPercent: row.cacheHitPercent,
+                        cacheHitPercent: row.todayCacheHitPercent,
                         workTimeMs: row.workTimeMs
                     )
                 )
@@ -375,6 +377,9 @@ public struct TokscaleDashboardModel: Equatable {
     }
 
     public func providerFocus(for id: String?) -> ProviderFocus {
+        if let id, let focus = providerFocusIfAvailable(for: id) {
+            return focus
+        }
         let details = providerDetails(for: id)
         return providerFocus(details: details)
     }
@@ -384,9 +389,8 @@ public struct TokscaleDashboardModel: Equatable {
             return providerFocus(details: details)
         }
         let title = clientDisplayName(id)
-        let hasQuota = quotaWindows.contains { window in
-            let provider = window.provider.lowercased()
-            return provider == id || provider == title.lowercased()
+        let hasQuota = quotaProviders.contains {
+            canonicalQuotaProviderID($0.provider) == canonicalQuotaProviderID(id)
         }
         guard hasQuota else {
             return nil
@@ -410,13 +414,21 @@ public struct TokscaleDashboardModel: Equatable {
     }
 
     private func providerFocus(details: ProviderDetails) -> ProviderFocus {
-        let normalized = details.id.lowercased()
+        let normalized = canonicalQuotaProviderID(details.id)
         let quota = quotaWindows.filter { window in
-            let provider = window.provider.lowercased()
-            return provider == details.title.lowercased() || provider == normalized
+            canonicalQuotaProviderID(window.provider) == normalized
+        }
+        let provider = quotaProviders.first {
+            canonicalQuotaProviderID($0.provider) == normalized
         }
         let primary = quota.first { Self.isFiveHourQuotaTitle($0.title) } ?? quota.first
         let weekly = quota.first { Self.isWeeklyQuotaTitle($0.title) }
+        let quotaPresentation = Self.quotaPresentation(
+            status: provider?.status,
+            hasWindows: !quota.isEmpty,
+            providerID: normalized,
+            isCached: summaryStale && !details.hasLiveQuotaRefresh
+        )
 
         return ProviderFocus(
             id: details.id,
@@ -431,7 +443,8 @@ public struct TokscaleDashboardModel: Equatable {
             quotaWindows: quota,
             primaryQuota: primary,
             weeklyQuota: weekly,
-            quotaStatus: quota.isEmpty ? "No live quota" : (summaryStale && !details.hasLiveQuotaRefresh ? "Cached" : "Live"),
+            quotaStatus: quotaPresentation.status,
+            quotaStatusDetail: quotaPresentation.detail,
             workTime: formatWorkTime(details.workTimeMs),
             focusedModelTime: Self.focusedModelTimeLabel(providerId: details.id, model: details.model),
             cacheHitPercent: details.cacheHitPercent
@@ -502,6 +515,39 @@ public struct TokscaleDashboardModel: Equatable {
                     remainingPercent: remainingPercent
                 )
             }
+        }
+    }
+
+    private static func quotaPresentation(
+        status: String?,
+        hasWindows: Bool,
+        providerID: String,
+        isCached: Bool
+    ) -> (status: String, detail: String) {
+        switch status {
+        case "auth-expired", "needs-auth":
+            if hasWindows {
+                return ("Cached", "Auth expired; kept last successful quota.")
+            }
+            let detail = providerID == "grok"
+                ? "Sign in to Grok to refresh credits."
+                : "Sign in again to refresh quota."
+            return ("Auth expired", detail)
+        case "rate-limited":
+            return hasWindows
+                ? ("Cached", "Rate limited; kept last successful quota.")
+                : ("Rate limited", "Live quota is temporarily unavailable.")
+        case "unavailable":
+            return hasWindows
+                ? ("Cached", "Live refresh failed; kept last successful quota.")
+                : ("Unavailable", "Local usage remains available.")
+        default:
+            if hasWindows {
+                return isCached
+                    ? ("Cached", "Last successful quota snapshot.")
+                    : ("Live", "Live subscription quota.")
+            }
+            return ("No live quota", "Local usage remains available.")
         }
     }
 
@@ -807,6 +853,7 @@ public extension TokscaleDashboardModel {
         public let primaryQuota: QuotaWindowSummary?
         public let weeklyQuota: QuotaWindowSummary?
         public let quotaStatus: String
+        public let quotaStatusDetail: String
         public let workTime: String
         public let focusedModelTime: String
         public let cacheHitPercent: Double
@@ -888,11 +935,13 @@ public extension TokscaleSummary {
         public let topModel: String?
         public let models: [ProviderModel]
         public let cacheHitPercent: Double
+        public let todayCacheHitPercent: Double
         public let workTimeMs: Int64
 
         enum CodingKeys: String, CodingKey {
             case client, costUsd, tokens, messages
             case todayCostUsd, todayTokens, todayMessages, topModel, models, cacheHitPercent
+            case todayCacheHitPercent
             case workTimeMs
         }
 
@@ -908,6 +957,7 @@ public extension TokscaleSummary {
             topModel = try c.decodeIfPresent(String.self, forKey: .topModel)
             models = try c.decodeIfPresent([ProviderModel].self, forKey: .models) ?? []
             cacheHitPercent = try c.decodeIfPresent(Double.self, forKey: .cacheHitPercent) ?? 0
+            todayCacheHitPercent = try c.decodeIfPresent(Double.self, forKey: .todayCacheHitPercent) ?? 0
             workTimeMs = try c.decodeIfPresent(Int64.self, forKey: .workTimeMs) ?? 0
         }
 
@@ -922,6 +972,7 @@ public extension TokscaleSummary {
             topModel: String?,
             models: [ProviderModel] = [],
             cacheHitPercent: Double = 0,
+            todayCacheHitPercent: Double = 0,
             workTimeMs: Int64 = 0
         ) {
             self.client = client
@@ -934,6 +985,7 @@ public extension TokscaleSummary {
             self.topModel = topModel
             self.models = models
             self.cacheHitPercent = cacheHitPercent
+            self.todayCacheHitPercent = todayCacheHitPercent
             self.workTimeMs = workTimeMs
         }
     }
@@ -970,6 +1022,19 @@ public extension TokscaleSummary {
         public let provider: String
         public let plan: String?
         public let windows: [QuotaWindow]
+        public let status: String?
+
+        public init(
+            provider: String,
+            plan: String?,
+            windows: [QuotaWindow],
+            status: String? = nil
+        ) {
+            self.provider = provider
+            self.plan = plan
+            self.windows = windows
+            self.status = status
+        }
     }
 
     struct QuotaWindow: Decodable, Equatable {
@@ -1049,6 +1114,14 @@ private func clientDisplayName(_ value: String) -> String {
     default:
         return value.prefix(1).uppercased() + value.dropFirst()
     }
+}
+
+private func canonicalQuotaProviderID(_ value: String) -> String {
+    let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    if normalized == "grok build" || normalized == "grok" {
+        return "grok"
+    }
+    return normalized
 }
 
 private func formatUSD(_ value: Double) -> String {

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/GraphCompanionAdapterTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/GraphCompanionAdapterTests.swift
@@ -398,6 +398,30 @@ final class GraphCompanionAdapterTests: XCTestCase {
         XCTAssertNil(patched)
     }
 
+    func testAuthoritativeEmptyQuotaClearsPreviousProviders() throws {
+        let base = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: Data(usageJSON.utf8),
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: "2026-06-07T03:01:00+00:00"
+        )
+
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchedQuota(
+                companionData: base,
+                usageData: Data("[]".utf8),
+                quotaRefreshedAt: "2026-06-07T04:00:00+00:00",
+                authoritative: true
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+
+        XCTAssertTrue(summary.quota.isEmpty)
+        XCTAssertEqual(summary.health.quotaRefreshedAt, "2026-06-07T04:00:00+00:00")
+    }
+
     func testPatchedQuotaReplacesWindowsWhenUsagePresent() throws {
         let base = try GraphCompanionAdapter.companionJSON(
             graphData: Data(graphJSON.utf8),
@@ -418,6 +442,106 @@ final class GraphCompanionAdapterTests: XCTestCase {
         XCTAssertEqual(summary.quota.count, 1)
         XCTAssertEqual(summary.quota[0].provider, "Claude")
         XCTAssertEqual(summary.health.quotaRefreshedAt, "2026-06-07T04:00:00+00:00")
+    }
+
+    func testPatchedQuotaPreservesFailedProvidersWhileUpdatingSuccessfulOnes() throws {
+        let initialUsage = Data(
+            """
+            [
+              { "provider": "Claude", "plan": "Max", "metrics": [
+                { "label": "Session", "used_percent": 12.0, "remaining_percent": 88.0,
+                  "remaining_label": "88% left", "resets_at": null }
+              ] },
+              { "provider": "Grok Build", "plan": "SuperGrok", "metrics": [
+                { "label": "Credits", "used_percent": 15.0, "remaining_percent": 85.0,
+                  "remaining_label": "85% left", "resets_at": null }
+              ] },
+              { "provider": "Gemini", "plan": null, "metrics": [
+                { "label": "Pro", "used_percent": 2.0, "remaining_percent": 98.0,
+                  "remaining_label": "98% left", "resets_at": null }
+              ] }
+            ]
+            """.utf8
+        )
+        let base = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graphJSON.utf8),
+            usageData: initialUsage,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: "2026-06-07T03:01:00+00:00"
+        )
+        let refresh = Data(
+            """
+            [
+              { "provider": "Claude", "plan": null, "metrics": [], "status": "rate-limited" },
+              { "provider": "Grok Build", "plan": null, "metrics": [], "status": "auth-expired" },
+              { "provider": "Codex", "plan": "Pro", "status": "live", "metrics": [
+                { "label": "Session", "used_percent": 8.0, "remaining_percent": 92.0,
+                  "remaining_label": "92% left", "resets_at": null }
+              ] }
+            ]
+            """.utf8
+        )
+
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchedQuota(
+                companionData: base,
+                usageData: refresh,
+                quotaRefreshedAt: "2026-06-07T04:00:00+00:00"
+            )
+        )
+        let summary = try TokscaleSummary.decode(patched)
+        let claude = try XCTUnwrap(summary.quota.first { $0.provider == "Claude" })
+        let grok = try XCTUnwrap(summary.quota.first { $0.provider == "Grok" })
+        let codex = try XCTUnwrap(summary.quota.first { $0.provider == "Codex" })
+
+        XCTAssertEqual(claude.windows.count, 1)
+        XCTAssertEqual(claude.status, "rate-limited")
+        XCTAssertEqual(grok.windows.count, 1)
+        XCTAssertEqual(grok.status, "auth-expired")
+        XCTAssertEqual(codex.windows.count, 1)
+        XCTAssertNil(codex.status)
+        XCTAssertFalse(summary.quota.contains { $0.provider == "Gemini" })
+    }
+
+    func testGrokBuildQuotaCanonicalizesToGrok() throws {
+        let usage = Data(
+            """
+            [{ "provider": "Grok Build", "plan": "SuperGrok", "metrics": [
+              { "label": "Credits", "used_percent": 15.0, "remaining_percent": 85.0,
+                "remaining_label": "85% left", "resets_at": null }
+            ] }]
+            """.utf8
+        )
+
+        let summary = try makeSummary(usage: usage)
+
+        XCTAssertEqual(summary.quota.first?.provider, "Grok")
+    }
+
+    func testQuotaUsesActiveCodexAccountWhenMultipleAccountsAreReturned() throws {
+        let usage = Data(
+            """
+            [
+              { "provider": "Codex", "account": { "id": "active", "is_active": true },
+                "plan": "Pro", "status": "live", "metrics": [
+                  { "label": "Session", "used_percent": 20.0, "remaining_percent": 80.0,
+                    "remaining_label": "80% left", "resets_at": null }
+                ] },
+              { "provider": "Codex", "account": { "id": "inactive", "is_active": false },
+                "plan": "Pro", "status": "live", "metrics": [
+                  { "label": "Session", "used_percent": 80.0, "remaining_percent": 20.0,
+                    "remaining_label": "20% left", "resets_at": null }
+                ] }
+            ]
+            """.utf8
+        )
+
+        let summary = try makeSummary(usage: usage)
+        let codex = try XCTUnwrap(summary.quota.first { $0.provider == "Codex" })
+
+        XCTAssertEqual(codex.windows.first?.usedPercent, 20.0)
     }
 
     func testRemoteProfileKeepsAccountAggregatesWhileLocalTodayWinsPresentation() throws {
@@ -1109,6 +1233,92 @@ final class GraphCompanionAdapterTests: XCTestCase {
         let summary = try TokscaleSummary.decode(companion)
         let claude = try XCTUnwrap(summary.providers.first { $0.client == "claude" })
         XCTAssertEqual(claude.cacheHitPercent, 90.0, accuracy: 0.01)
+    }
+
+    func testTodayCacheHitDoesNotReuseLifetimeOrYesterdayValues() throws {
+        let graph = """
+        {
+          "meta": { "generatedAt": "2026-06-07T03:00:00+00:00", "version": "3.0.3",
+                    "dateRange": { "start": "2026-06-06", "end": "2026-06-07" } },
+          "summary": {
+            "totalTokens": 1100, "totalCost": 11.0, "activeDays": 2,
+            "averagePerDay": 5.5, "maxCostInSingleDay": 10.0,
+            "clients": ["grok", "claude"], "models": ["grok-build", "claude-sonnet"]
+          },
+          "years": [],
+          "contributions": [
+            {
+              "date": "2026-06-06", "intensity": 4,
+              "totals": { "tokens": 1000, "cost": 10.0, "messages": 4 },
+              "clients": [
+                { "client": "grok", "modelId": "grok-build", "providerId": "xai",
+                  "cost": 10.0, "messages": 4,
+                  "tokens": { "input": 100, "output": 0, "cacheRead": 900,
+                              "cacheWrite": 0, "reasoning": 0 } }
+              ]
+            },
+            {
+              "date": "2026-06-07", "intensity": 2,
+              "totals": { "tokens": 100, "cost": 1.0, "messages": 1 },
+              "clients": [
+                { "client": "claude", "modelId": "claude-sonnet", "providerId": "anthropic",
+                  "cost": 1.0, "messages": 1,
+                  "tokens": { "input": 50, "output": 0, "cacheRead": 50,
+                              "cacheWrite": 0, "reasoning": 0 } }
+              ]
+            }
+          ]
+        }
+        """
+        let companion = try GraphCompanionAdapter.companionJSON(
+            graphData: Data(graph.utf8),
+            usageData: nil,
+            todayDate: "2026-06-07",
+            summaryPath: "/tmp/companion-summary.json",
+            lastScanDurationMs: 1,
+            quotaRefreshedAt: nil
+        )
+        let initial = try TokscaleSummary.decode(companion)
+        let initialGrok = try XCTUnwrap(initial.providers.first { $0.client == "grok" })
+        let initialClaude = try XCTUnwrap(initial.providers.first { $0.client == "claude" })
+
+        XCTAssertEqual(initialGrok.cacheHitPercent, 90.0, accuracy: 0.01)
+        XCTAssertEqual(initialGrok.todayCacheHitPercent, 0.0, accuracy: 0.01)
+        XCTAssertEqual(initialClaude.todayCacheHitPercent, 50.0, accuracy: 0.01)
+
+        let todayGraph = """
+        {
+          "meta": { "generatedAt": "2026-06-07T09:00:00+00:00", "version": "3.0.3",
+                    "dateRange": { "start": "2026-06-07", "end": "2026-06-07" } },
+          "summary": { "totalTokens": 100, "totalCost": 2.0, "activeDays": 1,
+                       "averagePerDay": 2.0, "maxCostInSingleDay": 2.0,
+                       "clients": ["claude"], "models": ["claude-sonnet"] },
+          "years": [],
+          "contributions": [
+            { "date": "2026-06-07", "intensity": 2,
+              "totals": { "tokens": 100, "cost": 2.0, "messages": 1 },
+              "clients": [
+                { "client": "claude", "modelId": "claude-sonnet", "providerId": "anthropic",
+                  "cost": 2.0, "messages": 1,
+                  "tokens": { "input": 20, "output": 0, "cacheRead": 80,
+                              "cacheWrite": 0, "reasoning": 0 } }
+              ] }
+          ]
+        }
+        """
+        let patched = try XCTUnwrap(
+            GraphCompanionAdapter.patchTodayData(
+                companionData: companion,
+                todayGraphData: Data(todayGraph.utf8),
+                todayDate: "2026-06-07"
+            )
+        )
+        let refreshed = try TokscaleSummary.decode(patched)
+        let refreshedGrok = try XCTUnwrap(refreshed.providers.first { $0.client == "grok" })
+        let refreshedClaude = try XCTUnwrap(refreshed.providers.first { $0.client == "claude" })
+
+        XCTAssertEqual(refreshedGrok.todayCacheHitPercent, 0.0, accuracy: 0.01)
+        XCTAssertEqual(refreshedClaude.todayCacheHitPercent, 80.0, accuracy: 0.01)
     }
 
     // `graph --work-time` adds a top-level todayWorkTime map (client → active ms).

--- a/packages/menubar/Tests/TokscaleMenuBarCoreTests/TokscaleSummaryTests.swift
+++ b/packages/menubar/Tests/TokscaleMenuBarCoreTests/TokscaleSummaryTests.swift
@@ -381,6 +381,60 @@ final class TokscaleSummaryTests: XCTestCase {
         XCTAssertEqual(grok.primaryQuota?.detail(for: .remaining), "15% used")
     }
 
+    func testDashboardMatchesGrokBuildAndShowsExpiredAuthStatus() throws {
+        let data = sampleSummaryJSON(
+            topJSON: #""client":"codex","model":"gpt-5.5""#,
+            accuracyJSON: #""confidence":"medium","sourceKinds":["local-scan"],"warnings":[]"#,
+            quotaJSON: """
+            [
+              {
+                "provider": "Grok Build",
+                "plan": null,
+                "status": "auth-expired",
+                "windows": []
+              }
+            ]
+            """
+        ).data(using: .utf8)!
+        let summary = try TokscaleSummary.decode(data)
+
+        let grok = TokscaleDashboardModel(summary: summary).providerFocus(for: "grok")
+
+        XCTAssertEqual(grok.quotaStatus, "Auth expired")
+        XCTAssertEqual(grok.quotaStatusDetail, "Sign in to Grok to refresh credits.")
+    }
+
+    func testDashboardShowsCachedQuotaWhenRefreshIsRateLimited() throws {
+        let data = sampleSummaryJSON(
+            topJSON: #""client":"claude","model":"claude-sonnet""#,
+            accuracyJSON: #""confidence":"medium","sourceKinds":["local-scan"],"warnings":[]"#,
+            quotaJSON: """
+            [
+              {
+                "provider": "Claude",
+                "plan": "Max",
+                "status": "rate-limited",
+                "windows": [
+                  {
+                    "label": "Session",
+                    "usedPercent": 8.0,
+                    "remainingPercent": 92.0,
+                    "resetsAt": null
+                  }
+                ]
+              }
+            ]
+            """
+        ).data(using: .utf8)!
+        let summary = try TokscaleSummary.decode(data)
+
+        let claude = TokscaleDashboardModel(summary: summary).providerFocus(for: "claude")
+
+        XCTAssertEqual(claude.quotaStatus, "Cached")
+        XCTAssertEqual(claude.quotaStatusDetail, "Rate limited; kept last successful quota.")
+        XCTAssertEqual(claude.primaryQuota?.title, "5h")
+    }
+
     func testDashboardModelUsesSingleSharedGrokCreditQuota() throws {
         let data = """
         {
@@ -462,6 +516,23 @@ final class TokscaleSummaryTests: XCTestCase {
         XCTAssertEqual(grok.primaryQuota?.title, "Credits")
         XCTAssertEqual(grok.primaryQuota?.value(for: .remaining), "80.0% left")
         XCTAssertEqual(grok.modelCostDetail, "grok $3.00 / composer $1.00")
+    }
+
+    func testProviderFocusUsesTodayCacheHitInsteadOfLifetimeValue() throws {
+        var dictionary = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: sampleSummaryData()) as? [String: Any]
+        )
+        var providers = try XCTUnwrap(dictionary["providers"] as? [[String: Any]])
+        let index = try XCTUnwrap(providers.firstIndex { ($0["client"] as? String) == "claude" })
+        providers[index]["cacheHitPercent"] = 97.6
+        providers[index]["todayCacheHitPercent"] = 42.5
+        dictionary["providers"] = providers
+        let data = try JSONSerialization.data(withJSONObject: dictionary)
+        let summary = try TokscaleSummary.decode(data)
+
+        let claude = TokscaleDashboardModel(summary: summary).providerFocus(for: "claude")
+
+        XCTAssertEqual(claude.cacheHitPercent, 42.5, accuracy: 0.01)
     }
 
     func testDashboardTreatsQuotaRefreshAsLiveWhenHistoryIsStale() throws {

--- a/packages/menubar/scripts/build-app.sh
+++ b/packages/menubar/scripts/build-app.sh
@@ -4,14 +4,14 @@ set -euo pipefail
 package_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$package_dir"
 
-swift build -c debug
+swift build -c release
 
 app_dir="$package_dir/.build/TokscaleMenuBar.app"
 contents_dir="$app_dir/Contents"
 macos_dir="$contents_dir/MacOS"
 
 mkdir -p "$macos_dir"
-cp "$package_dir/.build/debug/tokens-menubar" "$macos_dir/tokens-menubar"
+cp "$package_dir/.build/release/tokens-menubar" "$macos_dir/tokens-menubar"
 
 cat >"$contents_dir/Info.plist" <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
## Summary

- report Claude and Grok authentication, rate-limit, and availability states without exposing raw provider errors
- keep quota snapshots authoritative, canonicalize provider names, select the active Codex account, and separate today's cache ratio from lifetime history
- enlarge the macOS menubar interface, clarify local-today versus account-history totals, and build the installed app in release mode

## Verification

- `cargo test --workspace`
- `cargo clippy -p tokscale-cli --all-targets -- -D warnings`
- `swift test --package-path packages/menubar`
- release app installed and inspected across Glance, History, and Settings
- `codesign --verify --deep --strict /Applications/Tokens.app`
