### PR TITLE
fix(leaderboard): treat missing rank as empty state, not an error

### DIFF
--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -654,6 +654,19 @@ const ErrorBanner = styled.div`
   gap: 8px;
 `;
 
+const NoticeBanner = styled.div`
+  margin-bottom: 24px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--service-border);
+  background: var(--service-surface-muted);
+  color: var(--service-text-muted);
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
 const SortLabel = styled.span`
   color: var(--service-text-muted);
   font-size: 0.8125rem;
@@ -1204,6 +1217,9 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
       signal: abortController.signal,
     })
       .then((res) => {
+        // 404 means the user simply has no submissions in this period —
+        // that's an empty state, not a failure.
+        if (res.status === 404) return null;
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         return res.json();
       })
@@ -1351,6 +1367,16 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
         <ErrorBanner>
           <span>Unable to load your ranking. Please refresh the page.</span>
         </ErrorBanner>
+      )}
+
+      {currentUser && !currentUserRankError && !currentUserRank && !isLoading && (
+        <NoticeBanner>
+          <span>
+            {period === "today"
+              ? "You haven't submitted any usage today yet."
+              : "No submissions from you in this period yet."}
+          </span>
+        </NoticeBanner>
       )}
 
       {currentUser && currentUserRank && (


### PR DESCRIPTION
## Problem

Since Today became the default leaderboard period (e2ee7e52), any signed-in user who hasn't submitted yet that day sees **"Unable to load your ranking. Please refresh the page."** on page load. Refreshing doesn't help.

Root cause: `/api/leaderboard/user/[username]` returns **404** when the user has no submissions in the selected period (`getUserRank` → `null`), and the client treated every non-OK response as a hard failure.

## Fix

- The rank fetch now resolves a 404 to a `null` rank instead of throwing, so the error state is reserved for real failures (5xx / network).
- When the viewer has no rank in the selected period, a muted, period-aware notice is shown instead of the red error banner:
  - Today: *"You haven't submitted any usage today yet."*
  - Other periods: *"No submissions from you in this period yet."*
- The notice is suppressed while the leaderboard is loading to avoid flashing a stale-period message during period switches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
