### PR TITLE
feat(reasonix): parse authoritative stats JSONL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ written sessions, it is counted.
 | <img src=".github/assets/client-jcode.png" width="16" height="16" alt="" /> Jcode | <img src=".github/assets/client-junie.png" width="16" height="16" alt="" /> Junie | <img src=".github/assets/client-kilocode.png" width="16" height="16" alt="" /> Kilo | <img src=".github/assets/client-generic.svg" width="16" height="16" alt="" /> Kilo CLI |
 | <img src=".github/assets/client-kimi.png" width="16" height="16" alt="" /> Kimi | <img src=".github/assets/client-kiro.jpg" width="16" height="16" alt="" /> Kiro | <img src=".github/assets/client-micode.jpg" width="16" height="16" alt="" /> MiMo Code | <img src=".github/assets/client-mux.png" width="16" height="16" alt="" /> Mux |
 | <img src=".github/assets/client-openclaw.jpg" width="16" height="16" alt="" /> OpenClaw | <img src=".github/assets/client-opencode.png" width="16" height="16" alt="" /> OpenCode | <img src=".github/assets/client-opencodereview.png" width="16" height="16" alt="" /> OpenCodeReview | <img src=".github/assets/client-orca.png" width="16" height="16" alt="" /> Orca |
-| <img src=".github/assets/client-pi.png" width="16" height="16" alt="" /> Pi | <img src=".github/assets/client-qwen.png" width="16" height="16" alt="" /> Qwen | <img src=".github/assets/client-roocode.png" width="16" height="16" alt="" /> Roo Code | <img src=".github/assets/client-trae.png" width="16" height="16" alt="" /> Trae |
+| <img src=".github/assets/client-pi.png" width="16" height="16" alt="" /> Pi | <img src=".github/assets/client-qwen.png" width="16" height="16" alt="" /> Qwen | <img src=".github/assets/client-generic.svg" width="16" height="16" alt="" /> Reasonix | <img src=".github/assets/client-roocode.png" width="16" height="16" alt="" /> Roo Code |
+| <img src=".github/assets/client-trae.png" width="16" height="16" alt="" /> Trae |   |   |   |
 | <img src=".github/assets/client-warp.png" width="16" height="16" alt="" /> Warp | <img src=".github/assets/client-workbuddy.png" width="16" height="16" alt="" /> WorkBuddy | <img src=".github/assets/client-zcode.png" width="16" height="16" alt="" /> ZCode | <img src=".github/assets/client-zed.webp" width="16" height="16" alt="" /> Zed Agent |
 
 <details>
