### PR TITLE
fix(cli): clear the nine Windows-only clippy failures

### DIFF
--- a/cli/tokens-cli/src/antigravity.rs
+++ b/cli/tokens-cli/src/antigravity.rs
@@ -731,7 +731,7 @@ fn candidate_probe_ports(candidate: &ProcessCandidate, mut ports: Vec<u16>) -> V
 fn detect_process_candidates() -> Result<Vec<ProcessCandidate>> {
     #[cfg(target_os = "windows")]
     {
-        return detect_windows_process_candidates();
+        detect_windows_process_candidates()
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -920,6 +920,7 @@ fn is_antigravity_process(command: &str) -> bool {
         || lower.contains("\\antigravity\\")
 }
 
+#[cfg(not(target_os = "windows"))]
 fn process_executable_path(pid: u32) -> Option<PathBuf> {
     #[cfg(target_os = "linux")]
     {
@@ -981,7 +982,7 @@ fn extract_flag_value(command: &str, flag: &str) -> Option<String> {
 fn find_listening_ports(pid: u32) -> Result<Vec<u16>> {
     #[cfg(target_os = "windows")]
     {
-        return find_windows_listening_ports(pid);
+        find_windows_listening_ports(pid)
     }
 
     #[cfg(not(target_os = "windows"))]
@@ -1047,6 +1048,7 @@ fn parse_port_from_windows_address(address: &str) -> Option<u16> {
     port.parse::<u16>().ok()
 }
 
+#[cfg(not(target_os = "windows"))]
 fn run_port_query(program: &str, warning_label: &str, args: &[&str]) -> Result<Vec<u16>> {
     match run_command(program, args) {
         Ok(output) => Ok(parse_ports(&output)),
@@ -1069,6 +1071,7 @@ fn is_command_not_found(err: &anyhow::Error) -> bool {
     })
 }
 
+#[cfg(not(target_os = "windows"))]
 fn parse_ports(output: &str) -> Vec<u16> {
     let mut ports = Vec::new();
     for line in output.lines() {
@@ -1079,6 +1082,7 @@ fn parse_ports(output: &str) -> Vec<u16> {
     ports
 }
 
+#[cfg(not(target_os = "windows"))]
 fn parse_port_from_line(line: &str) -> Option<u16> {
     for token in line.split_whitespace() {
         if let Some(port) = token
@@ -1376,6 +1380,7 @@ fn contains_antigravity_marker(value: &Value) -> bool {
     }
 }
 
+#[cfg(not(target_os = "windows"))]
 fn run_command(program: &str, args: &[&str]) -> Result<String> {
     let output = run_command_output(program, args)?;
 

--- a/cli/tokens-cli/src/auth.rs
+++ b/cli/tokens-cli/src/auth.rs
@@ -2,6 +2,9 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::IsTerminal;
+// Only the unix branch of `save_credentials` writes through the trait; the
+// other one calls `fs::write`, which does not need it in scope.
+#[cfg(unix)]
 use std::io::Write;
 use std::path::PathBuf;
 

--- a/cli/tokens-cli/src/trae.rs
+++ b/cli/tokens-cli/src/trae.rs
@@ -55,6 +55,9 @@ pub mod auth {
     use base64::Engine;
     use chrono::{DateTime, Utc};
     use serde::{Deserialize, Serialize};
+    // Only the unix branch of `save_credentials` writes through the trait; the
+    // other one calls `fs::write`, which does not need it in scope.
+    #[cfg(unix)]
     use std::io::Write;
     use std::path::PathBuf;
 


### PR DESCRIPTION
The new CI builds on Windows as well as Linux and macOS, and its first run went red there — nine clippy failures that had been invisible because nobody had ever run clippy on Windows, so nothing behind a `cfg(unix)` dispatch was ever checked.

To be clear about severity: **the code always compiled on Windows.** These are warnings that `-D warnings` promotes to errors. The release pipeline was never broken.

## What was wrong

| Site | Issue |
|---|---|
| `auth.rs:5`, `trae.rs:58` | `use std::io::Write` unused on Windows |
| `antigravity.rs` ×5 | `process_executable_path`, `run_port_query`, `parse_ports`, `parse_port_from_line`, `run_command` never used |
| `antigravity.rs` ×2 | unneeded `return` |

## Fixes

**The imports are unix-only in practice.** Both `save_credentials` functions write through the trait under `cfg(unix)` and call `fs::write` otherwise, so on Windows the import had no user.

**The five helpers are reached only from the non-Windows side of a cfg dispatch** — Windows takes `detect_windows_process_candidates` and `find_windows_listening_ports` instead — so they are gated to match. This does not cascade: `is_command_not_found` and `run_command_output` keep Windows callers at `:1434` and `:1403`.

**The two returns were in the Windows arm of that same dispatch.** With the other arm compiled out the block becomes the tail expression, which is why the lint only fires there. The non-Windows arms were already written without a `return`, so dropping it makes the pair symmetric.

## Verification

Locally on macOS: `clippy --all-targets -- -D warnings` clean, release build links, binary reports its version. The Windows half is what this PR exists to have CI confirm.