### PR TITLE
ci(web): retry bun install + cache node_modules to absorb registry flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,41 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2
 
+      # Cache bun's global download cache and the installed node_modules, keyed
+      # by the lockfile. A hit means install only has to verify the lockfile
+      # matches — no tarball downloads, no extractions — which both speeds up
+      # the job and removes the surface that produced the transient
+      # `Fail extracting tarball for "next"` flake. Mirrors the cargo cache in
+      # the build job above.
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.bun/install/cache
+            web/node_modules
+          key: web-bun-${{ hashFiles('web/bun.lock') }}
+          restore-keys: web-bun-
+
       # --frozen-lockfile, unlike the release workflow, which deliberately does
       # not use it. Here a lockfile that disagrees with package.json is exactly
       # the kind of thing a PR should fail on: the styled-components removal
       # changed both, and a stale lock would have installed the packages it had
       # just dropped.
+      #
+      # Retry loop: `bun install` occasionally fails mid-extraction on a
+      # transient registry/network error (`Fail extracting tarball for "next"`),
+      # which has nothing to do with the PR. `--frozen-lockfile` is safe to
+      # retry — it never mutates the lockfile — so a plain bash loop with linear
+      # backoff recovers without human intervention. Zero overhead on the
+      # success path (exits on attempt 1).
       - name: Install
-        run: cd web && bun install --frozen-lockfile
+        run: |
+          cd web
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then exit 0; fi
+            echo "bun install attempt $attempt failed; retrying in $((attempt * 5))s" >&2
+            sleep $((attempt * 5))
+          done
+          exit 1
 
       # No --max-warnings 0. The tree carries a handful of long-standing
       # warnings that have nothing to do with any given PR, and failing on them


### PR DESCRIPTION
## Problem

The Web CI job intermittently fails at `bun install` with:

```
error: Fail extracting tarball for "next"
error: Fail extracting tarball from next
```

This is a transient registry/network failure unrelated to the PR under test. It has struck this PR ([run 31303662499](https://github.com/missuo/tokens/actions/runs/31303662499/job/93220409386)) and other recent PRs (e.g. `fix/grok-unified-log` failed then passed on rerun with the same code). The only recovery today is a manual workflow rerun — which requires admin rights on `missuo/tokens` that contributors don't have.

## Fix

Two first-party-only changes to the `web` job, both around the Install step:

1. **Cache** bun's global download cache (`~/.bun/install/cache`) and `web/node_modules` via `actions/cache@v5`, keyed by `hashFiles('web/bun.lock')` with a `web-bun-` partial-key fallback. A cache hit means install only verifies the lockfile — no tarball downloads, no extractions — which both speeds up the job and removes the surface that produced the flake. Mirrors the cargo cache already used in the `build` job in this same workflow.

2. **Retry loop** wrapping `bun install --frozen-lockfile` — 3 attempts with linear backoff (5s, 10s). `--frozen-lockfile` is idempotent and never mutates the lockfile, so retrying is always safe. **Zero overhead on the success path** (the loop exits on attempt 1).

```yaml
- uses: actions/cache@v5
  with:
    path: |
      ~/.bun/install/cache
      web/node_modules
    key: web-bun-${{ hashFiles('web/bun.lock') }}
    restore-keys: web-bun-

- name: Install
  run: |
    cd web
    for attempt in 1 2 3; do
      if bun install --frozen-lockfile; then exit 0; fi
      echo "bun install attempt $attempt failed; retrying in $((attempt * 5))s" >&2
      sleep $((attempt * 5))
    done
    exit 1
```

## Why first-party only

No third-party actions are introduced. `actions/cache@v5` is already used in this workflow (the Rust `build` job caches cargo with the identical `key`/`restore-keys` pattern), and the retry is plain POSIX bash — nothing new to audit, nothing that can break if a third-party action is abandoned.

## Trade-offs

- **Happy path**: strictly faster or equal — the retry loop exits on attempt 1 (negligible overhead), and a cache hit skips most of the install.
- **Flake path**: costs ~30-60s of retry/backoff but **auto-recovers** instead of failing the job and blocking the PR.
- **Cold cache / lockfile change**: behaves exactly like today's `bun install` (cache misses, fresh install), just with a retry safety net.

## Verification

- `actionlint .github/workflows/ci.yml` ✅ clean (exit 0, no warnings)
- `python3 -c "import yaml; yaml.safe_load(...)"` ✅ valid YAML
- CI run on this PR is the real proof: Web job should pass, and follow-up runs should show a visible speedup on cache hits.