### PR TITLE
feat(bans): add account bans and public Hall of Shame

### DIFF
--- a/packages/frontend/__tests__/lib/getLeaderboard.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboard.test.ts
@@ -31,6 +31,7 @@ const mockState = vi.hoisted(() => {
   const or = vi.fn((...conditions: unknown[]) => ({ kind: "or", conditions }));
   const gte = vi.fn(() => "gte");
   const lte = vi.fn(() => "lte");
+  const isNull = vi.fn(() => "isNull");
   const sql = Object.assign(
     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
       strings: Array.from(strings),
@@ -88,6 +89,7 @@ const mockState = vi.hoisted(() => {
     or,
     gte,
     lte,
+    isNull,
     sql,
     reset() {
       periodRows.length = 0;
@@ -99,6 +101,7 @@ const mockState = vi.hoisted(() => {
       or.mockClear();
       gte.mockClear();
       lte.mockClear();
+      isNull.mockClear();
       sql.mockClear();
       sql.raw.mockClear();
     },
@@ -145,6 +148,7 @@ vi.mock("drizzle-orm", () => ({
   or: mockState.or,
   gte: mockState.gte,
   lte: mockState.lte,
+  isNull: mockState.isNull,
   sql: mockState.sql,
 }));
 
@@ -409,7 +413,10 @@ describe("all-time leaderboard directives", () => {
 
     expect(mockState.or).toHaveBeenCalledTimes(2);
     expect(mockState.or.mock.calls.map((call) => call.length)).toEqual([2, 1]);
+    // The ranked subquery always filters out banned users, so the directive
+    // conditions are combined together with the isNull(bannedAt) guard.
     expect(mockState.and).toHaveBeenCalledWith(
+      "isNull",
       mockState.or.mock.results[0]?.value,
       mockState.or.mock.results[1]?.value
     );

--- a/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
+++ b/packages/frontend/__tests__/lib/getLeaderboardAllTime.test.ts
@@ -33,6 +33,7 @@ const mockState = vi.hoisted(() => {
   const or = vi.fn(() => "or");
   const gte = vi.fn(() => "gte");
   const lte = vi.fn(() => "lte");
+  const isNull = vi.fn(() => "isNull");
   const sql = Object.assign(
     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
       strings: Array.from(strings),
@@ -76,6 +77,7 @@ const mockState = vi.hoisted(() => {
     or,
     gte,
     lte,
+    isNull,
     sql,
     reset() {
       awaitedResults.length = 0;
@@ -87,6 +89,7 @@ const mockState = vi.hoisted(() => {
       or.mockClear();
       gte.mockClear();
       lte.mockClear();
+      isNull.mockClear();
       sql.mockClear();
       sql.raw.mockClear();
     },
@@ -133,6 +136,7 @@ vi.mock("drizzle-orm", () => ({
   or: mockState.or,
   gte: mockState.gte,
   lte: mockState.lte,
+  isNull: mockState.isNull,
   sql: mockState.sql,
 }));
 

--- a/packages/frontend/src/app/(main)/shame/page.tsx
+++ b/packages/frontend/src/app/(main)/shame/page.tsx
@@ -58,24 +58,45 @@ function formatBanDate(date: Date | null): string {
   return date.toISOString().slice(0, 10);
 }
 
+/**
+ * Cheaters ban themselves partly to promote a brand carried in their
+ * username, so the page never prints it in full: showing "fis*****de"
+ * documents the ban without handing them the advertising they wanted.
+ */
+function maskUsername(username: string): string {
+  if (username.length <= 3) {
+    return `${username[0] ?? ""}${"*".repeat(Math.max(username.length - 1, 2))}`;
+  }
+  const keepEnd = username.length >= 7 ? 2 : 1;
+  const start = username.slice(0, 2);
+  const end = username.slice(username.length - keepEnd);
+  return `${start}${"*".repeat(username.length - 2 - keepEnd)}${end}`;
+}
+
 function BannedUserCard({ user }: { user: BannedUserRow }) {
-  const avatar = user.avatarUrl || `https://github.com/${user.username}.png`;
+  const masked = maskUsername(user.username);
 
   return (
     <article className="rounded-xl border border-danger/30 bg-surface p-5">
       <div className="flex items-start gap-4">
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src={avatar}
-          alt={user.username}
-          width={48}
-          height={48}
-          className="h-12 w-12 shrink-0 rounded-lg object-cover opacity-80 grayscale ring-1 ring-line"
-        />
+        {user.avatarUrl ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={user.avatarUrl}
+            alt={masked}
+            width={48}
+            height={48}
+            className="h-12 w-12 shrink-0 rounded-lg object-cover opacity-80 grayscale ring-1 ring-line"
+          />
+        ) : (
+          <div className="grid h-12 w-12 shrink-0 place-items-center rounded-lg bg-foreground/10 font-mono text-lg font-bold text-muted ring-1 ring-line">
+            {user.username[0]?.toUpperCase() ?? "?"}
+          </div>
+        )}
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
             <h2 className="truncate font-mono text-base font-bold text-foreground">
-              @{user.username}
+              @{masked}
             </h2>
             <span className="rounded-md bg-danger/10 px-2 py-0.5 font-mono text-[11px] font-semibold uppercase tracking-wide text-danger">
               Banned
@@ -134,7 +155,8 @@ export default async function HallOfShamePage({ searchParams }: PageProps) {
             listed here submitted fraudulent usage data and are permanently
             banned: they cannot sign in or submit again, and none of their data
             counts toward any ranking. Their forged records are preserved as
-            evidence.
+            evidence. Usernames are partially masked — cheaters don&apos;t get
+            free publicity here.
           </p>
         </header>
 

--- a/packages/frontend/src/app/(main)/shame/page.tsx
+++ b/packages/frontend/src/app/(main)/shame/page.tsx
@@ -1,0 +1,167 @@
+import type { Metadata } from "next";
+import { isNotNull, desc, eq } from "drizzle-orm";
+import { db, users, submissions } from "@/lib/db";
+import { formatNumber, formatCurrency } from "@/lib/format";
+
+export const metadata: Metadata = {
+  title: "Hall of Shame - Tokens",
+  description:
+    "Accounts banned from the Tokens leaderboard for submitting fraudulent usage data.",
+};
+
+// The list only changes when a ban is issued; a short ISR window keeps the
+// page fresh without hitting the database on every view.
+export const revalidate = 300;
+
+interface BannedUserRow {
+  username: string;
+  displayName: string | null;
+  avatarUrl: string | null;
+  bannedAt: Date | null;
+  banReason: string | null;
+  claimedTokens: number | null;
+  claimedCost: string | null;
+}
+
+function isMissingDatabaseUrl(error: unknown): boolean {
+  return error instanceof Error && error.message === "DATABASE_URL environment variable is not set";
+}
+
+async function getBannedUsers(): Promise<BannedUserRow[]> {
+  try {
+    return await db
+      .select({
+        username: users.username,
+        displayName: users.displayName,
+        avatarUrl: users.avatarUrl,
+        bannedAt: users.bannedAt,
+        banReason: users.banReason,
+        claimedTokens: submissions.totalTokens,
+        claimedCost: submissions.totalCost,
+      })
+      .from(users)
+      .leftJoin(submissions, eq(submissions.userId, users.id))
+      .where(isNotNull(users.bannedAt))
+      .orderBy(desc(users.bannedAt));
+  } catch (error) {
+    if (isMissingDatabaseUrl(error)) {
+      return [];
+    }
+    throw error;
+  }
+}
+
+function formatBanDate(date: Date | null): string {
+  if (!date) {
+    return "";
+  }
+  return date.toISOString().slice(0, 10);
+}
+
+function BannedUserCard({ user }: { user: BannedUserRow }) {
+  const avatar = user.avatarUrl || `https://github.com/${user.username}.png`;
+
+  return (
+    <article className="rounded-xl border border-danger/30 bg-surface p-5">
+      <div className="flex items-start gap-4">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={avatar}
+          alt={user.username}
+          width={48}
+          height={48}
+          className="h-12 w-12 shrink-0 rounded-lg object-cover opacity-80 grayscale ring-1 ring-line"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <h2 className="truncate font-mono text-base font-bold text-foreground">
+              @{user.username}
+            </h2>
+            <span className="rounded-md bg-danger/10 px-2 py-0.5 font-mono text-[11px] font-semibold uppercase tracking-wide text-danger">
+              Banned
+            </span>
+            {user.bannedAt && (
+              <span className="font-mono text-xs text-muted">
+                {formatBanDate(user.bannedAt)}
+              </span>
+            )}
+          </div>
+          {user.claimedTokens != null && (
+            <p className="mt-1 font-mono text-xs text-muted">
+              Forged claim:{" "}
+              <span className="line-through">
+                {formatNumber(user.claimedTokens, true)} tokens
+                {user.claimedCost != null &&
+                  ` / ${formatCurrency(Number(user.claimedCost), true)}`}
+              </span>{" "}
+              — excluded from all rankings
+            </p>
+          )}
+        </div>
+      </div>
+      {user.banReason && (
+        <p className="mt-4 text-sm leading-relaxed text-foreground/90">
+          {user.banReason}
+        </p>
+      )}
+    </article>
+  );
+}
+
+interface PageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function HallOfShamePage({ searchParams }: PageProps) {
+  const [bannedUsers, params] = await Promise.all([getBannedUsers(), searchParams]);
+  const showBannedLoginError = params.error === "account_banned";
+
+  return (
+    <main className="main-container" id="main-content">
+      <div className="mx-auto max-w-[720px] px-4 py-10 sm:px-6">
+        {showBannedLoginError && (
+          <div className="mb-6 rounded-xl border border-danger/40 bg-danger/10 px-4 py-3 text-sm font-medium text-danger">
+            This account has been banned and can no longer sign in.
+          </div>
+        )}
+
+        <header>
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">
+            Hall of Shame
+          </h1>
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            The leaderboard only works if the numbers on it are real. Accounts
+            listed here submitted fraudulent usage data and are permanently
+            banned: they cannot sign in or submit again, and none of their data
+            counts toward any ranking. Their forged records are preserved as
+            evidence.
+          </p>
+        </header>
+
+        <section className="mt-8 flex flex-col gap-4" aria-label="Banned accounts">
+          {bannedUsers.length === 0 ? (
+            <p className="rounded-xl border border-line bg-surface px-4 py-6 text-center text-sm text-muted">
+              No banned accounts. Keep it that way.
+            </p>
+          ) : (
+            bannedUsers.map((user) => (
+              <BannedUserCard key={user.username} user={user} />
+            ))
+          )}
+        </section>
+
+        <section className="mt-10 rounded-xl border border-line bg-surface p-5">
+          <h2 className="text-sm font-semibold text-foreground">
+            Spotted something suspicious?
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-muted">
+            We welcome reports from the community. If a profile&apos;s numbers
+            look fabricated, let us know — every report is investigated against
+            the submitted raw data. Dedicated reporting channels will be
+            announced here soon.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/packages/frontend/src/app/api/auth/github/callback/route.ts
+++ b/packages/frontend/src/app/api/auth/github/callback/route.ts
@@ -69,6 +69,12 @@ export async function GET(request: Request) {
     let userId: string;
 
     if (existingUser.length > 0) {
+      // Banned accounts may not sign in again; every user is tied to a
+      // GitHub identity, so the ban follows the github_id.
+      if (existingUser[0].bannedAt) {
+        return NextResponse.redirect(`${baseUrl}/shame?error=account_banned`);
+      }
+
       // Update existing user
       userId = existingUser[0].id;
       await db

--- a/packages/frontend/src/app/api/auth/token/route.ts
+++ b/packages/frontend/src/app/api/auth/token/route.ts
@@ -27,6 +27,13 @@ export async function GET(request: Request) {
       );
     }
 
+    if (authResult.status === "banned") {
+      return NextResponse.json(
+        { error: "This account has been banned for violating the platform rules" },
+        { status: 403 }
+      );
+    }
+
     return NextResponse.json({
       user: {
         username: authResult.username,

--- a/packages/frontend/src/app/api/me/stats/route.ts
+++ b/packages/frontend/src/app/api/me/stats/route.ts
@@ -87,6 +87,13 @@ export async function GET(request: Request) {
       );
     }
 
+    if (authResult.status === "banned") {
+      return NextResponse.json(
+        { error: "This account has been banned for violating the platform rules" },
+        { status: 403 }
+      );
+    }
+
     const [submission] = await db
       .select({ id: submissions.id })
       .from(submissions)

--- a/packages/frontend/src/app/api/submit/route.ts
+++ b/packages/frontend/src/app/api/submit/route.ts
@@ -192,6 +192,13 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: "API token has expired" }, { status: 401 });
     }
 
+    if (authResult.status === "banned") {
+      return NextResponse.json(
+        { error: "This account has been banned for violating the platform rules" },
+        { status: 403 }
+      );
+    }
+
     const tokenRecord = authResult;
 
     // ========================================

--- a/packages/frontend/src/components/layout/Navigation.tsx
+++ b/packages/frontend/src/components/layout/Navigation.tsx
@@ -136,6 +136,7 @@ function UserMenu({ user, onSignOut }: { user: User; onSignOut: () => void }) {
 
 const NAV_LINKS = [
   { href: "/leaderboard", label: "Leaderboard", authOnly: false, match: (p: string) => p === "/leaderboard" },
+  { href: "/shame", label: "Hall of Shame", authOnly: false, match: (p: string) => p === "/shame" },
   { href: "/profile", label: "Profile", authOnly: true, match: (p: string) => p === "/profile" || p.startsWith("/u/") },
 ] as const;
 

--- a/packages/frontend/src/lib/auth/personalTokens.ts
+++ b/packages/frontend/src/lib/auth/personalTokens.ts
@@ -36,6 +36,7 @@ export interface AuthenticatedPersonalToken {
 export type PersonalTokenAuthResult =
   | { status: "invalid" }
   | { status: "expired" }
+  | { status: "banned" }
   | ({ status: "valid" } & AuthenticatedPersonalToken);
 
 export interface AuthenticatePersonalTokenOptions {
@@ -206,6 +207,7 @@ export async function authenticatePersonalToken(
       username: users.username,
       displayName: users.displayName,
       avatarUrl: users.avatarUrl,
+      bannedAt: users.bannedAt,
       expiresAt: apiTokens.expiresAt,
     })
     .from(apiTokens)
@@ -218,6 +220,10 @@ export async function authenticatePersonalToken(
   }
 
   const record = result[0];
+
+  if (record.bannedAt) {
+    return { status: "banned" };
+  }
 
   if (record.expiresAt && record.expiresAt <= new Date()) {
     return { status: "expired" };

--- a/packages/frontend/src/lib/auth/session.ts
+++ b/packages/frontend/src/lib/auth/session.ts
@@ -46,6 +46,12 @@ export async function getSession(): Promise<SessionUser | null> {
 
   const { user } = result[0];
 
+  // Banned users keep their rows but lose all access; their existing
+  // sessions stop resolving instead of being individually revoked.
+  if (user.bannedAt) {
+    return null;
+  }
+
   return {
     id: user.id,
     username: user.username,

--- a/packages/frontend/src/lib/db/migrations/0021_add_user_bans.sql
+++ b/packages/frontend/src/lib/db/migrations/0021_add_user_bans.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "banned_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "ban_reason" text;

--- a/packages/frontend/src/lib/db/migrations/meta/0021_snapshot.json
+++ b/packages/frontend/src/lib/db/migrations/meta/0021_snapshot.json
@@ -1,0 +1,1062 @@
+{
+  "id": "43dbd3a7-f92b-4953-8dae-9333a32a3a1f",
+  "prevId": "e2b186b6-3b0b-47ae-80d4-b836c435cecb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_tokens": {
+      "name": "api_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_tokens_token": {
+          "name": "idx_api_tokens_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_tokens_user_id": {
+          "name": "idx_api_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_tokens_user_id_users_id_fk": {
+          "name": "api_tokens_user_id_users_id_fk",
+          "tableFrom": "api_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_tokens_token_unique": {
+          "name": "api_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        },
+        "api_tokens_user_name_unique": {
+          "name": "api_tokens_user_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.daily_breakdown": {
+      "name": "daily_breakdown",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "submission_id": {
+          "name": "submission_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "submitted_device_id": {
+          "name": "submitted_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tokens": {
+          "name": "tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cost": {
+          "name": "cost",
+          "type": "numeric(14, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timestamp_ms": {
+          "name": "timestamp_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_time_ms": {
+          "name": "active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_daily_breakdown_submission_id": {
+          "name": "idx_daily_breakdown_submission_id",
+          "columns": [
+            {
+              "expression": "submission_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_submitted_device_id": {
+          "name": "idx_daily_breakdown_submitted_device_id",
+          "columns": [
+            {
+              "expression": "submitted_device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_daily_breakdown_date": {
+          "name": "idx_daily_breakdown_date",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "daily_breakdown_submission_id_submissions_id_fk": {
+          "name": "daily_breakdown_submission_id_submissions_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submissions",
+          "columnsFrom": [
+            "submission_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "daily_breakdown_submitted_device_id_submitted_devices_id_fk": {
+          "name": "daily_breakdown_submitted_device_id_submitted_devices_id_fk",
+          "tableFrom": "daily_breakdown",
+          "tableTo": "submitted_devices",
+          "columnsFrom": [
+            "submitted_device_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "daily_breakdown_submission_device_date_unique": {
+          "name": "daily_breakdown_submission_device_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "submission_id",
+            "submitted_device_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "varchar(9)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_device_codes_device_code": {
+          "name": "idx_device_codes_device_code",
+          "columns": [
+            {
+              "expression": "device_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_code": {
+          "name": "idx_device_codes_user_code",
+          "columns": [
+            {
+              "expression": "user_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_user_id": {
+          "name": "idx_device_codes_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_device_codes_expires_at": {
+          "name": "idx_device_codes_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "device_codes_user_id_users_id_fk": {
+          "name": "device_codes_user_id_users_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "device_code"
+          ]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'web'"
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sessions_token_hash": {
+          "name": "idx_sessions_token_hash",
+          "columns": [
+            {
+              "expression": "token_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_user_id": {
+          "name": "idx_sessions_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_hash_unique": {
+          "name": "sessions_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submissions": {
+      "name": "submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_tokens": {
+          "name": "total_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_creation_tokens": {
+          "name": "cache_creation_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reasoning_tokens": {
+          "name": "reasoning_tokens",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sources_used": {
+          "name": "sources_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "models_used": {
+          "name": "models_used",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cli_version": {
+          "name": "cli_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submission_hash": {
+          "name": "submission_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submit_count": {
+          "name": "submit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "has_backfill": {
+          "name": "has_backfill",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "total_active_time_ms": {
+          "name": "total_active_time_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longest_continuous_ms": {
+          "name": "longest_continuous_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_concurrent_sessions": {
+          "name": "max_concurrent_sessions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mcp_servers": {
+          "name": "mcp_servers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_submissions_created_at": {
+          "name": "idx_submissions_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_submissions_leaderboard": {
+          "name": "idx_submissions_leaderboard",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_tokens",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "total_cost",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submissions_user_id_users_id_fk": {
+          "name": "submissions_user_id_users_id_fk",
+          "tableFrom": "submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submissions_user_id_unique": {
+          "name": "submissions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.submitted_devices": {
+      "name": "submitted_devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_key": {
+          "name": "device_key",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_submitted_at": {
+          "name": "last_submitted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_submitted_devices_user_id": {
+          "name": "idx_submitted_devices_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "submitted_devices_user_id_users_id_fk": {
+          "name": "submitted_devices_user_id_users_id_fk",
+          "tableFrom": "submitted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "submitted_devices_user_device_key_unique": {
+          "name": "submitted_devices_user_device_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "device_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(39)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links": {
+          "name": "social_links",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "social_links_synced_at": {
+          "name": "social_links_synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "banned_at": {
+          "name": "banned_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_username": {
+          "name": "idx_users_username",
+          "columns": [
+            {
+              "expression": "username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_username_lower_unique": {
+          "name": "users_username_lower_unique",
+          "columns": [
+            {
+              "expression": "lower(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_users_github_id": {
+          "name": "idx_users_github_id",
+          "columns": [
+            {
+              "expression": "github_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/frontend/src/lib/db/migrations/meta/_journal.json
+++ b/packages/frontend/src/lib/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1784826575021,
       "tag": "0020_drop_group_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1784918833530,
+      "tag": "0021_add_user_bans",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/frontend/src/lib/db/schema.ts
+++ b/packages/frontend/src/lib/db/schema.ts
@@ -41,6 +41,14 @@ export const users = pgTable(
     socialLinksSyncedAt: timestamp("social_links_synced_at", {
       withTimezone: true,
     }),
+    /**
+     * Non-null once the user is banned. Banned users cannot authenticate
+     * (web session, OAuth login, or API token) and are excluded from every
+     * leaderboard, but their submitted rows are retained as evidence and
+     * listed on the Hall of Shame together with banReason.
+     */
+    bannedAt: timestamp("banned_at", { withTimezone: true }),
+    banReason: text("ban_reason"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .notNull()
       .defaultNow(),

--- a/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
+++ b/packages/frontend/src/lib/leaderboard/getLeaderboard.ts
@@ -6,7 +6,7 @@ import {
   normalizeUsernameCacheKey,
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
-import { eq, desc, sql, and, or, gte, lte } from "drizzle-orm";
+import { eq, desc, sql, and, or, gte, lte, isNull } from "drizzle-orm";
 import type { LeaderboardData, LeaderboardUser, Period, SortBy } from "@/lib/leaderboard/types";
 import {
   escapeLikePattern,
@@ -318,7 +318,8 @@ async function fetchPeriodLeaderboardRows(
     .where(
       and(
         gte(dailyBreakdown.date, dateRange.start),
-        lte(dailyBreakdown.date, dateRange.end)
+        lte(dailyBreakdown.date, dateRange.end),
+        isNull(users.bannedAt)
       )
     );
 
@@ -386,7 +387,7 @@ async function fetchLeaderboardData(
       })
       .from(submissions)
       .innerJoin(users, eq(submissions.userId, users.id))
-      .where(hasDirectiveFilters ? and(...directiveConditions) : undefined)
+      .where(and(isNull(users.bannedAt), ...directiveConditions))
       .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
       .as("ranked");
     const rankedSecondaryOrderByColumn = sortBy === "cost"
@@ -426,7 +427,9 @@ async function fetchLeaderboardData(
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
         uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
-      .from(submissions);
+      .from(submissions)
+      .innerJoin(users, eq(submissions.userId, users.id))
+      .where(isNull(users.bannedAt));
 
     return {
       users: (results as RankedLeaderboardDbRow[]).map((row) => ({
@@ -471,6 +474,7 @@ async function fetchLeaderboardData(
     })
     .from(submissions)
     .innerJoin(users, eq(submissions.userId, users.id))
+    .where(isNull(users.bannedAt))
     .groupBy(users.id, users.username, users.displayName, users.avatarUrl)
     .orderBy(
       desc(orderByColumn),
@@ -488,7 +492,9 @@ async function fetchLeaderboardData(
         totalCost: sql<number>`SUM(CAST(${submissions.totalCost} AS DECIMAL(18,4)))`,
         uniqueUsers: sql<number>`COUNT(DISTINCT ${submissions.userId})`,
       })
-      .from(submissions),
+      .from(submissions)
+      .innerJoin(users, eq(submissions.userId, users.id))
+      .where(isNull(users.bannedAt)),
   ]);
 
   const totalUsers = Number(globalStats[0]?.uniqueUsers) || 0;
@@ -567,7 +573,7 @@ async function fetchUserRank(
   const userResult = await db
     .select({ id: users.id, username: users.username, displayName: users.displayName, avatarUrl: users.avatarUrl, verified: verifiedExpr() })
     .from(users)
-    .where(usernameEqualsIgnoreCase(username))
+    .where(and(usernameEqualsIgnoreCase(username), isNull(users.bannedAt)))
     .limit(USERNAME_LOOKUP_LIMIT);
 
   const user = getSingleUsernameMatch(userResult, username);
@@ -610,6 +616,8 @@ async function fetchUserRank(
           total: compareColumn.as("total"),
         })
         .from(submissions)
+        .innerJoin(users, eq(submissions.userId, users.id))
+        .where(isNull(users.bannedAt))
         .groupBy(submissions.userId)
         .having(sql`${compareColumn} > ${userCompareValue}`)
         .as("higher_ranked")


### PR DESCRIPTION
## Summary

Adds account bans and a public **Hall of Shame** page, prompted by the confirmed data-fabrication case (`fishxcode`).

- `users.banned_at` / `users.ban_reason` columns (migration `0021_add_user_bans.sql`). Banned users keep their submitted rows as evidence — nothing is deleted.
- Enforcement: web sessions of banned users stop resolving, GitHub OAuth sign-in is refused (`/shame?error=account_banned`), API tokens authenticate as `banned`, and `/api/submit`, `/api/auth/token`, `/api/me/stats` return 403.
- Ranking exclusion: every leaderboard path (period rows, all-time list, directive search, global stats, user rank) filters `banned_at IS NULL`, so banned accounts neither appear nor inflate totals.
- New `/shame` page (nav: "Hall of Shame") listing each banned account with ban date, full reason, and struck-through forged totals, plus a note that community reports are welcome (reporting channels to be announced). Usernames are partially masked (`fi******de`) so accounts named after a brand can't use the ban itself as advertising.

## Testing

- `bun run typecheck` — clean
- `bun run lint` — no new warnings
- `bun run test` — 613/613 pass (drizzle mocks extended with `isNull`; one directive-search assertion updated for the new ban guard)
- `bun run build` — `/shame` builds as a dynamic route

🤖 Generated with [Claude Code](https://claude.com/claude-code)