@@ -83,6 +84,7 @@ written sessions, it is counted.
 | [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `~/.gemini/tmp/*/chats/*.json` |
 | [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) | `~/.kimi/sessions/` |
 | [Qwen CLI](https://github.com/QwenLM/qwen-cli) | `~/.qwen/projects/` |
+| Reasonix | `~/.reasonix/stats/*.jsonl` (override via `REASONIX_STATE_HOME` or `REASONIX_HOME`) |
 | [Amp](https://ampcode.com/) | `~/.local/share/amp/threads/` |
 | [Droid](https://factory.ai/) | `~/.factory/sessions/` |
 | [Cline](https://github.com/cline/cline) | VS Code globalStorage tasks, or `~/.cline/data/sessions/` for the Cline CLI / desktop |

--- a/cli/tokens-cli/src/main.rs
+++ b/cli/tokens-cli/src/main.rs
@@ -477,6 +477,7 @@ pub enum ClientFilter {
     DevinCli,
     #[value(name = "devin-desktop")]
     DevinDesktop,
+    Reasonix,
     Synthetic,
 }
 
@@ -526,6 +527,7 @@ impl ClientFilter {
             Self::Workbuddy => "workbuddy",
             Self::DevinCli => "devin-cli",
             Self::DevinDesktop => "devin-desktop",
+            Self::Reasonix => "reasonix",
             Self::Synthetic => "synthetic",
         }
     }
@@ -578,6 +580,7 @@ impl ClientFilter {
             Self::Workbuddy => Some(ClientId::WorkBuddy),
             Self::DevinCli => Some(ClientId::DevinCli),
             Self::DevinDesktop => Some(ClientId::DevinDesktop),
+            Self::Reasonix => Some(ClientId::Reasonix),
             Self::Synthetic => None,
         }
     }
@@ -626,6 +629,7 @@ impl ClientFilter {
             ClientId::WorkBuddy => Self::Workbuddy,
             ClientId::DevinCli => Self::DevinCli,
             ClientId::DevinDesktop => Self::DevinDesktop,
+            ClientId::Reasonix => Self::Reasonix,
         }
     }
 

--- a/cli/tokens-core/src/clients.rs
+++ b/cli/tokens-core/src/clients.rs
@@ -7,6 +7,13 @@ pub enum PathRoot {
         var: &'static str,
         fallback_relative: &'static str,
     },
+    /// Reasonix resolves its state directory from two optional env vars
+    /// (`REASONIX_STATE_HOME` taking precedence over `REASONIX_HOME`) before
+    /// falling back to the platform default (`~/.reasonix` on Unix,
+    /// `%APPDATA%/reasonix` on Windows). This is richer than `EnvVar`'s
+    /// single-var shape but kept self-contained here rather than introducing a
+    /// separate resolver helper, mirroring how `Config` inlines its logic.
+    ReasonixHome,
 }
 
 impl PathRoot {
@@ -65,6 +72,29 @@ impl PathRoot {
                     }
                 } else {
                     format!("{}/{}", home_dir, fallback_relative)
+                }
+            }
+            PathRoot::ReasonixHome => {
+                if use_env_roots {
+                    for var in ["REASONIX_STATE_HOME", "REASONIX_HOME"] {
+                        if let Ok(val) = std::env::var(var) {
+                            let trimmed = val.trim();
+                            if !trimmed.is_empty() {
+                                return trimmed.to_string();
+                            }
+                        }
+                    }
+                }
+                #[cfg(target_os = "windows")]
+                {
+                    std::path::Path::new(home_dir)
+                        .join("AppData/Roaming/reasonix")
+                        .to_string_lossy()
+                        .into_owned()
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    format!("{home_dir}/.reasonix")
                 }
             }
         }
@@ -550,6 +580,18 @@ define_clients!(
         headless: false,
         parse_local: true,
         submit_default: true
+    },
+    // Reasonix stores authoritative per-call provider usage as daily append-only
+    // JSONL records under `<state root>/stats/`. Transcript JSONL is excluded:
+    // it lacks exact token counters and would overlap these stats records.
+    Reasonix = 39 => {
+        id: "reasonix",
+        root: PathRoot::ReasonixHome,
+        relative: "stats",
+        pattern: "*.jsonl",
+        headless: false,
+        parse_local: true,
+        submit_default: true
     }
 );
 
@@ -582,4 +624,3 @@ impl Default for ClientCounts {
         Self::new()
     }
 }
-

--- a/cli/tokens-core/src/lib.rs
+++ b/cli/tokens-core/src/lib.rs
@@ -1902,6 +1902,29 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         workbuddy_fallback_messages,
     ));
 
