### PR TITLE
feat(profile): refresh verified-badge social links daily via cron

### DIFF
--- a/.github/workflows/refresh-social-links.yml
+++ b/.github/workflows/refresh-social-links.yml
@@ -1,0 +1,33 @@
+name: Refresh Social Links
+
+on:
+  schedule:
+    # Daily; drives the 24h verified-badge refresh promise in the UI tooltip.
+    - cron: "20 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    name: Refresh verified-badge social links
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Trigger refresh endpoint
+        env:
+          CRON_SECRET: ${{ secrets.TOKENS_CRON_SECRET }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${CRON_SECRET}" ]; then
+            echo "TOKENS_CRON_SECRET secret is required." >&2
+            exit 1
+          fi
+
+          curl -fsS -X POST \
+            -H "Authorization: Bearer ${CRON_SECRET}" \
+            --max-time 60 \
+            https://tokens.ci/api/cron/refresh-social-links

--- a/packages/frontend/compose.yaml
+++ b/packages/frontend/compose.yaml
@@ -43,6 +43,7 @@ services:
       GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID}
       GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET}
       CSRF_ALLOWED_ORIGINS: ${CSRF_ALLOWED_ORIGINS}
+      CRON_SECRET: ${CRON_SECRET:-}
     # Published only to localhost so your host Nginx can reverse-proxy it;
     # nothing is exposed on the public interface. Host port is configurable via
     # APP_PORT in .env (container always listens on 3000 internally).

--- a/packages/frontend/src/app/api/cron/refresh-social-links/route.ts
+++ b/packages/frontend/src/app/api/cron/refresh-social-links/route.ts
@@ -1,0 +1,59 @@
+import { timingSafeEqual } from "crypto";
+import { NextResponse } from "next/server";
+import { db, users } from "@/lib/db";
+import { syncGitHubSocialLinks } from "@/lib/githubSocials";
+import { isVerifiedBySocialLinks } from "@/lib/socialVerification";
+
+export const dynamic = "force-dynamic";
+
+const SYNC_CONCURRENCY = 4;
+
+function safeEqual(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a);
+  const bufferB = Buffer.from(b);
+  return bufferA.length === bufferB.length && timingSafeEqual(bufferA, bufferB);
+}
+
+/**
+ * Daily refresh of every user's GitHub social-links snapshot (drives the
+ * verified badge). Triggered by the refresh-social-links GitHub Actions
+ * schedule; guarded by CRON_SECRET. Responds immediately and syncs in the
+ * background so reverse-proxy timeouts can't cut the run short.
+ */
+export async function POST(request: Request) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    return NextResponse.json(
+      { error: "CRON_SECRET is not configured" },
+      { status: 503 },
+    );
+  }
+
+  const authorization = request.headers.get("authorization") ?? "";
+  if (!safeEqual(authorization, `Bearer ${secret}`)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const rows = await db.select({ username: users.username }).from(users);
+
+  void (async () => {
+    let verified = 0;
+    for (let i = 0; i < rows.length; i += SYNC_CONCURRENCY) {
+      const batch = rows.slice(i, i + SYNC_CONCURRENCY);
+      const results = await Promise.all(
+        batch.map((row) => syncGitHubSocialLinks(row.username)),
+      );
+      for (const links of results) {
+        if (isVerifiedBySocialLinks(links)) verified++;
+      }
+    }
+    console.log(
+      `[cron] refresh-social-links: synced ${rows.length} users, ${verified} verified`,
+    );
+  })();
+
+  return NextResponse.json(
+    { accepted: true, users: rows.length },
+    { status: 202 },
+  );
+}

--- a/packages/frontend/src/components/ui/VerifiedBadge.tsx
+++ b/packages/frontend/src/components/ui/VerifiedBadge.tsx
@@ -4,7 +4,7 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 import styled from "styled-components";
 
 const VERIFIED_TOOLTIP =
-  "Verified — earned by adding two or more social links (website included) to your GitHub profile.";
+  "Verified — earned by adding two or more social links (website included) to your GitHub profile. Status refreshes every 24 hours.";
 
 export interface VerifiedBadgeProps {
   size?: number;


### PR DESCRIPTION
Completes the verified-badge lifecycle:

- **New users**: already synced during the OAuth login callback (the only user-creation path), nothing new needed.
- **Existing users who add/remove social links later**: a new `POST /api/cron/refresh-social-links` endpoint re-syncs every user's GitHub social links. Guarded by `CRON_SECRET` (timing-safe compare; 503 when unconfigured), responds 202 immediately and works in the background at concurrency 4 (~160 users ≈ under a minute, well inside the OAuth-app rate limit).
- **Schedule**: `.github/workflows/refresh-social-links.yml` calls it daily at 03:20 UTC (plus manual `workflow_dispatch`). `TOKENS_CRON_SECRET` repo secret and the server-side `CRON_SECRET` env are already provisioned; `compose.yaml` now passes it through.
- **Tooltip** now says: *"…Status refreshes every 24 hours."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)