### PR TITLE
ci(deploy): read the server address from a secret instead of hardcoding it

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - name: Configure SSH
         env:
+          DEPLOY_HOST: ${{ secrets.TOKENS_DEPLOY_HOST }}
           DEPLOY_KNOWN_HOSTS: ${{ secrets.TOKENS_DEPLOY_KNOWN_HOSTS }}
           DEPLOY_SSH_KEY: ${{ secrets.TOKENS_DEPLOY_SSH_KEY }}
         run: |
@@ -29,6 +30,11 @@ jobs:
 
           if [ -z "${DEPLOY_SSH_KEY}" ]; then
             echo "TOKENS_DEPLOY_SSH_KEY secret is required." >&2
+            exit 1
+          fi
+
+          if [ -z "${DEPLOY_HOST}" ]; then
+            echo "TOKENS_DEPLOY_HOST secret is required." >&2
             exit 1
           fi
 
@@ -41,15 +47,17 @@ jobs:
           if [ -n "${DEPLOY_KNOWN_HOSTS}" ]; then
             printf '%s\n' "${DEPLOY_KNOWN_HOSTS}" | tr -d '\r' > ~/.ssh/known_hosts
           else
-            ssh-keyscan -T 10 -H 23.191.8.35 > ~/.ssh/known_hosts
+            ssh-keyscan -T 10 -H "${DEPLOY_HOST}" > ~/.ssh/known_hosts
           fi
           chmod 600 ~/.ssh/known_hosts
 
       - name: Deploy on server
+        env:
+          DEPLOY_HOST: ${{ secrets.TOKENS_DEPLOY_HOST }}
         run: |
           set -euo pipefail
 
-          ssh -i ~/.ssh/tokens_deploy -o IdentitiesOnly=yes root@23.191.8.35 <<'EOF'
+          ssh -i ~/.ssh/tokens_deploy -o IdentitiesOnly=yes "root@${DEPLOY_HOST}" <<'EOF'
             set -euo pipefail
             cd /root/tokens
             git pull --ff-only


### PR DESCRIPTION
The deploy workflow hardcoded the production server IP in two places (the `ssh-keyscan` fallback and the `ssh` target). Since this is a public repository, that published the server address to anyone reading the workflow.

## Changes

- The server address now comes from a new `TOKENS_DEPLOY_HOST` repository secret (already set). Secrets are also masked in Actions logs, so the address no longer appears in run output.
- Both steps fail fast with a clear message if the secret is missing.
- No behavior change otherwise: the `TOKENS_DEPLOY_KNOWN_HOSTS` override and the keyscan fallback work exactly as before.

## Caveats worth knowing

- The IP remains visible in **git history** of this file and in logs of past workflow runs (Actions log retention ~90 days). If the goal is that nobody can learn the server address from this repo, the IP itself should eventually be rotated, or history rewritten — moving it to a secret stops future exposure but does not erase the past.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
