### PR TITLE
feat(profile): add verified badge for users with 2+ GitHub social links

### DIFF
--- a/packages/frontend/__tests__/api/githubAuthReturnTo.test.ts
+++ b/packages/frontend/__tests__/api/githubAuthReturnTo.test.ts
@@ -107,6 +107,10 @@ vi.mock("drizzle-orm", () => ({
   eq: vi.fn(() => "eq"),
 }));
 
+vi.mock("@/lib/githubSocials", () => ({
+  syncGitHubSocialLinks: vi.fn(async () => []),
+}));
+
 type StartRouteExports = typeof import("../../src/app/api/auth/github/route");
 type CallbackRouteExports = typeof import("../../src/app/api/auth/github/callback/route");
 

--- a/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getGroupLeaderboard.test.ts
@@ -245,6 +245,7 @@ describe("group leaderboard data", () => {
       "totalTokens",
       "userId",
       "username",
+      "verified",
     ]);
     expect(selectedKeys(1)).toEqual([
       "userId",

--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -239,6 +239,7 @@ describe("period leaderboard data", () => {
       "totalTokens",
       "userId",
       "username",
+      "verified",
     ]);
     expect(leaderboard.stats).toEqual({
       totalTokens: 1250,
@@ -250,6 +251,7 @@ describe("period leaderboard data", () => {
       "username",
       "displayName",
       "avatarUrl",
+      "verified",
       "tokens",
       "cost",
       "sourceBreakdown",

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -348,6 +348,7 @@ describe("all-time leaderboard queries", () => {
       "username",
       "displayName",
       "avatarUrl",
+      "verified",
       "totalTokens",
       "totalCost",
     ]);
@@ -364,6 +365,7 @@ describe("all-time leaderboard queries", () => {
       "totalTokens",
       "userId",
       "username",
+      "verified",
     ]);
     expect(leaderboard.stats).toEqual({
       totalTokens: 3000,
@@ -407,6 +409,7 @@ describe("all-time leaderboard queries", () => {
       "totalTokens",
       "userId",
       "username",
+      "verified",
     ]);
   });
 

--- a/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
+++ b/packages/frontend/src/app/(main)/leaderboard/LeaderboardClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "nextjs-toploader/app";
 import { useSearchParams, usePathname } from "next/navigation";
 import styled from "styled-components";
 import { CopyIcon, CheckIcon, SearchIcon, XIcon } from "@/components/ui/Icons";
+import { VerifiedBadge } from "@/components/ui/VerifiedBadge";
 import { LeaderboardSkeleton } from "@/components/Skeleton";
 import {
   MetricItem,
@@ -327,6 +328,18 @@ const DesktopAvatar = styled.img`
   object-fit: cover;
   outline: 1px solid var(--service-border);
   outline-offset: -1px;
+`;
+
+const AvatarWrap = styled.span`
+  position: relative;
+  display: inline-flex;
+  flex: 0 0 auto;
+`;
+
+const AvatarVerifiedBadge = styled(VerifiedBadge)`
+  position: absolute;
+  right: -3px;
+  bottom: -3px;
 `;
 
 const UserInfo = styled.div`
@@ -975,10 +988,13 @@ const LeaderboardRow = memo(function LeaderboardRow({
           onClick={(event) => event.stopPropagation()}
           aria-current={isCurrentUser ? "true" : undefined}
         >
-          <DesktopAvatar
-            src={user.avatarUrl || `https://github.com/${user.username}.png`}
-            alt=""
-          />
+          <AvatarWrap>
+            <DesktopAvatar
+              src={user.avatarUrl || `https://github.com/${user.username}.png`}
+              alt=""
+            />
+            {user.verified && <AvatarVerifiedBadge size={14} />}
+          </AvatarWrap>
           <UserInfo>
             <UserDisplayName>
               {user.displayName || user.username}
@@ -1031,6 +1047,7 @@ function LeaderboardMobileRow({
       avatarUrl={user.avatarUrl}
       username={user.username}
       displayName={user.displayName || user.username}
+      verified={user.verified}
       primaryLabel={primary.label}
       primaryValue={primary.value}
       meta={secondary}
@@ -1392,10 +1409,13 @@ export default function LeaderboardClient({ initialData, currentUser, initialSor
           }}
         >
           <CurrentUserInfo>
-            <CurrentUserAvatar
-              src={currentUser.avatarUrl || `https://github.com/${currentUser.username}.png`}
-              alt=""
-            />
+            <AvatarWrap>
+              <CurrentUserAvatar
+                src={currentUser.avatarUrl || `https://github.com/${currentUser.username}.png`}
+                alt=""
+              />
+              {currentUserRank.verified && <AvatarVerifiedBadge size={14} />}
+            </AvatarWrap>
             <CurrentUserDetails>
               <CurrentUserName>
                 {currentUser.displayName || currentUser.username}

--- a/packages/frontend/src/app/api/auth/github/callback/route.ts
+++ b/packages/frontend/src/app/api/auth/github/callback/route.ts
@@ -8,6 +8,7 @@ import {
 import { sanitizeAuthReturnTo } from "@/lib/auth/returnTo";
 import { createSession, setSessionCookie } from "@/lib/auth/session";
 import { db, users } from "@/lib/db";
+import { syncGitHubSocialLinks } from "@/lib/githubSocials";
 import { eq } from "drizzle-orm";
 
 export async function GET(request: Request) {
@@ -95,6 +96,10 @@ export async function GET(request: Request) {
 
       userId = newUser.id;
     }
+
+    // Refresh the social-links snapshot in the background; login must not
+    // wait on the GitHub API.
+    void syncGitHubSocialLinks(githubUser.login);
 
     // Create session
     const sessionToken = await createSession(userId, {

--- a/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
+++ b/packages/frontend/src/app/u/[username]/ProfilePageClient.tsx
@@ -28,6 +28,7 @@ import {
   type ProfileUser,
 } from "@/components/profile";
 import type { DailyContribution } from "@/lib/types";
+import { isVerifiedBySocialLinks } from "@/lib/socialVerification";
 import { useSettings } from "@/lib/useSettings";
 
 type ProfilePeriod = "all" | "week" | "month";
@@ -237,6 +238,7 @@ export default function ProfilePageClient({
             lastUpdated={data.updatedAt ?? undefined}
             period={period}
             socialLinks={socialLinks}
+            verified={isVerifiedBySocialLinks(socialLinks)}
           />
 
           {data.hasBackfill && (

--- a/packages/frontend/src/components/leaderboard/RankingUI.tsx
+++ b/packages/frontend/src/components/leaderboard/RankingUI.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import styled from "styled-components";
+import { VerifiedBadge } from "@/components/ui/VerifiedBadge";
 import { getGroupMonogram } from "./presentation";
 
 export const CompactBadge = styled.span`
@@ -170,15 +171,26 @@ const MobileRank = styled.span`
   &[data-rank="3"] { color: var(--rank-bronze); }
 `;
 
-const MobileAvatar = styled.img`
+const MobileAvatarWrap = styled.span`
+  position: relative;
   grid-row: 1 / 3;
+  display: inline-flex;
+  align-self: center;
+`;
+
+const MobileAvatar = styled.img`
   width: 38px;
   height: 38px;
-  align-self: center;
   border-radius: 50%;
   object-fit: cover;
   outline: 1px solid var(--service-border);
   outline-offset: -1px;
+`;
+
+const MobileVerifiedBadge = styled(VerifiedBadge)`
+  position: absolute;
+  right: -3px;
+  bottom: -3px;
 `;
 
 const MobileIdentity = styled.div`
@@ -242,6 +254,7 @@ export function MobileRankingRow({
   avatarUrl,
   username,
   displayName,
+  verified = false,
   primaryLabel,
   primaryValue,
   meta,
@@ -252,6 +265,7 @@ export function MobileRankingRow({
   avatarUrl: string | null;
   username: string;
   displayName: string;
+  verified?: boolean;
   primaryLabel: string;
   primaryValue: string;
   meta: string;
@@ -265,10 +279,13 @@ export function MobileRankingRow({
         aria-current={isCurrentUser ? "true" : undefined}
       >
         <MobileRank data-rank={rank <= 3 ? rank : undefined}>#{rank}</MobileRank>
-        <MobileAvatar
-          src={avatarUrl || `https://github.com/${username}.png`}
-          alt=""
-        />
+        <MobileAvatarWrap>
+          <MobileAvatar
+            src={avatarUrl || `https://github.com/${username}.png`}
+            alt=""
+          />
+          {verified && <MobileVerifiedBadge size={13} />}
+        </MobileAvatarWrap>
         <MobileIdentity>
           <MobileName>{displayName}</MobileName>
           <MobileUsername>@{username}</MobileUsername>

--- a/packages/frontend/src/components/profile/ProfileOverview.tsx
+++ b/packages/frontend/src/components/profile/ProfileOverview.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import styled, { css } from "styled-components";
 import { toast } from "react-toastify";
 import { formatCurrency, formatNumber } from "@/lib/utils";
+import { VerifiedBadge } from "@/components/ui/VerifiedBadge";
 import { ProfileEmbedDialog } from "./ProfileEmbedDialog";
 import { ProfileSocialLinks } from "./ProfileSocialLinks";
 import type { ProfileSocialLink, ProfileStatsData, ProfileUser } from "./types";
@@ -15,6 +16,7 @@ export interface ProfileOverviewProps {
   lastUpdated?: string | null;
   period?: "all" | "month" | "week";
   socialLinks?: ProfileSocialLink[];
+  verified?: boolean;
   className?: string;
 }
 
@@ -48,6 +50,11 @@ const Identity = styled.div`
   gap: 1rem;
 `;
 
+const AvatarShell = styled.div`
+  position: relative;
+  flex: 0 0 auto;
+`;
+
 const Avatar = styled.div`
   position: relative;
   width: 72px;
@@ -62,6 +69,12 @@ const Avatar = styled.div`
     width: 80px;
     height: 80px;
   }
+`;
+
+const AvatarVerifiedBadge = styled(VerifiedBadge)`
+  position: absolute;
+  right: -4px;
+  bottom: -4px;
 `;
 
 const AvatarImage = styled(Image)`
@@ -378,6 +391,7 @@ export function ProfileOverview({
   lastUpdated,
   period = "all",
   socialLinks,
+  verified = false,
   className,
 }: ProfileOverviewProps) {
   const [isEmbedDialogOpen, setIsEmbedDialogOpen] = useState(false);
@@ -451,15 +465,18 @@ export function ProfileOverview({
     >
       <OverviewHeader>
         <Identity>
-          <Avatar>
-            <AvatarImage
-              src={avatarUrl}
-              alt={`${displayName}'s avatar`}
-              fill
-              sizes="(min-width: 640px) 80px, 72px"
-              priority
-            />
-          </Avatar>
+          <AvatarShell>
+            <Avatar>
+              <AvatarImage
+                src={avatarUrl}
+                alt={`${displayName}'s avatar`}
+                fill
+                sizes="(min-width: 640px) 80px, 72px"
+                priority
+              />
+            </Avatar>
+            {verified && <AvatarVerifiedBadge size={22} />}
+          </AvatarShell>
 
           <IdentityCopy>
             <DisplayName id="profile-overview-heading">

--- a/packages/frontend/src/components/ui/VerifiedBadge.tsx
+++ b/packages/frontend/src/components/ui/VerifiedBadge.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import styled from "styled-components";
+
+const VERIFIED_TOOLTIP =
+  "Verified — earned by adding two or more social links (website included) to your GitHub profile.";
+
+export interface VerifiedBadgeProps {
+  size?: number;
+  className?: string;
+}
+
+/**
+ * Blue check shown next to avatars of users with enough linked GitHub
+ * social accounts. Hover reveals how to earn it.
+ */
+export function VerifiedBadge({ size = 14, className }: VerifiedBadgeProps) {
+  const glyph = Math.max(8, Math.round(size * 0.62));
+  return (
+    <Badge
+      className={className}
+      $size={size}
+      role="img"
+      aria-label={VERIFIED_TOOLTIP}
+      data-tooltip={VERIFIED_TOOLTIP}
+    >
+      <svg
+        aria-hidden="true"
+        width={glyph}
+        height={glyph}
+        viewBox="0 0 20 20"
+        fill="none"
+      >
+        <path
+          d="M4.5 10.5l3.5 3.5 7.5-8"
+          stroke="#fff"
+          strokeWidth="2.6"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </Badge>
+  );
+}
+
+const Badge = styled.span<{ $size: number }>`
+  position: relative;
+  display: inline-flex;
+  width: ${({ $size }) => $size}px;
+  height: ${({ $size }) => $size}px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: #1d9bf0;
+  box-shadow: 0 0 0 2px var(--service-surface, var(--background, #fff));
+  cursor: default;
+
+  &::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    width: max-content;
+    max-width: 240px;
+    background-color: #111b2c;
+    color: #e5e5e5;
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.45;
+    letter-spacing: 0;
+    white-space: normal;
+    text-align: center;
+    box-shadow:
+      0 8px 30px rgba(0, 0, 0, 0.4),
+      0 0 0 1px rgba(255, 255, 255, 0.06);
+    z-index: 1000;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+  }
+
+  &:hover::after {
+    opacity: 1;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    &::after {
+      transition: none;
+    }
+  }
+`;

--- a/packages/frontend/src/lib/db/migrations/0019_add_user_social_links.sql
+++ b/packages/frontend/src/lib/db/migrations/0019_add_user_social_links.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "social_links" jsonb;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "social_links_synced_at" timestamp with time zone;

--- a/packages/frontend/src/lib/db/migrations/meta/0019_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,1543 @@
+{
+  "id": "d4773e0d-4edf-423c-901b-69f50fe5662a",
+  "prevId": "ffee8557-f4bf-4ada-b5c1-a7085c515ae7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_invites": {
+      "name": "group_invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_username": {
+          "name": "invited_username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_username_normalized": {
+          "name": "invited_username_normalized",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_user_id": {
+          "name": "invited_user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_invites_group_status": {
+          "name": "idx_group_invites_group_status",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_user_status": {
+          "name": "idx_group_invites_invited_user_status",
+          "columns": [
+            {
+              "expression": "invited_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_username_status": {
+          "name": "idx_group_invites_invited_username_status",
+          "columns": [
+            {
+              "expression": "invited_username_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_expires_at": {
+          "name": "idx_group_invites_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_invites_invited_by": {
+          "name": "idx_group_invites_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_invites_group_id_groups_id_fk": {
+          "name": "group_invites_group_id_groups_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_user_id_users_id_fk": {
+          "name": "group_invites_invited_user_id_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_invites_invited_by_users_id_fk": {
+          "name": "group_invites_invited_by_users_id_fk",
+          "tableFrom": "group_invites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_invites_token_hash_unique": {
+          "name": "group_invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.group_members": {
+      "name": "group_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_group_members_user_id": {
+          "name": "idx_group_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_group_members_invited_by": {
+          "name": "idx_group_members_invited_by",
+          "columns": [
+            {
+              "expression": "invited_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "group_members_group_id_groups_id_fk": {
+          "name": "group_members_group_id_groups_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "groups",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_user_id_users_id_fk": {
+          "name": "group_members_user_id_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "group_members_invited_by_users_id_fk": {
+          "name": "group_members_invited_by_users_id_fk",
+          "tableFrom": "group_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "group_members_group_user_unique": {
+          "name": "group_members_group_user_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "group_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_groups_created_by": {
+          "name": "idx_groups_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_groups_visibility_updated": {
+          "name": "idx_groups_visibility_updated",
+          "columns": [
+            {
+              "expression": "is_public",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "updated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "groups_created_by_users_id_fk": {
+          "name": "groups_created_by_users_id_fk",
+          "tableFrom": "groups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "groups_slug_unique": {
+          "name": "groups_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links_synced_at": {
+          "name": "social_links_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1784611194680,
       "tag": "0018_add_has_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1784825702322,
+      "tag": "0019_add_user_social_links",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -32,6 +32,15 @@ export const users = pgTable(
     displayName: varchar("display_name", { length: 255 }),
     avatarUrl: text("avatar_url"),
     email: varchar("email", { length: 255 }),
+    /**
+     * Snapshot of the user's public GitHub social links (website + recognized
+     * social accounts), refreshed on login and on profile views. An array of
+     * {provider, url}; >= 2 entries marks the user as verified.
+     */
+    socialLinks: jsonb("social_links"),
+    socialLinksSyncedAt: timestamp("social_links_synced_at", {
+      withTimezone: true,
+    }),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/packages/frontend/src/lib/githubSocials.ts
+++ b/packages/frontend/src/lib/githubSocials.ts
@@ -1,4 +1,6 @@
 import { unstable_cache } from "next/cache";
+import { db, users } from "@/lib/db";
+import { usernameEqualsIgnoreCase } from "@/lib/db/usernameLookup";
 import type {
   ProfileSocialLink,
   ProfileSocialProvider,
@@ -135,10 +137,43 @@ async function fetchGitHubSocialLinks(
   return links;
 }
 
+async function persistSocialLinks(
+  username: string,
+  links: ProfileSocialLink[],
+): Promise<void> {
+  try {
+    await db
+      .update(users)
+      .set({ socialLinks: links, socialLinksSyncedAt: new Date() })
+      .where(usernameEqualsIgnoreCase(username));
+  } catch {
+    // The snapshot column powers the leaderboard verified badge; failing to
+    // refresh it must never break the caller.
+  }
+}
+
+/**
+ * Fetch the user's current social links from GitHub and persist the snapshot
+ * on their users row (used by the leaderboard verified badge). Never throws.
+ */
+export async function syncGitHubSocialLinks(
+  username: string,
+): Promise<ProfileSocialLink[]> {
+  try {
+    const links = await fetchGitHubSocialLinks(username);
+    await persistSocialLinks(username, links);
+    return links;
+  } catch {
+    return [];
+  }
+}
+
 /**
  * Social links from the user's public GitHub profile: the website field plus
  * recognized entries from the social accounts API. Failures resolve to an
  * empty list — this is a profile enrichment, never a render blocker.
+ * Refreshes also persist the snapshot to the users row (at most once per
+ * cache window per user).
  */
 export function getGitHubSocialLinks(
   username: string,
@@ -146,13 +181,7 @@ export function getGitHubSocialLinks(
   const cacheKey = username.toLowerCase();
 
   return unstable_cache(
-    async () => {
-      try {
-        return await fetchGitHubSocialLinks(username);
-      } catch {
-        return [];
-      }
-    },
+    () => syncGitHubSocialLinks(username),
     [`github-socials:${cacheKey}`],
     {
       tags: ["github-socials", `github-socials:${cacheKey}`],

--- a/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
+++ b/packages/frontend/src/lib/groups/getGroupLeaderboard.ts
@@ -190,6 +190,8 @@ function buildPeriodGroupLeaderboardData(
       username: row.username,
       displayName: row.displayName,
       avatarUrl: row.avatarUrl,
+      // Groups UI never renders the badge; the feature is being removed.
+      verified: false,
       role: row.role,
       totalTokens: row.tokens,
       totalCost: row.cost,
@@ -317,6 +319,7 @@ async function fetchAllTimeRows(groupId: string, sortBy: SortBy, search: string 
     username: row.username,
     displayName: row.displayName,
     avatarUrl: row.avatarUrl,
+    verified: false,
     role: row.role,
     totalTokens: Number(row.totalTokens) || 0,
     totalCost: Number(row.totalCost) || 0,

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -13,14 +13,22 @@ import {
   hasDirectives,
   parseSearchDirectives,
 } from "@/lib/leaderboard/searchDirectives";
+import { SOCIAL_VERIFIED_THRESHOLD } from "@/lib/socialVerification";
 
 export type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
+
+// A user with >= SOCIAL_VERIFIED_THRESHOLD linked socials is "verified". The
+// snapshot on users.social_links is refreshed by lib/githubSocials.ts.
+function verifiedExpr() {
+  return sql<boolean>`COALESCE(jsonb_array_length(${users.socialLinks}) >= ${SOCIAL_VERIFIED_THRESHOLD}, false)`;
+}
 
 interface LeaderboardPeriodRow {
   userId: string;
   username: string;
   displayName: string | null;
   avatarUrl: string | null;
+  verified: boolean;
   tokens: number;
   cost: number;
   sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
@@ -36,6 +44,7 @@ interface PeriodLeaderboardDbRow {
   username: string;
   displayName: string | null;
   avatarUrl: string | null;
+  verified: boolean | null;
   tokens: number | string | null;
   cost: number | string | null;
   sourceBreakdown: Record<string, { models: Record<string, unknown> }> | null;
@@ -46,6 +55,7 @@ interface AllTimeLeaderboardDbRow {
   username: string;
   displayName: string | null;
   avatarUrl: string | null;
+  verified: boolean | null;
   totalTokens: number | string | null;
   totalCost: number | string | null;
 }
@@ -160,6 +170,7 @@ function aggregatePeriodRows(
       username: row.username,
       displayName: row.displayName,
       avatarUrl: row.avatarUrl,
+      verified: row.verified,
       totalTokens: row.tokens,
       totalCost: row.cost,
     });
@@ -296,6 +307,7 @@ async function fetchPeriodLeaderboardRows(
       username: users.username,
       displayName: users.displayName,
       avatarUrl: users.avatarUrl,
+      verified: verifiedExpr().as("verified"),
       tokens: dailyBreakdown.tokens,
       cost: dailyBreakdown.cost,
       sourceBreakdown: dailyBreakdown.sourceBreakdown,
@@ -315,6 +327,7 @@ async function fetchPeriodLeaderboardRows(
     username: row.username,
     displayName: row.displayName,
     avatarUrl: row.avatarUrl,
+    verified: Boolean(row.verified),
     tokens: Number(row.tokens) || 0,
     cost: Number(row.cost) || 0,
     sourceBreakdown: row.sourceBreakdown ?? null,
@@ -367,6 +380,7 @@ async function fetchLeaderboardData(
         username: users.username,
         displayName: users.displayName,
         avatarUrl: users.avatarUrl,
+        verified: verifiedExpr().as("verified"),
         totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
       })
@@ -421,6 +435,7 @@ async function fetchLeaderboardData(
         username: row.username,
         displayName: row.displayName,
         avatarUrl: row.avatarUrl,
+        verified: Boolean(row.verified),
         totalTokens: Number(row.totalTokens) || 0,
         totalCost: Number(row.totalCost) || 0,
       })),
@@ -450,6 +465,7 @@ async function fetchLeaderboardData(
       username: users.username,
       displayName: users.displayName,
       avatarUrl: users.avatarUrl,
+      verified: verifiedExpr().as("verified"),
       totalTokens: sql<number>`SUM(${submissions.totalTokens})`.as("total_tokens"),
       totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`.as("total_cost"),
     })
@@ -485,6 +501,7 @@ async function fetchLeaderboardData(
       username: row.username,
       displayName: row.displayName,
       avatarUrl: row.avatarUrl,
+      verified: Boolean(row.verified),
       totalTokens: Number(row.totalTokens) || 0,
       totalCost: Number(row.totalCost) || 0,
     })),
@@ -548,7 +565,7 @@ async function fetchUserRank(
   }
 
   const userResult = await db
-    .select({ id: users.id, username: users.username, displayName: users.displayName, avatarUrl: users.avatarUrl })
+    .select({ id: users.id, username: users.username, displayName: users.displayName, avatarUrl: users.avatarUrl, verified: verifiedExpr() })
     .from(users)
     .where(usernameEqualsIgnoreCase(username))
     .limit(USERNAME_LOOKUP_LIMIT);
@@ -606,6 +623,7 @@ async function fetchUserRank(
     username: user.username,
     displayName: user.displayName,
     avatarUrl: user.avatarUrl,
+    verified: Boolean(user.verified),
     totalTokens: userTotalTokens,
     totalCost: userTotalCost,
   };

--- a/packages/frontend/src/lib/leaderboard/types.ts
+++ b/packages/frontend/src/lib/leaderboard/types.ts
@@ -15,6 +15,8 @@ export interface LeaderboardUser {
   avatarUrl: string | null;
   totalTokens: number;
   totalCost: number;
+  /** True when the user has enough linked social accounts on GitHub. */
+  verified: boolean;
 }
 
 export interface LeaderboardData {

--- a/packages/frontend/src/lib/socialVerification.ts
+++ b/packages/frontend/src/lib/socialVerification.ts
@@ -1,0 +1,10 @@
+import type { ProfileSocialLink } from "@/components/profile/types";
+
+/** Number of social links (website included) that marks a profile verified. */
+export const SOCIAL_VERIFIED_THRESHOLD = 2;
+
+export function isVerifiedBySocialLinks(
+  links: ProfileSocialLink[] | null | undefined,
+): boolean {
+  return (links?.length ?? 0) >= SOCIAL_VERIFIED_THRESHOLD;
+}


### PR DESCRIPTION
Users with **two or more social links** on their GitHub profile (website counts) get a blue verified check on their avatar — on their profile page and everywhere on the leaderboard (desktop table, mobile rows, and the signed-in user card). Hovering the badge shows how to earn it: *"Verified — earned by adding two or more social links (website included) to your GitHub profile."*

## How it works

- **Snapshot column**: migration 0019 adds `users.social_links` (jsonb) + `users.social_links_synced_at`. The snapshot is refreshed by the existing GitHub socials fetch — on profile page views (at most once per hour per user via the existing cache) and in the background on every login. **Already applied to production** (written as `IF NOT EXISTS`, so the recorded migration stays a clean no-op for drizzle's bookkeeping).
- **Leaderboard**: all rank queries (all-time, all-time search, period, user rank) select `COALESCE(jsonb_array_length(social_links) >= 2, false)` — no extra requests, no per-row GitHub calls.
- **Threshold** lives in one place: `SOCIAL_VERIFIED_THRESHOLD` in `src/lib/socialVerification.ts` (client-safe module).
- Users the sync hasn't reached yet simply show no badge; the flag populates as people log in or their profiles get viewed.

## Verification

- `tsc --noEmit`, eslint, `next build` pass; full vitest suite 688/688 (updated the field-list assertions that intentionally pin leaderboard query shapes, and the auth-callback test mock for the new background sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
