### PR TITLE
docs(web): align public pricing copy with actual multi-source architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,12 @@ Clients that expose usage only through an account API need a sync step first —
 `tokens cursor sync`, `tokens antigravity sync`, `tokens trae sync`,
 `tokens warp sync` — after which they submit like everything else.
 
-Pricing comes from [LiteLLM's pricing data](https://github.com/BerriAI/litellm),
-including tiered rates and cache discounts.
+Pricing comes from a combination of
+[LiteLLM](https://github.com/BerriAI/litellm),
+[OpenRouter](https://openrouter.ai) and
+[models.dev](https://github.com/anomalyco/models.dev),
+with the best matching rate used per model. Built-in overrides handle tiered
+rates and cache discounts where the upstream feeds do not.
 
 ## What makes it different
 

--- a/web/src/app/(main)/terms/page.tsx
+++ b/web/src/app/(main)/terms/page.tsx
@@ -141,7 +141,8 @@ export default function TermsPage() {
       <Clause heading="Accuracy">
         <p>
           Cost figures are estimates. They are computed from public pricing data
-          and the token counts your tools recorded; they are not invoices, they
+          (LiteLLM, OpenRouter and models.dev) and the token counts your tools
+          recorded; they are not invoices, they
           do not account for your plan, discounts or credits, and they will not
           match what a provider actually bills you. Rankings depend on
           self-reported data and may be wrong or incomplete. Do not rely on any


### PR DESCRIPTION
## Summary
- README and the Terms accuracy clause still described pricing as coming from LiteLLM only.
- The CLI actually fetches and merges LiteLLM, OpenRouter and models.dev, with built-in overrides for tiered rates and cache discounts.
- Updated the public copy in `README.md` and `web/src/app/(main)/terms/page.tsx` to name all three sources and match the implementation.

#### Test plan
- [x] `bun run --cwd web typecheck` passes
- [x] `git status` shows only `README.md` and `terms/page.tsx` modified
- [x] Diff reviewed with `git diff main...HEAD`