### PR TITLE
fix(copilot): count desktop assistant messages

### DIFF
--- a/cli/tokens-core/src/sessions/copilot_desktop.rs
+++ b/cli/tokens-core/src/sessions/copilot_desktop.rs
@@ -8,6 +8,7 @@ use crate::provider_identity::inferred_provider_from_model;
 use chrono::{DateTime, NaiveDateTime};
 use rusqlite::{Connection, OpenFlags};
 use serde_json::Value;
+use std::collections::HashSet;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use tracing::warn;
@@ -21,12 +22,25 @@ struct CopilotDesktopSessionRow {
     total_cached_tokens: i64,
     total_reasoning_tokens: i64,
     created_at: Option<String>,
+    is_forked: bool,
 }
 
 #[derive(Debug, Default)]
 struct SessionStateMetadata {
     model: Option<String>,
     cwd: Option<String>,
+    assistant_message_count: i32,
+}
+
+fn forked_session_sql_expression(conn: &Connection) -> &'static str {
+    if conn
+        .prepare("SELECT forked_from_session_id FROM sessions LIMIT 0")
+        .is_ok()
+    {
+        "forked_from_session_id IS NOT NULL"
+    } else {
+        "0"
+    }
 }
 
 pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
@@ -45,7 +59,11 @@ pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
         }
     };
 
-    let mut stmt = match conn.prepare(
+    // Fork metadata was added after the original sessions schema. Select a
+    // constant fallback for older databases instead of making the whole parser
+    // fail when the column is absent.
+    let forked_expression = forked_session_sql_expression(&conn);
+    let sessions_query = format!(
         r#"
         SELECT
             id,
@@ -56,14 +74,17 @@ pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
             total_cached_tokens,
             total_reasoning_tokens,
             total_nano_aiu,
-            created_at
+            created_at,
+            {forked_expression} AS is_forked
         FROM sessions
         WHERE total_input_tokens > 0
            OR total_output_tokens > 0
            OR total_cached_tokens > 0
            OR total_reasoning_tokens > 0
-        "#,
-    ) {
+        "#
+    );
+
+    let mut stmt = match conn.prepare(&sessions_query) {
         Ok(stmt) => stmt,
         Err(err) => {
             warn!(
@@ -84,6 +105,7 @@ pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
             total_cached_tokens: row.get::<_, Option<i64>>(5)?.unwrap_or(0),
             total_reasoning_tokens: row.get::<_, Option<i64>>(6)?.unwrap_or(0),
             created_at: row.get(8)?,
+            is_forked: row.get::<_, i64>(9)? != 0,
         })
     }) {
         Ok(rows) => rows,
@@ -112,7 +134,7 @@ pub fn parse_copilot_desktop_db(db_path: &Path) -> Vec<UnifiedMessage> {
 }
 
 fn session_row_to_message(db_path: &Path, row: CopilotDesktopSessionRow) -> UnifiedMessage {
-    let metadata = read_session_state_metadata(db_path, &row.id);
+    let metadata = read_session_state_metadata(db_path, &row.id, !row.is_forked);
     let model_id = metadata
         .model
         .as_deref()
@@ -164,10 +186,23 @@ fn session_row_to_message(db_path: &Path, row: CopilotDesktopSessionRow) -> Unif
         message.set_workspace(Some(workspace_key), workspace_label);
     }
 
+    // The database row contains aggregate usage for the whole session, so the
+    // UnifiedMessage default of one would otherwise count sessions instead of
+    // assistant messages. Preserve that default as a compatibility fallback
+    // when the event history is unavailable, does not expose message events,
+    // or belongs to a fork that persists inherited parent history.
+    if metadata.assistant_message_count > 0 {
+        message.message_count = metadata.assistant_message_count;
+    }
+
     message
 }
 
