### PR TITLE
feat(profile): render banned accounts as a data-free grayscale ban notice

### DIFF
--- a/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
+++ b/packages/frontend/__tests__/lib/getUserEmbedStats.test.ts
@@ -33,6 +33,7 @@ const mockState = vi.hoisted(() => {
   const eq = vi.fn(() => "eq");
   const and = vi.fn(() => "and");
   const gte = vi.fn(() => "gte");
+  const isNull = vi.fn(() => "isNull");
   const sql = Object.assign(
     vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
       strings: Array.from(strings),
@@ -72,6 +73,7 @@ const mockState = vi.hoisted(() => {
     eq,
     and,
     gte,
+    isNull,
     sql,
     reset() {
       awaitedResults.length = 0;
@@ -82,6 +84,7 @@ const mockState = vi.hoisted(() => {
       eq.mockClear();
       and.mockClear();
       gte.mockClear();
+      isNull.mockClear();
       sql.mockClear();
       sql.raw.mockClear();
     },
@@ -130,6 +133,7 @@ vi.mock("drizzle-orm", () => ({
   eq: mockState.eq,
   and: mockState.and,
   gte: mockState.gte,
+  isNull: mockState.isNull,
   sql: mockState.sql,
 }));
 

--- a/packages/frontend/src/app/u/[username]/BannedProfileView.tsx
+++ b/packages/frontend/src/app/u/[username]/BannedProfileView.tsx
@@ -1,0 +1,89 @@
+import Link from "next/link";
+
+export interface BannedProfileData {
+  banned: true;
+  bannedAt: string | null;
+  banReason: string | null;
+  user: {
+    username: string;
+    displayName: string | null;
+    avatarUrl: string | null;
+    createdAt: string;
+  };
+}
+
+/**
+ * Replacement for the normal profile when the account is banned. The URL
+ * stays reachable, but every statistic is withheld: the page renders only
+ * the identity, a ban stamp, and the reason. The identity block is pushed
+ * to grayscale so the stamp is the only thing with any color.
+ */
+export default function BannedProfileView({ data }: { data: BannedProfileData }) {
+  const { user } = data;
+  const banDate = data.bannedAt ? data.bannedAt.slice(0, 10) : null;
+
+  return (
+    <main className="main-container" id="main-content">
+      <div className="mx-auto max-w-[560px] px-4 py-16 sm:px-6">
+        <section className="relative overflow-hidden rounded-2xl border border-line bg-surface p-8 text-center">
+          {/* Rotated rubber-stamp mark — deliberately the only colored element */}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute right-4 top-6 rotate-12 rounded-md border-4 border-danger/70 px-3 py-1 font-mono text-xl font-black uppercase tracking-widest text-danger/80"
+          >
+            Banned
+          </div>
+
+          <div className="grayscale">
+            {user.avatarUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={user.avatarUrl}
+                alt={user.username}
+                width={96}
+                height={96}
+                className="mx-auto h-24 w-24 rounded-2xl object-cover opacity-60 ring-1 ring-line"
+              />
+            ) : (
+              <div className="mx-auto grid h-24 w-24 place-items-center rounded-2xl bg-foreground/10 font-mono text-3xl font-bold text-muted ring-1 ring-line">
+                {user.username[0]?.toUpperCase() ?? "?"}
+              </div>
+            )}
+
+            <h1 className="mt-5 font-mono text-xl font-bold text-muted line-through">
+              @{user.username}
+            </h1>
+          </div>
+
+          <p className="mt-2 inline-block rounded-md bg-danger/10 px-2.5 py-1 font-mono text-xs font-semibold uppercase tracking-wide text-danger">
+            Account banned{banDate ? ` on ${banDate}` : ""}
+          </p>
+
+          <p className="mt-6 text-sm leading-relaxed text-muted">
+            This account has been permanently banned for submitting fraudulent
+            usage data. All of its statistics have been removed from public
+            view and are excluded from every ranking.
+          </p>
+
+          {data.banReason && (
+            <div className="mt-6 rounded-xl border border-danger/25 bg-danger/5 p-4 text-left">
+              <h2 className="font-mono text-[11px] font-semibold uppercase tracking-wide text-danger">
+                Ban reason
+              </h2>
+              <p className="mt-2 text-sm leading-relaxed text-foreground/85">
+                {data.banReason}
+              </p>
+            </div>
+          )}
+
+          <Link
+            href="/shame"
+            className="mt-8 inline-block rounded-lg border border-line bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:border-foreground/25"
+          >
+            View the Hall of Shame →
+          </Link>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/packages/frontend/src/app/u/[username]/page.tsx
+++ b/packages/frontend/src/app/u/[username]/page.tsx
@@ -5,6 +5,7 @@ import { getGitHubSocialLinks } from '@/lib/githubSocials';
 import { loadPublicProfileDevicesForPage } from '@/lib/publicProfileDevices';
 import { loadPublicProfileForPage } from '@/lib/publicProfileData';
 import ProfilePageClient, { type ProfileData } from './ProfilePageClient';
+import BannedProfileView, { type BannedProfileData } from './BannedProfileView';
 
 export const revalidate = 60;
 
@@ -21,7 +22,7 @@ function parseProfilePeriod(value: string | string[] | undefined): ProfilePeriod
 async function getProfileData(
   username: string,
   period: ProfilePeriod,
-): Promise<ProfileData | null> {
+): Promise<ProfileData | BannedProfileData | null> {
   // Calling the shared server handler keeps Vercel Deployment Protection out
   // of the render path. A server-side HTTP self-fetch is anonymous and is
   // redirected to Vercel's HTML login page on protected preview deployments.
@@ -42,7 +43,14 @@ async function getProfileData(
     return null;
   }
 
-  return result.data as ProfileData;
+  const data = result.data as ProfileData | BannedProfileData;
+  return data;
+}
+
+function isBannedProfile(
+  data: ProfileData | BannedProfileData,
+): data is BannedProfileData {
+  return "banned" in data && data.banned === true;
 }
 
 // Devices are an enrichment on top of the core profile: if this fetch fails
@@ -105,6 +113,10 @@ export default async function ProfilePage({
 
   if (data.user?.username && data.user.username !== username) {
     permanentRedirect(`/u/${data.user.username}${period === "all" ? "" : `?period=${period}`}`);
+  }
+
+  if (isBannedProfile(data)) {
+    return <BannedProfileView data={data} />;
   }
 
   return (

--- a/packages/frontend/src/lib/embed/getUserEmbedStats.ts
+++ b/packages/frontend/src/lib/embed/getUserEmbedStats.ts
@@ -6,7 +6,7 @@ import {
   normalizeUsernameCacheKey,
   usernameEqualsIgnoreCase,
 } from "@/lib/db/usernameLookup";
-import { eq, sql, and, gte } from "drizzle-orm";
+import { eq, sql, and, gte, isNull } from "drizzle-orm";
 import { getContributionIntensity, getContributionWindow } from "./embedShared";
 
 export type EmbedSortBy = "tokens" | "cost";
@@ -87,7 +87,9 @@ async function fetchUserEmbedStats(
     })
     .from(users)
     .leftJoin(submissions, eq(submissions.userId, users.id))
-    .where(usernameEqualsIgnoreCase(username))
+    // Banned users render as "not found": embed badges are exactly the
+    // advertising surface a leaderboard cheater is after.
+    .where(and(usernameEqualsIgnoreCase(username), isNull(users.bannedAt)))
     .limit(USERNAME_LOOKUP_LIMIT);
   const result = getSingleUsernameMatch(matchingUsers, username);
 
@@ -107,18 +109,19 @@ async function fetchUserEmbedStats(
     const rankResult = await db.execute<{ rank: number; total: number }>(sql`
       WITH ranked AS (
         SELECT
-          user_id,
+          s.user_id,
           RANK() OVER (
             ORDER BY
               ${
                 sortBy === "cost"
-                  ? sql`CAST(total_cost AS DECIMAL(18,4)) DESC`
-                  : sql`total_tokens DESC`
+                  ? sql`CAST(s.total_cost AS DECIMAL(18,4)) DESC`
+                  : sql`s.total_tokens DESC`
               }
           ) AS rank
-        FROM submissions
+        FROM submissions s
+        JOIN users u ON u.id = s.user_id AND u.banned_at IS NULL
       )
-      SELECT rank, (SELECT COUNT(*)::int FROM submissions) AS total
+      SELECT rank, (SELECT COUNT(*)::int FROM ranked) AS total
       FROM ranked WHERE user_id = ${result.id}
     `);
 
@@ -174,7 +177,7 @@ async function fetchUserEmbedContributions(
   const matchingUsers = await db
     .select({ id: users.id })
     .from(users)
-    .where(usernameEqualsIgnoreCase(username))
+    .where(and(usernameEqualsIgnoreCase(username), isNull(users.bannedAt)))
     .limit(USERNAME_LOOKUP_LIMIT);
   const user = getSingleUsernameMatch(matchingUsers, username);
 
@@ -258,7 +261,7 @@ async function fetchUserEmbedToday(username: string): Promise<EmbedTodayUsage | 
   const matchingUsers = await db
     .select({ id: users.id })
     .from(users)
-    .where(usernameEqualsIgnoreCase(username))
+    .where(and(usernameEqualsIgnoreCase(username), isNull(users.bannedAt)))
     .limit(USERNAME_LOOKUP_LIMIT);
   const user = getSingleUsernameMatch(matchingUsers, username);
 

--- a/packages/frontend/src/lib/publicProfileData.ts
+++ b/packages/frontend/src/lib/publicProfileData.ts
@@ -112,6 +112,8 @@ export async function getPublicProfileResponse(
         displayName: users.displayName,
         avatarUrl: users.avatarUrl,
         createdAt: users.createdAt,
+        bannedAt: users.bannedAt,
+        banReason: users.banReason,
       })
       .from(users)
       .where(usernameEqualsIgnoreCase(username))
@@ -129,6 +131,22 @@ export async function getPublicProfileResponse(
         canonicalUrl.searchParams.set("period", period);
       }
       return NextResponse.redirect(canonicalUrl, 308);
+    }
+
+    // Banned profiles stay reachable but expose no usage data: just enough
+    // identity to render the ban notice.
+    if (user.bannedAt) {
+      return NextResponse.json({
+        banned: true,
+        bannedAt: user.bannedAt.toISOString(),
+        banReason: user.banReason,
+        user: {
+          username: user.username,
+          displayName: user.displayName,
+          avatarUrl: user.avatarUrl,
+          createdAt: user.createdAt.toISOString(),
+        },
+      });
     }
 
     const dailyBreakdownFilter = periodRange
@@ -176,10 +194,11 @@ export async function getPublicProfileResponse(
         db.execute<{ rank: number }>(sql`
         WITH user_totals AS (
           SELECT
-            user_id,
-            SUM(total_tokens) as total_tokens
-          FROM submissions
-          GROUP BY user_id
+            s.user_id,
+            SUM(s.total_tokens) as total_tokens
+          FROM submissions s
+          JOIN users u ON u.id = s.user_id AND u.banned_at IS NULL
+          GROUP BY s.user_id
         ),
         ranked AS (
           SELECT

--- a/packages/frontend/src/lib/publicProfileDevices.ts
+++ b/packages/frontend/src/lib/publicProfileDevices.ts
@@ -37,6 +37,7 @@ export async function getPublicProfileDevicesResponse(
         username: users.username,
         displayName: users.displayName,
         avatarUrl: users.avatarUrl,
+        bannedAt: users.bannedAt,
       })
       .from(users)
       .where(usernameEqualsIgnoreCase(username))
@@ -45,6 +46,18 @@ export async function getPublicProfileDevicesResponse(
     const user = getSingleUsernameMatch(matchingUsers, username);
     if (!user) {
       return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    // Banned users expose no usage data, device stats included.
+    if (user.bannedAt) {
+      return NextResponse.json({
+        user: {
+          username: user.username,
+          displayName: user.displayName,
+          avatarUrl: user.avatarUrl,
+        },
+        devices: [],
+      });
     }
 
     const rows = await db


### PR DESCRIPTION
## Summary

Follow-up to #37: banned accounts' profile pages stay reachable, but expose no data.

- `/u/<username>` for a banned account now renders a dedicated view: grayscale identity, a rotated red **BANNED** stamp, the ban date, the full ban reason, and a link to the Hall of Shame. No stats, charts, contribution graph, devices, models, or rank — the normal profile client is never rendered.
- `/api/users/<username>` returns a minimal `{ banned: true, bannedAt, banReason, user }` payload for banned accounts (no usage data), and `/api/users/<username>/devices` returns an empty device list.
- Embed and badge SVGs (`/api/embed/.../svg`, `/api/badge/.../svg`) treat banned users as not found — any badge the cheater embedded on their own site now renders the neutral "not found" badge instead of advertising stats.
- The profile-rank and embed-rank CTEs now exclude banned users, matching the leaderboard exclusion from #37 (previously a banned account still displaced everyone's rank on profile pages and badges).

## Testing

- `bun run typecheck` — clean
- `bun run test` — 613/613 pass (embed test drizzle mock extended with `isNull`)
- `bun run build` — compiles; `/u/[username]` and `/shame` build as dynamic routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