+    // Reasonix writes authoritative per-call usage to append-only daily JSONL,
+    // so cache by file (samples-only fingerprint catches appends) and rely on
+    // the parser's namespaced dedup key instead of a separate seen-set.
+    let reasonix_outcomes: Vec<CachedParseOutcome> = scan_result
+        .get(ClientId::Reasonix)
+        .par_iter()
+        .map(|path| {
+            load_or_parse_source(
+                message_cache::CacheIdentity::for_client(ClientId::Reasonix),
+                path,
+                &source_cache,
+                pricing,
+                sessions::reasonix::parse_reasonix_file,
+            )
+        })
+        .collect();
+    for outcome in reasonix_outcomes {
+        all_messages.extend(outcome.messages);
+        if let Some(entry) = outcome.cache_entry {
+            source_cache.insert(entry);
+        }
+    }
+
     if include_synthetic {
         if let Some(db_path) = &scan_result.synthetic_db {
             let outcome = load_or_parse_sqlite_source(

--- a/cli/tokens-core/src/sessions/mod.rs
+++ b/cli/tokens-core/src/sessions/mod.rs
@@ -36,6 +36,7 @@ pub mod opencode;
 pub mod opencodereview;
 pub mod pi;
 pub mod qwen;
+pub mod reasonix;
 pub mod roocode;
 pub mod synthetic;
 pub(crate) mod tencent_buddy;
@@ -444,4 +445,3 @@ pub fn workspace_label_from_key(key: &str) -> Option<String> {
 fn timestamp_to_date(timestamp_ms: i64) -> String {
     crate::bucket_tz::bucket_timezone().date_of_ms(timestamp_ms)
 }
-

--- a/cli/tokens-core/src/sessions/reasonix.rs
+++ b/cli/tokens-core/src/sessions/reasonix.rs
@@ -1,0 +1,304 @@
+//! Parser for Reasonix's authoritative append-only statistics records.
+//!
+//! Reasonix writes one JSON object per provider request to
+//! `<REASONIX_HOME>/stats/YYYY-MM-DD.jsonl`. Each record carries per-call
+//! token totals (`prompt`, `completion`, `reasoning`, `cache_hit`,
+//! `cache_miss`) and an authoritative `requests` count that we surface as
+//! `message_count`. Session transcript JSONL is intentionally not scanned:
+//! it has no authoritative usage counters and would overlap these records.
+
+use super::utils::parse_timestamp_value;
+use super::UnifiedMessage;
+use crate::provider_identity::{canonical_provider, inferred_provider_from_model};
+use crate::TokenBreakdown;
+use serde::Deserialize;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+const CLIENT_ID: &str = "reasonix";
+/// Sentinel model/provider used when a record's model ref is empty or its
+/// upstream provider cannot be inferred. Keeps the row attributable so spend
+/// still lands on a stable bucket rather than being dropped.
+const UNKNOWN_MODEL: &str = "reasonix-unknown";
+
+#[derive(Debug, Deserialize)]
+struct ReasonixStat {
+    ts: serde_json::Value,
+    #[serde(default)]
+    model: String,
+    #[serde(default)]
+    prompt: i64,
+    #[serde(default)]
+    completion: i64,
+    #[serde(default)]
+    reasoning: i64,
+    #[serde(default)]
+    cache_hit: i64,
+    // Newer records carry an explicit ordinary-input bucket; older ones omit
+    // it, in which case we derive input from `prompt` minus cache hits.
+    cache_miss: Option<i64>,
+    #[serde(default)]
+    total: i64,
+    #[serde(default)]
+    requests: i64,
+    // `turn` markers delimit user turns and carry no usage; skip them.
+    #[serde(default)]
+    turn: bool,
+}
+
+/// Split a `provider/model` ref into its components. A bare model name is
+/// paired with its inferred upstream provider, falling back to the Reasonix
+/// client id only when neither the canonical-provider table nor the model
+/// inference heuristics recognise it.
+fn split_model_ref(model_ref: &str) -> (String, String) {
+    let model_ref = model_ref.trim();
+    if let Some((provider, model)) = model_ref.split_once('/') {
+        let provider = canonical_provider(provider).unwrap_or_else(|| provider.to_string());
+        return (provider, model.trim().to_string());
+    }
+    let provider = inferred_provider_from_model(model_ref)
+        .unwrap_or(CLIENT_ID)
+        .to_string();
+    (provider, model_ref.to_string())
+}
+
+fn non_negative(value: i64) -> i64 {
+    value.max(0)
+}
+
+/// Parse a Reasonix stats JSONL file into unified messages.
+///
+/// Token buckets stay additive: the `prompt` field already includes cached
+/// tokens and `completion` already includes reasoning, so the parser stores
+/// the non-overlapping components. An explicit nonzero `cache_miss` is the
+/// authoritative ordinary-input bucket; when it's absent the parser derives
+/// that bucket from `prompt` minus `cache_hit` (clamped at zero).
+pub fn parse_reasonix_file(path: &Path) -> Vec<UnifiedMessage> {
+    let Ok(file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+
+    let source_id = format!("reasonix-stats:{}", path.display());
+
+    BufReader::new(file)
+        .lines()
+        .enumerate()
+        .filter_map(|(line_index, line)| {
+            let line = line.ok()?;
+            let record: ReasonixStat = serde_json::from_str(line.trim()).ok()?;
+            // Drop non-usage rows: turn markers, model-only records, and rows
+            // with neither tokens nor an authoritative request count. A row
+            // with `total: 0, requests: N` is kept so its request count is
+            // still reported.
+            if record.turn
+                || record.model.trim().is_empty()
+                || (record.total <= 0 && record.requests <= 0)
+            {
+                return None;
+            }
+
+            let timestamp = parse_timestamp_value(&record.ts)?;
+            let (provider_id, model_id) = split_model_ref(&record.model);
+
+            let cache_read = non_negative(record.cache_hit);
+            let raw_prompt = non_negative(record.prompt);
+            // An explicit nonzero cache miss is Reasonix's authoritative
+            // ordinary-input bucket. Older records omit it, so derive that
+            // bucket from prompt tokens minus cache hits in that case.
+            let input = match record.cache_miss {
+                Some(cache_miss) if cache_miss != 0 => non_negative(cache_miss),
+                _ => raw_prompt.saturating_sub(cache_read),
+            };
+            // `completion` already includes reasoning, so keep the buckets
+            // additive: clamp reasoning into `[0, completion]` and report the
+            // remainder as output.
+            let reasoning = non_negative(record.reasoning).min(non_negative(record.completion));
+            let output = non_negative(record.completion).saturating_sub(reasoning);
+            let tokens = TokenBreakdown {
+                input,
+                output,
+                cache_read,
+                cache_write: 0,
+                reasoning,
+            };
+
+            // Dedup by (path, line index, requests, total). The line index
+            // keeps distinct rows apart when a fixture repeats the same
+            // `(requests, total)` pair, while still collapsing byte-identical
+            // re-emissions of the same record.
+            let dedup_key = format!(
+                "reasonix:{source_id}:{line_index}:{requests}:{total}",
+                requests = record.requests,
+                total = record.total,
+            );
+
+            let mut message = UnifiedMessage::new_with_dedup(
+                CLIENT_ID,
+                if model_id.is_empty() {
+                    UNKNOWN_MODEL.to_string()
+                } else {
+                    model_id
+                },
+                provider_id,
+                source_id.clone(),
+                timestamp,
+                tokens,
+                0.0,
+                Some(dedup_key),
+            );
+            // `requests` is the authoritative per-call count. Clamp into the
+            // `i32` message-count range so a zero maps to 1 (the row exists,
+            // so the call happened at least once) and an overflowing value
+            // saturates rather than wrapping.
+            message.message_count = record.requests.clamp(1, i64::from(i32::MAX)) as i32;
+            Some(message)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    fn write_stats(content: &str) -> NamedTempFile {
+        let mut file = NamedTempFile::new().unwrap();
+        use std::io::Write;
+        file.write_all(content.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn parses_authoritative_stats_with_provider_usage_and_timestamp() {
+        let file = write_stats(
+            r#"{"ts":"2026-08-04T09:10:11Z","model":"deepseek/chat","prompt":100,"completion":20,"cache_hit":10,"total":130,"requests":3}"#,
+        );
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        let message = &messages[0];
+        assert_eq!(message.client, CLIENT_ID);
+        assert_eq!(message.provider_id, "deepseek");
+        assert_eq!(message.model_id, "chat");
+        assert_eq!(message.timestamp, 1_785_834_611_000);
+        // `prompt` already includes cache_hit, so ordinary input is 100 - 10.
+        assert_eq!(message.tokens.input, 90);
+        assert_eq!(message.tokens.cache_read, 10);
+        assert_eq!(message.tokens.output, 20);
+        assert_eq!(message.tokens.reasoning, 0);
+        assert_eq!(message.tokens.total(), 120);
+        assert_eq!(message.message_count, 3);
+    }
+
+    #[test]
+    fn skips_turn_markers_malformed_and_zero_usage_records() {
+        let file = write_stats(
+            r#"{"ts":"2026-08-04T09:00:00Z","turn":true}
+not json
+{"ts":"2026-08-04T09:01:00Z","model":"","total":10}
+{"ts":"2026-08-04T09:02:00Z","model":"x","total":0,"requests":0}
+{"ts":"2026-08-04T09:03:00Z","model":"x","prompt":3,"completion":2,"total":5,"requests":0}"#,
+        );
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.total(), 5);
+        // `requests: 0` clamps to 1 because the row itself represents a call.
+        assert_eq!(messages[0].message_count, 1);
+    }
+
+    #[test]
+    fn preserves_unknown_model_provider_as_reasonix_only_when_not_inferable() {
+        let file = write_stats(
+            r#"{"ts":"2026-08-04T09:00:00Z","model":"zzz-unknown-vendor-model","total":7,"requests":1}"#,
+        );
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        // No `provider/model` slash and not a recognisable model: provider
+        // falls back to the client id.
+        assert_eq!(messages[0].provider_id, CLIENT_ID);
+    }
+
+    #[test]
+    fn split_model_ref_handles_provider_slash_and_inference() {
+        // Explicit provider passes through canonicalisation.
+        let (provider, model) = split_model_ref("deepseek/chat");
+        assert_eq!(provider, "deepseek");
+        assert_eq!(model, "chat");
+
+        // Multi-segment model names keep everything after the first slash.
+        let (provider, model) = split_model_ref("openrouter/google/gemini-2.5-pro");
+        assert_eq!(provider, "openrouter");
+        assert_eq!(model, "google/gemini-2.5-pro");
+
+        // Bare recognisable model resolves to the inferred provider.
+        let (provider, _) = split_model_ref("claude-sonnet-4");
+        assert_eq!(provider, "anthropic");
+    }
+
+    #[test]
+    fn preserves_explicit_cache_miss_when_it_disagrees_with_prompt_input() {
+        let file = write_stats(
+            r#"{"ts":"2026-08-04T09:00:00Z","model":"x/y","prompt":100,"completion":1,"cache_hit":10,"cache_miss":50,"total":61,"requests":1}"#,
+        );
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        // Explicit nonzero cache_miss wins over the `prompt - cache_hit` derivation.
+        assert_eq!(messages[0].tokens.input, 50);
+        assert_eq!(messages[0].tokens.cache_read, 10);
+    }
+
+    #[test]
+    fn falls_back_to_prompt_minus_cache_hit_when_cache_miss_is_absent() {
+        let file = write_stats(
+            r#"{"ts":"2026-08-04T09:00:00Z","model":"x/y","prompt":40,"completion":1,"cache_hit":15,"total":56,"requests":1}"#,
+        );
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 25);
+        assert_eq!(messages[0].tokens.cache_read, 15);
+    }
+
+    #[test]
+    fn reasoning_is_clamped_into_completion_so_buckets_stay_additive() {
+        let file = write_stats(
+            r#"{"ts":"2026-08-04T09:00:00Z","model":"x/y","prompt":10,"completion":8,"reasoning":20,"total":26,"requests":1}"#,
+        );
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        // reasoning clamps to completion (8), output becomes 0; nothing is
+        // double-counted.
+        assert_eq!(messages[0].tokens.reasoning, 8);
+        assert_eq!(messages[0].tokens.output, 0);
+        assert_eq!(messages[0].tokens.total(), 18);
+    }
+
+    #[test]
+    fn maps_authoritative_request_count_to_bounded_message_count() {
+        let file = write_stats(
+            r#"{"ts":"2026-08-04T09:00:00Z","model":"x/y","total":1,"requests":9999999999}"#,
+        );
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].message_count, i32::MAX);
+    }
+
+    #[test]
+    fn preserves_tokenless_request_counts_but_skips_plain_zero_rows() {
+        let file = write_stats(
+            r#"{"ts":"2026-08-04T09:00:00Z","model":"x/y","total":0,"requests":2}
+{"ts":"2026-08-04T09:01:00Z","model":"x/y","total":0,"requests":0}"#,
+        );
+        let messages = parse_reasonix_file(file.path());
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.total(), 0);
+        assert_eq!(messages[0].message_count, 2);
+    }
+}

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -67,6 +67,7 @@ export const SOURCE_DISPLAY_NAMES: Record<ClientType, string> = {
   workbuddy: "WorkBuddy",
   "devin-cli": "Devin CLI",
   "devin-desktop": "Devin Desktop",
+  reasonix: "Reasonix",
 };
 
 // Client logos, served from this deployment rather than hotlinked.
@@ -126,6 +127,7 @@ export const SOURCE_LOGOS: Record<ClientType, string> = {
     `${GITHUB_CDN_BASE}/client-workbuddy.png`,
   "devin-cli": `${GITHUB_CDN_BASE}/client-devin.jpg`,
   "devin-desktop": `${GITHUB_CDN_BASE}/client-devin.jpg`,
+  reasonix: `${GITHUB_CDN_BASE}/client-generic.svg`,
 };
 
 export const SOURCE_COLORS: Record<ClientType, string> = {
@@ -170,12 +172,13 @@ export const SOURCE_COLORS: Record<ClientType, string> = {
   workbuddy: "#2563EB",
   "devin-cli": "#334155",
   "devin-desktop": "#334155",
+  reasonix: "#6366F1",
 };
 
 /**
  * Every client the CLI scans, in display order.
  *
- * Mirrors `define_clients!` in `cli/tokens-core/src/clients.rs` — 39 entries,
+ * Mirrors `define_clients!` in `cli/tokens-core/src/clients.rs` — 40 entries,
  * excluding the two filter-only aliases (`synthetic`, `9router`) that have no
  * scan path of their own. Kept as an explicit list rather than derived from
  * SOURCE_DISPLAY_NAMES, which also carries those aliases and legacy keys.
@@ -214,6 +217,7 @@ export const SUPPORTED_CLIENTS: readonly ClientType[] = [
   "opencodereview",
   "pi",
   "qwen",
+  "reasonix",
   "roocode",
   "trae",
   "warp",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -40,6 +40,7 @@ export const SUPPORTED_CLIENT_TYPES = [
   "workbuddy",
   "devin-cli",
   "devin-desktop",
+  "reasonix",
 ] as const;
 
 export type CcMirrorClientType = `cc-mirror/${string}`;


### PR DESCRIPTION
Closes #55.

## Problem

`tokens` did not support Reasonix at all. Usage stored under `~/.reasonix/stats/*.jsonl` was silently ignored, so Reasonix users submitted zero usage.

## Fix

Adds Reasonix end-to-end:

- **`ClientId::Reasonix`** variant (index 39) registering `<state root>/stats/*.jsonl`.
- **`PathRoot::ReasonixHome`** — resolves `$REASONIX_STATE_HOME` → `$REASONIX_HOME` → platform default (`~/.reasonix` on Unix, `%APPDATA%/reasonix` on Windows). Self-contained in the `PathRoot` match (same shape as `Config`) rather than introducing a separate resolver helper.
- **`sessions/reasonix.rs`** — the parser.
- **Aggregation** in `lib.rs` caches by file via the samples-only fingerprint (catches appends to a daily log) and relies on the parser's namespaced dedup key.
- **CLI filter** wiring (`ClientFilter::Reasonix`) so `-c reasonix` works.
- **Web registry** (`SUPPORTED_CLIENT_TYPES`, `SOURCE_DISPLAY_NAMES`, `SOURCE_LOGOS`, `SOURCE_COLORS`, `SUPPORTED_CLIENTS`).
- **README** badge grid + data-location table.

### Token bucket arithmetic

Reasonix writes one JSON object per provider request with per-call token totals. Token buckets stay additive: `prompt` already includes cached tokens and `completion` already includes reasoning, so the parser stores the non-overlapping components:

- An explicit nonzero `cache_miss` is the authoritative ordinary-input bucket; when absent the parser derives input from `prompt - cache_hit`.
- Reasoning is clamped into `[0, completion]` so `output = completion - reasoning` can never double-count.
- `requests` is surfaced as `message_count`, clamped to `[1, i32::MAX]` so a zero maps to 1 (the row exists, so the call happened) and an overflow saturates rather than wrapping.

### Row filtering

Turn markers, model-only records, and rows with neither tokens nor an authoritative request count are dropped. A row with `total: 0, requests: N` is kept so its request count is still reported.

### Discovery

Generic — the scanner walks `<state root>/stats/*.jsonl` from the `ClientId` registration, so no `scanner.rs` edits were needed.

## Validation

9 unit tests (bucket arithmetic, cache_miss fallback, reasoning clamp, request-count mapping, row-skip rules, provider/model split) — all green.

Synthetic fixture dry-run:

```console
$ mkdir -p ~/.reasonix/stats && cat > ~/.reasonix/stats/2026-08-07.jsonl <<'JSON'
{"ts":"2026-08-07T09:10:11Z","model":"deepseek/chat","prompt":1500,"completion":300,"cache_hit":500,"total":2300,"requests":5}
{"ts":"2026-08-07T10:20:30Z","model":"anthropic/claude-sonnet-4","prompt":800,"completion":120,"reasoning":40,"cache_hit":0,"total":960,"requests":2}
{"ts":"2026-08-07T11:00:00Z","turn":true}
JSON
$ tokens submit --dry-run -c reasonix
  Date range: 2026-08-07 to 2026-08-07
  Active days: 1
  Total tokens: 2,720
  Total cost: $0.00
  Clients: reasonix
  Models: 2 models
```

Breakdown checks out: row 1 = 1000 input + 500 cache_read + 300 output = 1800; row 2 = 800 input + 80 output + 40 reasoning = 920. Total = 2720. The `turn:true` row is correctly skipped.