-fn read_session_state_metadata(db_path: &Path, session_id: &str) -> SessionStateMetadata {
+fn read_session_state_metadata(
+    db_path: &Path,
+    session_id: &str,
+    count_assistant_messages: bool,
+) -> SessionStateMetadata {
     let Some(copilot_root) = db_path.parent() else {
         return SessionStateMetadata::default();
     };
@@ -176,16 +211,20 @@ fn read_session_state_metadata(db_path: &Path, session_id: &str) -> SessionState
         .join(session_id)
         .join("events.jsonl");
 
-    read_events_metadata(&events_path)
+    read_events_metadata(&events_path, count_assistant_messages)
 }
 
-fn read_events_metadata(events_path: &Path) -> SessionStateMetadata {
+fn read_events_metadata(
+    events_path: &Path,
+    count_assistant_messages: bool,
+) -> SessionStateMetadata {
     let file = match std::fs::File::open(events_path) {
         Ok(file) => file,
         Err(_) => return SessionStateMetadata::default(),
     };
 
     let mut metadata = SessionStateMetadata::default();
+    let mut seen_assistant_messages = HashSet::new();
     for line in BufReader::new(file).lines().map_while(Result::ok) {
         let trimmed = line.trim();
         if trimmed.is_empty() {
@@ -200,6 +239,25 @@ fn read_events_metadata(events_path: &Path) -> SessionStateMetadata {
         };
 
         match event_type {
+            "assistant.message" if count_assistant_messages => {
+                let message_id = event
+                    .pointer("/data/messageId")
+                    .and_then(Value::as_str)
+                    .map(str::trim)
+                    .filter(|id| !id.is_empty())
+                    .or_else(|| {
+                        event
+                            .get("id")
+                            .and_then(Value::as_str)
+                            .map(str::trim)
+                            .filter(|id| !id.is_empty())
+                    });
+
+                if message_id.is_none_or(|id| seen_assistant_messages.insert(id.to_string())) {
+                    metadata.assistant_message_count =
+                        metadata.assistant_message_count.saturating_add(1);
+                }
+            }
             "session.start" if metadata.cwd.is_none() => {
                 metadata.cwd = event
                     .pointer("/data/context/cwd")
@@ -259,3 +317,129 @@ fn parse_iso8601_timestamp_ms(value: &str) -> Option<i64> {
         })
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn session_row(id: &str) -> CopilotDesktopSessionRow {
+        CopilotDesktopSessionRow {
+            id: id.to_string(),
+            model: Some("claude-sonnet-4".to_string()),
+            total_input_tokens: 100,
+            total_output_tokens: 20,
+            total_cached_tokens: 30,
+            total_reasoning_tokens: 5,
+            created_at: Some("2026-08-06T00:00:00Z".to_string()),
+            is_forked: false,
+        }
+    }
+
+    fn write_session_events(temp_dir: &TempDir, session_id: &str, events: &str) {
+        let session_dir = temp_dir.path().join("session-state").join(session_id);
+        fs::create_dir_all(&session_dir).expect("create session-state fixture");
+        fs::write(session_dir.join("events.jsonl"), events).expect("write events fixture");
+    }
+
+    #[test]
+    fn counts_unique_assistant_messages_on_the_session_aggregate() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let session_id = "session-with-events";
+        write_session_events(
+            &temp_dir,
+            session_id,
+            concat!(
+                "{\"type\":\"session.start\",\"data\":{\"context\":{\"cwd\":\"/tmp/project\"}}}\n",
+                "{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"message-1\"},\"id\":\"event-1\"}\n",
+                "{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"message-1\"},\"id\":\"event-replay\"}\n",
+                "{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"message-2\"},\"id\":\"event-2\"}\n",
+                "{\"type\":\"session.compaction_complete\",\"id\":\"compaction-1\"}\n",
+                "not-json\n",
+            ),
+        );
+
+        let message =
+            session_row_to_message(&temp_dir.path().join("data.db"), session_row(session_id));
+
+        assert_eq!(message.message_count, 2);
+        assert_eq!(message.timestamp, 1_785_974_400_000);
+        assert_eq!(message.tokens.input, 70);
+        assert_eq!(message.tokens.output, 20);
+        assert_eq!(message.tokens.cache_read, 30);
+        assert_eq!(message.tokens.reasoning, 5);
+        assert_eq!(message.workspace_key.as_deref(), Some("/tmp/project"));
+    }
+
+    #[test]
+    fn falls_back_to_one_message_without_session_events() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let message = session_row_to_message(
+            &temp_dir.path().join("data.db"),
+            session_row("session-without-events"),
+        );
+
+        assert_eq!(message.message_count, 1);
+    }
+
+    #[test]
+    fn falls_back_to_event_id_for_blank_message_ids() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let session_id = "session-with-blank-message-ids";
+        write_session_events(
+            &temp_dir,
+            session_id,
+            concat!(
+                "{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"  \"},\"id\":\"event-1\"}\n",
+                "{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"\"},\"id\":\"event-1\"}\n",
+                "{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"\"},\"id\":\"event-2\"}\n",
+            ),
+        );
+
+        let metadata =
+            read_session_state_metadata(&temp_dir.path().join("data.db"), session_id, true);
+
+        assert_eq!(metadata.assistant_message_count, 2);
+    }
+
+    #[test]
+    fn forked_sessions_keep_the_compatibility_message_count() {
+        let temp_dir = TempDir::new().expect("create temp dir");
+        let session_id = "forked-session";
+        write_session_events(
+            &temp_dir,
+            session_id,
+            concat!(
+                "{\"type\":\"session.start\",\"data\":{\"context\":{\"cwd\":\"/tmp/fork-project\"}}}\n",
+                "{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"inherited-message\"},\"id\":\"event-1\"}\n",
+                "{\"type\":\"assistant.message\",\"data\":{\"messageId\":\"child-message\"},\"id\":\"event-2\"}\n",
+            ),
+        );
+        let mut row = session_row(session_id);
+        row.is_forked = true;
+
+        let message = session_row_to_message(&temp_dir.path().join("data.db"), row);
+
+        assert_eq!(message.message_count, 1);
+        assert_eq!(message.workspace_key.as_deref(), Some("/tmp/fork-project"));
+    }
+
+    #[test]
+    fn selects_a_non_fork_fallback_for_legacy_schema() {
+        let conn = Connection::open_in_memory().expect("create in-memory database");
+        conn.execute("CREATE TABLE sessions (id TEXT)", [])
+            .expect("create legacy sessions table");
+
+        assert_eq!(forked_session_sql_expression(&conn), "0");
+
+        conn.execute(
+            "ALTER TABLE sessions ADD COLUMN forked_from_session_id TEXT",
+            [],
+        )
+        .expect("add fork metadata column");
+        assert_eq!(
+            forked_session_sql_expression(&conn),
+            "forked_from_session_id IS NOT NULL"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- count Copilot Desktop `assistant.message` events instead of sessions
- deduplicate messages by `messageId`, with an event ID fallback
- preserve the existing one-message fallback for missing histories and forked sessions
- support databases without fork metadata

## Root cause

Copilot Desktop stores token usage as one aggregate database row per session.
The parser therefore retained `UnifiedMessage`'s default `message_count = 1`,
causing sessions to be reported as messages.

## Validation

- verified against 19 real Copilot Desktop sessions
- assistant output-token totals matched the corresponding database aggregates
- `cargo test --manifest-path cli/Cargo.toml`
- `cargo clippy --manifest-path cli/Cargo.toml --all-targets -- -D warnings`
- release build and CLI smoke test