### PR TITLE
fix(leaderboard): remove duplicate aggregate tooltips

### DIFF
--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -1321,7 +1321,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
             <MetricValue
               $accent
               aria-label={`Tokens ${data.stats.totalTokens.toLocaleString("en-US")}`}
-              title={data.stats.totalTokens.toLocaleString("en-US")}
             >
               <HoverTooltip data-tooltip={data.stats.totalTokens.toLocaleString('en-US')}>
                 {formatNumber(data.stats.totalTokens)}
@@ -1332,7 +1331,6 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
             <MetricLabel>Cost</MetricLabel>
             <MetricValue
               aria-label={`Cost ${data.stats.totalCost.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 2 })}`}
-              title={data.stats.totalCost.toLocaleString("en-US", { style: "currency", currency: "USD", minimumFractionDigits: 2 })}
             >
               <HoverTooltip data-tooltip={data.stats.totalCost.toLocaleString('en-US', { style: 'currency', currency: 'USD', minimumFractionDigits: 2 })}>
                 {formatCurrency(data.stats.totalCost)}


### PR DESCRIPTION

<img width="1132" height="316" alt="image" src="https://github.com/user-attachments/assets/3e1a3cc8-5a60-4b23-b813-7ba022488bfa" />


## Summary

- Remove redundant native `title` tooltips from the aggregate Tokens and Cost metrics.
- Preserve the accessible full-value labels and existing custom tooltip markup.
- Prevent the gray browser-native popup from appearing over the leaderboard summary.

## Testing

- ESLint passed for `LeaderboardClient.tsx`.
- Frontend TypeScript typecheck passed.
- `formatTokenCount.test.ts`: 9 tests passed.
- Verified in `/leaderboard` that both aggregate metrics no longer expose a native `title`, while `aria-label` and `data-tooltip` remain.