### PR TITLE
feat(commandcode): support v3 sessions alongside v1 and v2

### DIFF
--- a/cli/tokens-core/src/lib.rs
+++ b/cli/tokens-core/src/lib.rs
@@ -2260,3 +2260,144 @@ fn should_keep_deduped_message(seen_keys: &mut HashSet<String>, message: &Unifie
         .is_none_or(|key| seen_keys.insert(key.clone()))
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_commandcode_usage_report() {
+        // The report dispatcher also loads/persists the process-wide source
+        // cache. Run in a child with an isolated config/home rather than
+        // touching the user's cache or racing other tests' environment.
+        const TEST_HOME: &str = "TOKENS_COMMANDCODE_REPORT_TEST_HOME";
+        let home = match std::env::var_os(TEST_HOME) {
+            Some(home) => PathBuf::from(home),
+            None => {
+                let dir = tempfile::tempdir().unwrap();
+                let output = std::process::Command::new(std::env::current_exe().unwrap())
+                    .args([
+                        "--exact",
+                        "tests::test_commandcode_usage_report",
+                        "--nocapture",
+                    ])
+                    .env(TEST_HOME, dir.path())
+                    .env("HOME", dir.path())
+                    .env("TOKENS_CONFIG_DIR", dir.path().join("config"))
+                    .output()
+                    .unwrap();
+                assert!(
+                    output.status.success(),
+                    "isolated report test failed:\n{}\n{}",
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                return;
+            }
+        };
+        set_bucket_timezone(BucketTimezone::Named(chrono_tz::UTC));
+
+        let project = home.join(".commandcode/projects/test-project");
+        std::fs::create_dir_all(&project).unwrap();
+        // First usage is captured from Command Code 1.52.0 (not a saved
+        // transcript). The other requests exercise both cache buckets, with
+        // absent, positive, and explicitly zero costUsd on the same model.
+        std::fs::write(
+            project.join("usage.jsonl"),
+            concat!(
+                "{\"type\":\"session\",\"version\":3,\"id\":\"usage\"}\n",
+                r#"{"type":"message","timestamp":"2026-09-10T12:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"OK"}]},"model":"Qwen/Qwen3.8-27B","usage":{"inputTokens":11988,"outputTokens":48,"cacheReadTokens":64,"cacheWriteTokens":0}}"#, "\n",
+                r#"{"type":"message","timestamp":"2026-09-10T12:01:00Z","message":{"role":"assistant","content":[{"type":"text","text":"OK"}]},"model":"Qwen/Qwen3.8-27B","usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":800,"cacheWriteTokens":100}}"#, "\n",
+                r#"{"type":"message","timestamp":"2026-09-11T12:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"OK"}]},"model":"Qwen/Qwen3.8-27B","usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":800,"cacheWriteTokens":100,"costUsd":0.125}}"#, "\n",
+                r#"{"type":"message","timestamp":"2026-09-12T12:00:00Z","message":{"role":"assistant","content":[{"type":"text","text":"OK"}]},"model":"Qwen/Qwen3.8-27B","usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":800,"cacheWriteTokens":100,"costUsd":0.0}}"#, "\n",
+            ),
+        )
+        .unwrap();
+
+        // Deliberately synthetic prices, not today's Qwen catalog: distinct
+        // rates ensure charging a cache bucket as fresh input cannot pass.
+        // Per million tokens: input $2, output $8, read $0.50, write $3.
+        let pricing = pricing::PricingService::new(
+            HashMap::from([(
+                "qwen3.8-27b".to_string(),
+                pricing::ModelPricing {
+                    input_cost_per_token: Some(2e-6),
+                    output_cost_per_token: Some(8e-6),
+                    cache_read_input_token_cost: Some(0.5e-6),
+                    cache_creation_input_token_cost: Some(3e-6),
+                    ..Default::default()
+                },
+            )]),
+            HashMap::new(),
+        );
+        let report = generate_graph_with_loaded_pricing(
+            ReportOptions {
+                home_dir: Some(home.to_str().unwrap().to_string()),
+                clients: Some(vec!["commandcode".to_string()]),
+                use_env_roots: false,
+                ..Default::default()
+            },
+            Some(&pricing),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.contributions.len(), 3);
+        let estimated = &report.contributions[0];
+        assert_eq!(estimated.date, "2026-09-10");
+        assert_eq!(estimated.totals.messages, 2);
+        // 12,036 from the captured request + 1,100 from the both-cache request.
+        assert_eq!(estimated.totals.tokens, 13_136);
+        assert_eq!(
+            estimated.token_breakdown,
+            TokenBreakdown {
+                input: 12_024,
+                output: 148,
+                cache_read: 864,
+                cache_write: 100,
+                reasoning: 0,
+            }
+        );
+        // Captured request $0.024264 + both-cache request $0.001700.
+        assert!((estimated.totals.cost - 0.025964).abs() < 1e-12);
+        assert_eq!(estimated.clients.len(), 1);
+        assert_eq!(estimated.clients[0].client, "commandcode");
+        assert_eq!(estimated.clients[0].model_id, "qwen3.8-27b");
+        assert_eq!(estimated.clients[0].messages, 2);
+        assert_eq!(estimated.clients[0].tokens, estimated.token_breakdown);
+        assert!((estimated.clients[0].cost - 0.025964).abs() < 1e-12);
+
+        // Both would cost $0.0017 locally. Neither the positive provider
+        // estimate nor a free request may be overwritten by that price.
+        for (day, date, cost) in [
+            (&report.contributions[1], "2026-09-11", 0.125),
+            (&report.contributions[2], "2026-09-12", 0.0),
+        ] {
+            assert_eq!(day.date, date);
+            assert_eq!(day.totals.messages, 1);
+            assert_eq!(day.totals.tokens, 1_100);
+            assert_eq!(day.totals.cost, cost);
+            assert_eq!(
+                day.token_breakdown,
+                TokenBreakdown {
+                    input: 100,
+                    output: 100,
+                    cache_read: 800,
+                    cache_write: 100,
+                    reasoning: 0,
+                }
+            );
+            assert_eq!(day.clients.len(), 1);
+            assert_eq!(day.clients[0].cost, cost);
+        }
+
+        assert_eq!(report.summary.total_tokens, 15_336);
+        assert!((report.summary.total_cost - 0.150964).abs() < 1e-12);
+        assert_eq!(report.summary.total_days, 3);
+        assert_eq!(report.summary.active_days, 3);
+        assert_eq!(report.summary.clients, ["commandcode"]);
+        assert_eq!(report.summary.models, ["qwen3.8-27b"]);
+        assert_eq!(report.years.len(), 1);
+        assert_eq!(report.years[0].total_tokens, 15_336);
+        assert!((report.years[0].total_cost - 0.150964).abs() < 1e-12);
+    }
+}

--- a/cli/tokens-core/src/lib.rs
+++ b/cli/tokens-core/src/lib.rs
@@ -1375,8 +1375,8 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
-    // Command Code assistant entries carry real usage and cost (marked
-    // authoritative), so only usage-less turns are estimated and priced. The
+    // Command Code assistant entries carry real usage, and a reported `costUsd`
+    // is marked authoritative, so only turns without one are priced here. The
     // model id can still come from ~/.commandcode/config.json (the last-resort
     // fallback), so the source cache — which fingerprints only the transcript
     // file — is bypassed: otherwise a config.json model change would leave stale

--- a/cli/tokens-core/src/lib.rs
+++ b/cli/tokens-core/src/lib.rs
@@ -2298,6 +2298,21 @@ mod tests {
 
         let project = home.join(".commandcode/projects/test-project");
         std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(
+            home.join(".commandcode/config.json"),
+            r#"{"model":"Qwen/Qwen3.8-27B"}"#,
+        )
+        .unwrap();
+        for version in ["0.17.18", "0.52.5"] {
+            let legacy_project = home.join(format!(".commandcode/projects/legacy-{version}"));
+            std::fs::create_dir_all(&legacy_project).unwrap();
+            std::fs::copy(
+                Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join(format!("tests/fixtures/commandcode/{version}.jsonl")),
+                legacy_project.join(format!("{version}.jsonl")),
+            )
+            .unwrap();
+        }
         // First usage is captured from Command Code 1.52.0 (not a saved
         // transcript). The other requests exercise both cache buckets, with
         // absent, positive, and explicitly zero costUsd on the same model.
@@ -2341,8 +2356,32 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(report.contributions.len(), 3);
-        let estimated = &report.contributions[0];
+        let [legacy, estimated, embedded_cost, free] = report.contributions.as_slice() else {
+            panic!("expected four daily contributions");
+        };
+        // Native v1 and v2 each estimate 13 input + 13 output tokens from
+        // their serialized content, and use the configured model for pricing.
+        assert_eq!(legacy.date, "2026-07-20");
+        assert_eq!(legacy.totals.messages, 2);
+        assert_eq!(legacy.totals.tokens, 52);
+        assert_eq!(
+            legacy.token_breakdown,
+            TokenBreakdown {
+                input: 26,
+                output: 26,
+                cache_read: 0,
+                cache_write: 0,
+                reasoning: 0,
+            }
+        );
+        assert!((legacy.totals.cost - 0.000260).abs() < 1e-12);
+        assert_eq!(legacy.clients.len(), 1);
+        assert_eq!(legacy.clients[0].client, "commandcode");
+        assert_eq!(legacy.clients[0].model_id, "qwen3.8-27b");
+        assert_eq!(legacy.clients[0].messages, 2);
+        assert_eq!(legacy.clients[0].tokens, legacy.token_breakdown);
+        assert!((legacy.clients[0].cost - 0.000260).abs() < 1e-12);
+
         assert_eq!(estimated.date, "2026-09-10");
         assert_eq!(estimated.totals.messages, 2);
         // 12,036 from the captured request + 1,100 from the both-cache request.
@@ -2369,8 +2408,8 @@ mod tests {
         // Both would cost $0.0017 locally. Neither the positive provider
         // estimate nor a free request may be overwritten by that price.
         for (day, date, cost) in [
-            (&report.contributions[1], "2026-09-11", 0.125),
-            (&report.contributions[2], "2026-09-12", 0.0),
+            (embedded_cost, "2026-09-11", 0.125),
+            (free, "2026-09-12", 0.0),
         ] {
             assert_eq!(day.date, date);
             assert_eq!(day.totals.messages, 1);
@@ -2390,14 +2429,14 @@ mod tests {
             assert_eq!(day.clients[0].cost, cost);
         }
 
-        assert_eq!(report.summary.total_tokens, 15_336);
-        assert!((report.summary.total_cost - 0.150964).abs() < 1e-12);
-        assert_eq!(report.summary.total_days, 3);
-        assert_eq!(report.summary.active_days, 3);
+        assert_eq!(report.summary.total_tokens, 15_388);
+        assert!((report.summary.total_cost - 0.151224).abs() < 1e-12);
+        assert_eq!(report.summary.total_days, 4);
+        assert_eq!(report.summary.active_days, 4);
         assert_eq!(report.summary.clients, ["commandcode"]);
         assert_eq!(report.summary.models, ["qwen3.8-27b"]);
         assert_eq!(report.years.len(), 1);
-        assert_eq!(report.years[0].total_tokens, 15_336);
-        assert!((report.years[0].total_cost - 0.150964).abs() < 1e-12);
+        assert_eq!(report.years[0].total_tokens, 15_388);
+        assert!((report.years[0].total_cost - 0.151224).abs() < 1e-12);
     }
 }

--- a/cli/tokens-core/src/lib.rs
+++ b/cli/tokens-core/src/lib.rs
@@ -1375,10 +1375,10 @@ fn parse_all_messages_with_pricing_with_env_strategy(
         }
     }
 
-    // Command Code does not persist token usage or cost locally, so tokens are
-    // estimated and priced. The model id comes from ~/.commandcode/config.json
-    // (canonicalized, e.g. "MiniMaxAI/MiniMax-M3-Free" -> "MiniMax-M3"), not the
-    // transcript, so the source cache — which fingerprints only the transcript
+    // Command Code assistant entries carry real usage and cost (marked
+    // authoritative), so only usage-less turns are estimated and priced. The
+    // model id can still come from ~/.commandcode/config.json (the last-resort
+    // fallback), so the source cache — which fingerprints only the transcript
     // file — is bypassed: otherwise a config.json model change would leave stale
     // cached pricing until the transcript itself changed.
     let commandcode_messages: Vec<UnifiedMessage> = scan_result

--- a/cli/tokens-core/src/sessions/commandcode.rs
+++ b/cli/tokens-core/src/sessions/commandcode.rs
@@ -2,7 +2,11 @@
 //!
 //! Parses JSONL transcripts from `~/.commandcode/projects/<slug>/<session>.jsonl`.
 //!
-//! Assistant entries persist the real per-request token usage and embedded cost
+//! v1/v2 store flat role/content records without usage; those retain per-turn
+//! text estimation. v2 identifies itself with metadata.version = 2. v3 uses a
+//! versioned session header and wrapped message entries.
+//!
+//! v3 assistant entries persist the real per-request token usage and embedded cost
 //! on the line itself (`usage` with `inputTokens`/`outputTokens`/`cacheReadTokens`/
 //! `cacheWriteTokens`/`costUsd`, plus `model`). `inputTokens` includes both cache
 //! buckets, so they are subtracted to obtain non-cached input. A valid embedded
@@ -55,6 +59,7 @@ const UNKNOWN_MODEL: &str = "unknown";
 struct CommandCodeEntry {
     #[serde(rename = "type")]
     entry_type: Option<String>,
+    version: Option<u32>,
     id: Option<String>,
     timestamp: Option<String>,
     /// The message is wrapped in a `message` object; assistant entries carry
@@ -62,6 +67,17 @@ struct CommandCodeEntry {
     message: Option<CommandCodeMessage>,
     usage: Option<CommandCodeUsage>,
     model: Option<String>,
+    // v1/v2 store message fields directly; v2 adds metadata.version = 2.
+    role: Option<String>,
+    content: Option<serde_json::Value>,
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
+    metadata: Option<CommandCodeMetadata>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommandCodeMetadata {
+    version: Option<u32>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -114,6 +130,7 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
 
     let mut messages = Vec::new();
     let mut session_id: Option<String> = None;
+    let mut transcript_version: Option<u32> = None;
     // Model from the most recent `model_change` entry; used when a message
     // entry does not carry its own `model` field.
     let mut last_changed_model: Option<String> = None;
@@ -146,20 +163,51 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
 
         // The header line carries the session id.
         if entry.entry_type.as_deref() == Some("session") {
+            transcript_version = entry.version;
             session_id = session_id
                 .or_else(|| entry.id.clone())
                 .filter(|id| !id.is_empty());
             continue;
         }
 
-        if entry.entry_type.as_deref() == Some("model_change") {
+        if matches!(transcript_version, None | Some(3))
+            && entry.entry_type.as_deref() == Some("model_change")
+        {
             last_changed_model = entry.model.clone().filter(|model| !model.trim().is_empty());
             continue;
         }
 
-        let (role, content) = match entry.message.as_ref() {
-            Some(message) => (message.role.as_deref(), message.content.as_ref()),
-            None => continue,
+        let (role, content, usage, model) = match (transcript_version, entry.entry_type.as_deref())
+        {
+            // v3 can also be read without a header using the filename as ID.
+            (None | Some(3), Some("message")) => {
+                let Some(message) = entry.message.as_ref() else {
+                    continue;
+                };
+                (
+                    message.role.as_deref(),
+                    message.content.as_ref(),
+                    entry.usage.as_ref(),
+                    entry.model.as_ref(),
+                )
+            }
+            (None, None)
+                if matches!(
+                    entry
+                        .metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.version),
+                    None | Some(1 | 2)
+                ) =>
+            {
+                if session_id.is_none() {
+                    session_id = entry.session_id.clone().filter(|id| !id.is_empty());
+                }
+                // Native v1/v2 writers do not persist per-request usage/model.
+                (entry.role.as_deref(), entry.content.as_ref(), None, None)
+            }
+            // Do not reinterpret unknown versions or malformed v3 as legacy.
+            _ => continue,
         };
         let chars = content.map(content_chars).unwrap_or(0);
 
@@ -169,7 +217,7 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
                 // for free models, when finite and non-negative (the same bar
                 // cline and gjc apply). Otherwise local pricing should fill
                 // it in from the normalized token counts.
-                let (tokens, cost, cost_is_authoritative) = match entry.usage.as_ref() {
+                let (tokens, cost, cost_is_authoritative) = match usage {
                     Some(usage) => {
                         let cache_read = usage.cache_read_tokens.unwrap_or(0).max(0);
                         let cache_write = usage.cache_write_tokens.unwrap_or(0).max(0);
@@ -222,9 +270,8 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
 
                 // Per-entry model, falling back to the most recent model
                 // change, then to the configured agent model.
-                let raw_model = entry
-                    .model
-                    .clone()
+                let raw_model = model
+                    .cloned()
                     .or(last_changed_model.clone())
                     .or_else(|| config_model.clone())
                     .filter(|model| !model.trim().is_empty());
@@ -415,6 +462,130 @@ mod tests {
         let path = projects.join(format!("{session_id}.jsonl"));
         std::fs::write(&path, lines.join("\n") + "\n").unwrap();
         path
+    }
+
+    #[test]
+    fn test_released_v3_writer_fixtures() {
+        // Files were emitted by the released writers, not hand-written to
+        // match this parser. See tests/fixtures/commandcode/README.md.
+        for version in ["1.0.0", "1.20.0", "1.50.0", "1.52.0", "1.53.0"] {
+            let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("tests/fixtures/commandcode")
+                .join(format!("{version}.jsonl"));
+            let messages = parse_commandcode_file(&path);
+            assert_eq!(messages.len(), 3, "Command Code {version}");
+            for (message, model, cost) in [
+                (&messages[0], "claude-sonnet-4-6", 0.25),
+                (&messages[1], "MiniMax-M3", 0.0),
+            ] {
+                assert_eq!(message.session_id, "native-v3");
+                assert_eq!(message.model_id, model, "Command Code {version}");
+                assert_eq!(
+                    message.tokens,
+                    TokenBreakdown {
+                        input: 1100,
+                        output: 50,
+                        cache_read: 700,
+                        cache_write: 200,
+                        reasoning: 0,
+                    },
+                    "Command Code {version}"
+                );
+                assert_eq!(message.tokens.total(), 2050);
+                assert_eq!(message.cost, cost);
+                assert_eq!(message.cost_source, CostSource::ProviderReported);
+                assert!(message.is_turn_start);
+            }
+            // No usage event: use the most recent model_change and estimate
+            // only the new prompt (66 serialized chars) and answer (58 chars).
+            let estimated = &messages[2];
+            assert_eq!(estimated.model_id, "MiniMax-M3", "Command Code {version}");
+            assert_eq!(
+                estimated.tokens,
+                TokenBreakdown {
+                    input: 17,
+                    output: 15,
+                    ..Default::default()
+                }
+            );
+            assert_eq!(estimated.cost_source, CostSource::Unknown);
+            assert!(estimated.is_turn_start);
+        }
+    }
+
+    #[test]
+    fn test_native_v1_v2_transcripts_are_estimated_without_migration() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/commandcode");
+        for version in ["0.17.18", "0.50.0", "0.52.5"] {
+            let dir = tempfile::tempdir().unwrap();
+            let source = std::fs::read_to_string(root.join(format!("{version}.jsonl"))).unwrap();
+            let path = fixture(
+                dir.path(),
+                "legacy-project",
+                "filename-id",
+                Some("org/Config-Model"),
+                &source.lines().collect::<Vec<_>>(),
+            );
+            let messages = parse_commandcode_file(&path);
+            assert_eq!(messages.len(), 1, "Command Code {version}");
+            assert_eq!(messages[0].session_id, "native-v2");
+            assert_eq!(messages[0].model_id, "Config-Model");
+            assert_eq!(messages[0].timestamp, 1_784_548_800_000);
+            assert_eq!(
+                messages[0].tokens,
+                TokenBreakdown {
+                    input: 13,
+                    output: 13,
+                    ..Default::default()
+                },
+                "Command Code {version}"
+            );
+            assert_eq!(messages[0].cost_source, CostSource::Unknown);
+            assert!(messages[0].is_turn_start);
+        }
+    }
+
+    #[test]
+    fn test_migrated_v2_transcript_is_estimated() {
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/commandcode");
+        // Produced by 1.0.0's migration of the 0.52.5 writer fixture. Migration
+        // preserves content/model but cannot recover absent historical usage.
+        let messages = parse_commandcode_file(&root.join("0.52.5-migrated-by-1.0.0.jsonl"));
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "migrated-v2");
+        assert_eq!(messages[0].model_id, "claude-sonnet-4-6");
+        assert_eq!(
+            messages[0].tokens,
+            TokenBreakdown {
+                input: 13,
+                output: 13,
+                ..Default::default()
+            }
+        );
+        assert_eq!(messages[0].cost_source, CostSource::Unknown);
+        assert!(messages[0].is_turn_start);
+    }
+
+    #[test]
+    fn test_unknown_versions_and_malformed_v3_do_not_fall_back_to_legacy() {
+        for lines in [
+            vec![
+                r#"{"role":"assistant","content":"must not be estimated","metadata":{"version":4}}"#,
+            ],
+            vec![r#"{"type":"message","role":"assistant","content":"must not be estimated"}"#],
+            vec![
+                r#"{"type":"session","version":4,"id":"future"}"#,
+                r#"{"type":"message","message":{"role":"assistant","content":"unknown format"},"usage":{"inputTokens":100}}"#,
+            ],
+            vec![
+                r#"{"type":"session","version":3,"id":"v3"}"#,
+                r#"{"role":"assistant","content":"malformed v3"}"#,
+            ],
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let path = fixture(dir.path(), "project", "invalid", None, &lines);
+            assert!(parse_commandcode_file(&path).is_empty(), "{lines:?}");
+        }
     }
 
     const TS: &str = "2026-09-10T03:11:06.582Z";

--- a/cli/tokens-core/src/sessions/commandcode.rs
+++ b/cli/tokens-core/src/sessions/commandcode.rs
@@ -582,6 +582,54 @@ mod tests {
     }
 
     #[test]
+    fn test_commandcode_missing_cost_usd_is_not_authoritative() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-nocost",
+            None,
+            &[
+                r#"{"type":"session","version":3,"id":"sess-nocost","timestamp":"2026-09-10T03:10:55Z"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":100,"outputTokens":10,"cacheReadTokens":50,"cacheWriteTokens":0},"model":"org/m"}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        // Real token counts stay verbatim; an absent costUsd must not mark
+        // the cost authoritative, or local pricing would never fill it in.
+        assert_eq!(messages[0].tokens.input, 100);
+        assert_eq!(messages[0].tokens.output, 10);
+        assert_eq!(messages[0].cost, 0.0);
+        assert_eq!(messages[0].cost_source, CostSource::Unknown);
+    }
+
+    #[test]
+    fn test_commandcode_reported_zero_cost_stays_authoritative() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-free",
+            None,
+            &[
+                r#"{"type":"session","version":3,"id":"sess-free","timestamp":"2026-09-10T03:10:55Z"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":100,"outputTokens":10,"cacheReadTokens":0,"cacheWriteTokens":0,"costUsd":0.0},"model":"org/free-model"}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        // A reported 0.0 (free model) is real pricing; local pricing must not
+        // overwrite it.
+        assert_eq!(messages[0].cost, 0.0);
+        assert_eq!(messages[0].cost_source, CostSource::ProviderReported);
+    }
+
+    #[test]
     fn test_commandcode_skips_checkpoint_files() {
         let dir = tempfile::tempdir().unwrap();
         let projects = dir

--- a/cli/tokens-core/src/sessions/commandcode.rs
+++ b/cli/tokens-core/src/sessions/commandcode.rs
@@ -2,13 +2,14 @@
 //!
 //! Parses JSONL transcripts from `~/.commandcode/projects/<slug>/<session>.jsonl`.
 //!
-//! Assistant entries persist the real per-request token usage and cost on the
-//! line itself (`usage` with `inputTokens`/`outputTokens`/`cacheReadTokens`/
-//! `cacheWriteTokens`/`costUsd`, plus `model`); when present, the token counts
-//! are used verbatim, and a valid reported `costUsd` (finite, non-negative —
-//! the same bar cline and gjc apply) is marked authoritative so local pricing
-//! does not overwrite it. Transcripts without `usage`
-//! (older versions or truncated turns) only contain message text, so token
+//! Assistant entries persist the real per-request token usage and embedded cost
+//! on the line itself (`usage` with `inputTokens`/`outputTokens`/`cacheReadTokens`/
+//! `cacheWriteTokens`/`costUsd`, plus `model`). `inputTokens` includes both cache
+//! buckets, so they are subtracted to obtain non-cached input. A valid embedded
+//! `costUsd` (finite, non-negative — the same bar cline and gjc apply) is marked
+//! authoritative so local pricing does not overwrite Command Code's estimate.
+//! Transcripts without `usage` (older versions or truncated turns) only contain
+//! message text, so token
 //! counts are ESTIMATED from message text at ~4 characters per token,
 //! consistent with this crate's other estimated sources (see Kiro).
 //!
@@ -164,22 +165,33 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
 
         match role {
             Some("assistant") => {
-                // A valid reported `costUsd` (finite, non-negative — the same
-                // validity bar cline and gjc apply to embedded costs) means
-                // the provider priced the request, including a real 0.0 for
-                // free models; absent or invalid means local pricing should
-                // still fill it in from the real tokens.
+                // Preserve Command Code's embedded `costUsd`, including 0.0
+                // for free models, when finite and non-negative (the same bar
+                // cline and gjc apply). Otherwise local pricing should fill
+                // it in from the normalized token counts.
                 let (tokens, cost, cost_is_authoritative) = match entry.usage.as_ref() {
                     Some(usage) => {
+                        let cache_read = usage.cache_read_tokens.unwrap_or(0).max(0);
+                        let cache_write = usage.cache_write_tokens.unwrap_or(0).max(0);
+                        // Command Code's toSessionUsage preserves inclusive input;
+                        // its estimateSessionCostUsd subtracts both cache buckets.
+                        // Normalize here so totals and local pricing stay additive.
+                        let input = usage
+                            .input_tokens
+                            .unwrap_or(0)
+                            .max(0)
+                            .saturating_sub(cache_read)
+                            .saturating_sub(cache_write)
+                            .max(0);
                         let reported_cost = usage
                             .cost_usd
                             .filter(|cost| cost.is_finite() && *cost >= 0.0);
                         (
                             TokenBreakdown {
-                                input: usage.input_tokens.unwrap_or(0).max(0),
+                                input,
                                 output: usage.output_tokens.unwrap_or(0).max(0),
-                                cache_read: usage.cache_read_tokens.unwrap_or(0).max(0),
-                                cache_write: usage.cache_write_tokens.unwrap_or(0).max(0),
+                                cache_read,
+                                cache_write,
                                 reasoning: 0,
                             },
                             reported_cost.unwrap_or(0.0),
@@ -252,8 +264,8 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
                     Some(dedup_key),
                 );
                 if cost_is_authoritative {
-                    // The provider reported both the tokens and the cost;
-                    // local pricing must not overwrite either.
+                    // Preserve Command Code's embedded cost rather than
+                    // replacing it with our local pricing estimate.
                     message.mark_provider_reported_cost();
                 }
                 message.message_count = 1;
@@ -409,7 +421,7 @@ mod tests {
     const TS_MS: i64 = 1_789_009_866_582;
 
     #[test]
-    fn test_commandcode_parses_real_usage_and_cost_verbatim() {
+    fn test_commandcode_normalizes_real_usage_and_preserves_cost() {
         let dir = tempfile::tempdir().unwrap();
         let path = fixture(
             dir.path(),
@@ -435,13 +447,14 @@ mod tests {
         assert_eq!(
             msg.tokens,
             TokenBreakdown {
-                input: 20783,
+                input: 13359,
                 output: 59,
                 cache_read: 7296,
                 cache_write: 128,
                 reasoning: 0,
             }
         );
+        assert_eq!(msg.tokens.total(), 20842);
         assert!((msg.cost - 0.003057152).abs() < 1e-9);
         assert_eq!(msg.cost_source, CostSource::ProviderReported);
         assert!(msg.is_turn_start);
@@ -459,7 +472,7 @@ mod tests {
             &[
                 r#"{"type":"session","version":3,"id":"sess-cache","timestamp":"2026-09-10T03:10:55Z"}"#,
                 r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hello there"}]}}"#,
-                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"usage":{"inputTokens":0,"outputTokens":10,"cacheReadTokens":9999,"cacheWriteTokens":0,"costUsd":0.001},"model":"org/model-x"}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"usage":{"inputTokens":9999,"outputTokens":0,"cacheReadTokens":9999,"cacheWriteTokens":0,"costUsd":0.001},"model":"org/model-x"}"#,
             ],
         );
 
@@ -467,6 +480,46 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].tokens.input, 0);
         assert_eq!(messages[0].tokens.cache_read, 9999);
+    }
+
+    #[test]
+    fn test_commandcode_normalizes_inclusive_input_boundaries() {
+        // The first row is real usage captured from Command Code 1.52.0.
+        // Clamp each bucket before subtraction and avoid overflowing when
+        // corrupt cache counts exceed the inclusive input or i64::MAX in sum.
+        for (input, output, cache_read, cache_write, expected_input, expected_total) in [
+            (11988, 48, 64, 0, 11924, 12036),
+            (1000, 100, 800, 100, 100, 1100),
+            (100, 10, 0, 0, 100, 110),
+            (100, 10, 80, 70, 0, 160),
+            (100, 10, -80, -70, 100, 110),
+            (-100, 10, 80, 70, 0, 160),
+            (i64::MAX, 10, i64::MAX, i64::MAX, 0, i64::MAX),
+        ] {
+            let dir = tempfile::tempdir().unwrap();
+            let entry = serde_json::json!({
+                "type": "message",
+                "timestamp": TS,
+                "message": {"role": "assistant", "content": [{"type": "text", "text": "OK"}]},
+                "model": "Qwen/Qwen3.8-27B",
+                "usage": {
+                    "inputTokens": input,
+                    "outputTokens": output,
+                    "cacheReadTokens": cache_read,
+                    "cacheWriteTokens": cache_write,
+                },
+            })
+            .to_string();
+            let path = fixture(dir.path(), "test-project", "sess-boundary", None, &[&entry]);
+            let messages = parse_commandcode_file(&path);
+            assert_eq!(messages.len(), 1);
+            assert_eq!(messages[0].tokens.input, expected_input, "{entry}");
+            assert_eq!(messages[0].tokens.output, output);
+            assert_eq!(messages[0].tokens.cache_read, cache_read.max(0));
+            assert_eq!(messages[0].tokens.cache_write, cache_write.max(0));
+            assert_eq!(messages[0].tokens.total(), expected_total, "{entry}");
+            assert_eq!(messages[0].cost_source, CostSource::Unknown);
+        }
     }
 
     #[test]
@@ -606,9 +659,9 @@ mod tests {
 
         let messages = parse_commandcode_file(&path);
         assert_eq!(messages.len(), 1);
-        // Real token counts stay verbatim; an absent costUsd must not mark
-        // the cost authoritative, or local pricing would never fill it in.
-        assert_eq!(messages[0].tokens.input, 100);
+        // Local pricing must receive non-cached input, and an absent costUsd
+        // must not mark the cost authoritative or pricing would never fill it in.
+        assert_eq!(messages[0].tokens.input, 50);
         assert_eq!(messages[0].tokens.output, 10);
         assert_eq!(messages[0].cost, 0.0);
         assert_eq!(messages[0].cost_source, CostSource::Unknown);

--- a/cli/tokens-core/src/sessions/commandcode.rs
+++ b/cli/tokens-core/src/sessions/commandcode.rs
@@ -2,20 +2,20 @@
 //!
 //! Parses JSONL transcripts from `~/.commandcode/projects/<slug>/<session>.jsonl`.
 //!
-//! Unlike most sources, Command Code does NOT persist token usage locally: the
-//! CLI computes per-request usage in memory and ships it to its backend
-//! (`api.commandcode.ai`, surfaced in the web Usage dashboard). The on-disk
-//! transcript only contains message text (one JSON object per line with
-//! `role`/`content`/`timestamp`/`sessionId`), so token counts are ESTIMATED
-//! from message text at ~4 characters per token, consistent with this crate's
-//! other estimated sources (see Kiro).
+//! Assistant entries persist the real per-request token usage and cost on the
+//! line itself (`usage` with `inputTokens`/`outputTokens`/`cacheReadTokens`/
+//! `cacheWriteTokens`/`costUsd`, plus `model`); when present, they are used
+//! verbatim and the cost is marked authoritative. Transcripts without `usage`
+//! (older versions or truncated turns) only contain message text, so token
+//! counts are ESTIMATED from message text at ~4 characters per token,
+//! consistent with this crate's other estimated sources (see Kiro).
 //!
 //! These estimates approximate tokens processed; they will not match Command
 //! Code's server-reported usage, which reflects tool-output truncation and
 //! auxiliary model runs (e.g. tool-desc, taste-1) absent from the transcript.
 //!
 //! **Input estimation is per-turn, not cumulative.**
-//! Command Code stores no local token counts and re-sends prior context on each
+//! Command Code re-sends prior context on each
 //! request, but the on-disk transcript does not say how much of that context is
 //! cached versus re-billed. Each assistant turn's input is therefore estimated
 //! from only the *new* context that turn introduced — the user prompt plus any
@@ -28,13 +28,14 @@
 //! whole session, which is the same accounting other estimated clients use.
 //! Whether re-sent context should be attributed to `cache_read` remains a
 //! maintainer decision requiring Command Code's real billing model, which is not
-//! available from the transcript. Do not silently change the estimation model
-//! without a corresponding update to this doc-comment and the pinning test
-//! `test_commandcode_input_is_per_turn_delta`.
+//! available for turns without `usage`. Do not silently change the estimation
+//! model without a corresponding update to this doc-comment and the pinning
+//! test `test_commandcode_input_is_per_turn_delta`.
 //!
-//! Output is estimated from the assistant message's own content. The model id
-//! is not stored per message, so it is read from `~/.commandcode/config.json`
-//! (the configured agent model), falling back to "unknown".
+//! Output (for usage-less turns) is estimated from the assistant message's own
+//! content. The model id is read from the entry, falling back to the last
+//! `model_change` entry, then `~/.commandcode/config.json` (the configured
+//! agent model), and finally "unknown".
 
 use super::utils::file_modified_timestamp_ms;
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
@@ -49,11 +50,41 @@ const UNKNOWN_MODEL: &str = "unknown";
 
 #[derive(Debug, Deserialize)]
 struct CommandCodeEntry {
+    #[serde(rename = "type")]
+    entry_type: Option<String>,
+    id: Option<String>,
+    timestamp: Option<String>,
+    /// Flat (legacy) shape: one JSON object per line with the message fields
+    /// at the top level.
     role: Option<String>,
     content: Option<serde_json::Value>,
-    timestamp: Option<String>,
     #[serde(rename = "sessionId")]
     session_id: Option<String>,
+    /// v3 tree shape: the message is wrapped in a `message` object, and
+    /// assistant entries carry real usage and the model on the line itself.
+    message: Option<CommandCodeMessage>,
+    usage: Option<CommandCodeUsage>,
+    model: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommandCodeMessage {
+    role: Option<String>,
+    content: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommandCodeUsage {
+    #[serde(rename = "inputTokens")]
+    input_tokens: Option<i64>,
+    #[serde(rename = "outputTokens")]
+    output_tokens: Option<i64>,
+    #[serde(rename = "cacheReadTokens")]
+    cache_read_tokens: Option<i64>,
+    #[serde(rename = "cacheWriteTokens")]
+    cache_write_tokens: Option<i64>,
+    #[serde(rename = "costUsd")]
+    cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -79,25 +110,16 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
     };
 
     let fallback_timestamp = file_modified_timestamp_ms(path);
-    let raw_model = model_from_config(path);
-    // Recover the real provider from the configured gateway id (e.g.
-    // `MiniMaxAI/MiniMax-M3-Free` -> `minimax`) so pricing resolves to that
-    // provider's catalog. The client's own `command-code` provider is not a
-    // pricing provider, so without this a MiniMax model would never reach a
-    // `minimax/...` key. Falls back to `command-code` when nothing is inferred.
-    let provider_id = raw_model
-        .as_deref()
-        .and_then(provider_hint_for_model)
-        .unwrap_or(PROVIDER_ID);
-    let model_id = raw_model
-        .map(|model| canonicalize_model(&model))
-        .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
+    let config_model = model_from_config(path);
     let session_id_from_path = session_id_from_path(path);
     let workspace_key = workspace_key_from_path(path);
     let workspace_label = workspace_key.as_deref().and_then(workspace_label_from_key);
 
     let mut messages = Vec::new();
     let mut session_id: Option<String> = None;
+    // Model from the most recent `model_change` entry; used when a message
+    // entry does not carry its own `model` field.
+    let mut last_changed_model: Option<String> = None;
     // Char count of the *new* context added since the previous assistant
     // response (the user prompt plus any tool results for this turn). This
     // stands in for the input (prompt) tokens of the current request without
@@ -125,31 +147,99 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
             Err(_) => continue,
         };
 
+        // The header line carries the session id.
+        if entry.entry_type.as_deref() == Some("session") {
+            session_id = session_id
+                .or_else(|| entry.id.clone())
+                .filter(|id| !id.is_empty());
+            continue;
+        }
+
+        if entry.entry_type.as_deref() == Some("model_change") {
+            last_changed_model = entry.model.clone().filter(|model| !model.trim().is_empty());
+            continue;
+        }
+
         if session_id.is_none() {
             if let Some(id) = entry.session_id.as_deref().filter(|id| !id.is_empty()) {
                 session_id = Some(id.to_string());
             }
         }
 
-        let chars = entry.content.as_ref().map(content_chars).unwrap_or(0);
+        // Resolve role/content from whichever shape the entry uses.
+        let role = entry
+            .role
+            .clone()
+            .or_else(|| entry.message.as_ref().and_then(|m| m.role.clone()));
+        let content = entry
+            .content
+            .clone()
+            .or_else(|| entry.message.as_ref().and_then(|m| m.content.clone()));
+        let chars = content.as_ref().map(content_chars).unwrap_or(0);
 
-        match entry.role.as_deref() {
+        match role.as_deref() {
             Some("assistant") => {
-                let input = estimate_tokens(turn_input_chars);
-                let output = estimate_tokens(chars);
+                let (tokens, cost, has_real_usage) = match entry.usage.as_ref() {
+                    Some(usage) => (
+                        TokenBreakdown {
+                            input: usage.input_tokens.unwrap_or(0),
+                            output: usage.output_tokens.unwrap_or(0),
+                            cache_read: usage.cache_read_tokens.unwrap_or(0),
+                            cache_write: usage.cache_write_tokens.unwrap_or(0),
+                            reasoning: 0,
+                        },
+                        usage.cost_usd.unwrap_or(0.0),
+                        true,
+                    ),
+                    None => (
+                        TokenBreakdown {
+                            input: estimate_tokens(turn_input_chars),
+                            output: estimate_tokens(chars),
+                            cache_read: 0,
+                            cache_write: 0,
+                            reasoning: 0,
+                        },
+                        0.0,
+                        false,
+                    ),
+                };
                 // This turn's input has been consumed; the next turn's input is
                 // only the *new* context that follows this response. The
                 // assistant's own output is not part of any input estimate.
                 turn_input_chars = 0;
 
-                if input + output == 0 {
+                if tokens.total() == 0 {
                     pending_turn_start = false;
                     continue;
                 }
 
+                // Per-entry model, falling back to the most recent model
+                // change, then to the configured agent model.
+                let raw_model = entry
+                    .model
+                    .clone()
+                    .or(last_changed_model.clone())
+                    .or_else(|| config_model.clone())
+                    .filter(|model| !model.trim().is_empty());
+                // Recover the real provider from the gateway id (e.g.
+                // `MiniMaxAI/MiniMax-M3-Free` -> `minimax`) so pricing resolves
+                // to that provider's catalog. The client's own `command-code`
+                // provider is not a pricing provider, so without this a
+                // MiniMax model would never reach a `minimax/...` key.
+                // Falls back to `command-code` when nothing is inferred.
+                let provider_id = raw_model
+                    .as_deref()
+                    .and_then(provider_hint_for_model)
+                    .unwrap_or(PROVIDER_ID)
+                    .to_string();
+                let model_id = raw_model
+                    .map(|model| canonicalize_model(&model))
+                    .unwrap_or_else(|| UNKNOWN_MODEL.to_string());
+
                 let resolved_session = session_id
                     .clone()
                     .unwrap_or_else(|| session_id_from_path.clone());
+                let dedup_key = format!("{}:{}", resolved_session, assistant_index);
                 let timestamp = entry
                     .timestamp
                     .as_deref()
@@ -158,20 +248,19 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
 
                 let mut message = UnifiedMessage::new_with_dedup(
                     CLIENT_ID,
-                    model_id.clone(),
+                    model_id,
                     provider_id,
-                    resolved_session.clone(),
+                    resolved_session,
                     timestamp,
-                    TokenBreakdown {
-                        input,
-                        output,
-                        cache_read: 0,
-                        cache_write: 0,
-                        reasoning: 0,
-                    },
-                    0.0,
-                    Some(format!("{}:{}", resolved_session, assistant_index)),
+                    tokens,
+                    cost,
+                    Some(dedup_key),
                 );
+                if has_real_usage {
+                    // The provider reported both the tokens and the cost;
+                    // local pricing must not overwrite either.
+                    message.mark_provider_reported_cost();
+                }
                 message.message_count = 1;
                 message.is_turn_start = pending_turn_start;
                 message.set_workspace(workspace_key.clone(), workspace_label.clone());
@@ -292,3 +381,278 @@ fn workspace_key_from_path(path: &Path) -> Option<String> {
         .and_then(normalize_workspace_key)
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::CostSource;
+
+    /// Build a transcript at `<root>/.commandcode/projects/<slug>/<id>.jsonl`
+    /// plus an optional `<root>/.commandcode/config.json`.
+    fn fixture(
+        root: &std::path::Path,
+        slug: &str,
+        session_id: &str,
+        config_model: Option<&str>,
+        lines: &[&str],
+    ) -> std::path::PathBuf {
+        let cc_root = root.join(".commandcode");
+        let projects = cc_root.join("projects").join(slug);
+        std::fs::create_dir_all(&projects).unwrap();
+        if let Some(model) = config_model {
+            std::fs::write(
+                cc_root.join("config.json"),
+                format!("{{\"model\": {model:?}}}"),
+            )
+            .unwrap();
+        }
+        let path = projects.join(format!("{session_id}.jsonl"));
+        std::fs::write(&path, lines.join("\n") + "\n").unwrap();
+        path
+    }
+
+    const TS: &str = "2026-09-10T03:11:06.582Z";
+    const TS_MS: i64 = 1_789_009_866_582;
+
+    #[test]
+    fn test_commandcode_parses_real_usage_and_cost_verbatim() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-1",
+            None,
+            &[
+                r#"{"type":"session","version":3,"id":"sess-1","timestamp":"2026-09-10T03:10:55.728Z","cwd":"/Users/alice/repo"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06.582Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":20783,"outputTokens":59,"cacheReadTokens":7296,"cacheWriteTokens":128,"costUsd":0.003057152},"model":"deepseek/deepseek-v4-flash"}"#,
+            ],
+        );
+        assert_eq!(parse_rfc3339_ms(TS), Some(TS_MS));
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.client, "commandcode");
+        assert_eq!(msg.session_id, "sess-1");
+        assert_eq!(msg.model_id, "deepseek-v4-flash");
+        assert_eq!(msg.provider_id, "deepseek");
+        assert_eq!(msg.timestamp, TS_MS);
+        assert_eq!(
+            msg.tokens,
+            TokenBreakdown {
+                input: 20783,
+                output: 59,
+                cache_read: 7296,
+                cache_write: 128,
+                reasoning: 0,
+            }
+        );
+        assert!((msg.cost - 0.003057152).abs() < 1e-9);
+        assert_eq!(msg.cost_source, CostSource::ProviderReported);
+        assert!(msg.is_turn_start);
+        assert_eq!(msg.workspace_key.as_deref(), Some("users-alice-repo"));
+    }
+
+    #[test]
+    fn test_commandcode_zero_input_all_cache_read_is_not_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-cache",
+            None,
+            &[
+                r#"{"type":"session","version":3,"id":"sess-cache","timestamp":"2026-09-10T03:10:55Z"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hello there"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hi"}]},"usage":{"inputTokens":0,"outputTokens":10,"cacheReadTokens":9999,"cacheWriteTokens":0,"costUsd":0.001},"model":"org/model-x"}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].tokens.input, 0);
+        assert_eq!(messages[0].tokens.cache_read, 9999);
+    }
+
+    #[test]
+    fn test_commandcode_input_is_per_turn_delta() {
+        // Pinning test for the estimation fallback: with no `usage` fields,
+        // each assistant turn's input is estimated from only the new context
+        // that turn introduced (the user prompt), never the cumulative
+        // conversation.
+        let user_content = serde_json::json!([{"type": "text", "text": "aaaa"}]);
+        let expected = estimate_tokens(content_chars(&user_content));
+        let user_line = format!(
+            r#"{{"type":"message","id":"m","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{{"role":"user","content":{content}}}}}"#,
+            content = user_content
+        );
+        let assistant_line = r#"{"type":"message","id":"a","parentId":"m","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"bbbb"}]}}"#;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-est",
+            None,
+            &[
+                r#"{"type":"session","version":3,"id":"sess-est","timestamp":"2026-09-10T03:10:55Z"}"#,
+                &user_line,
+                assistant_line,
+                &user_line,
+                assistant_line,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].tokens.input, expected);
+        assert_eq!(messages[1].tokens.input, expected);
+        assert!(messages[0].is_turn_start);
+        assert!(messages[1].is_turn_start);
+        assert_eq!(messages[0].cost_source, CostSource::Unknown);
+    }
+
+    #[test]
+    fn test_commandcode_model_falls_back_to_model_change_then_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-model",
+            Some("Config/Config-Model"),
+            &[
+                r#"{"type":"session","version":3,"id":"sess-model","timestamp":"2026-09-10T03:10:55Z"}"#,
+                r#"{"type":"model_change","id":"mc1","parentId":null,"timestamp":"2026-09-10T03:11:00Z","model":"org/changed-model"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                // No `model` on this entry -> falls back to model_change.
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":0,"cacheWriteTokens":0,"costUsd":0.001}}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "changed-model");
+    }
+
+    #[test]
+    fn test_commandcode_config_model_used_when_entry_has_no_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-config",
+            Some("org/Config-Model-Free"),
+            &[
+                r#"{"type":"session","version":3,"id":"sess-config","timestamp":"2026-09-10T03:10:55Z"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":0,"cacheWriteTokens":0,"costUsd":0.0}}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].model_id, "Config-Model");
+    }
+
+    #[test]
+    fn test_commandcode_session_id_from_header_beats_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "path-id",
+            None,
+            &[
+                r#"{"type":"session","version":3,"id":"header-id","timestamp":"2026-09-10T03:10:55Z"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":0,"cacheWriteTokens":0,"costUsd":0.001},"model":"org/m"}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "header-id");
+        assert_eq!(messages[0].dedup_key.as_deref(), Some("header-id:0"));
+    }
+
+    #[test]
+    fn test_commandcode_session_id_from_path_when_no_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "path-fallback",
+            None,
+            &[
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":10,"outputTokens":5,"cacheReadTokens":0,"cacheWriteTokens":0,"costUsd":0.001},"model":"org/m"}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].session_id, "path-fallback");
+    }
+
+    #[test]
+    fn test_commandcode_flat_legacy_shape_still_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let user_content = serde_json::json!([{"type": "text", "text": "hello there world"}]);
+        let expected = estimate_tokens(content_chars(&user_content));
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-legacy",
+            Some("org/Legacy-Model"),
+            &[
+                r#"{"role":"user","content":[{"type":"text","text":"hello there world"}],"timestamp":"2026-09-10T03:10:56Z","sessionId":"legacy-id"}"#,
+                r#"{"role":"assistant","content":[{"type":"text","text":"hi there"}],"timestamp":"2026-09-10T03:11:06Z","sessionId":"legacy-id"}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        let msg = &messages[0];
+        assert_eq!(msg.session_id, "legacy-id");
+        assert_eq!(msg.model_id, "Legacy-Model");
+        assert_eq!(msg.tokens.input, expected);
+        assert_eq!(msg.cost_source, CostSource::Unknown);
+    }
+
+    #[test]
+    fn test_commandcode_skips_checkpoint_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let projects = dir
+            .path()
+            .join(".commandcode")
+            .join("projects")
+            .join("users-alice-repo");
+        std::fs::create_dir_all(&projects).unwrap();
+        let path = projects.join("sess-1.checkpoints.jsonl");
+        std::fs::write(
+            &path,
+            r#"{"id":"x","messageId":"x","turnNumber":1,"createdAt":"2026-09-10T03:11:03Z","prompt":"hi"}"#,
+        )
+        .unwrap();
+
+        assert!(parse_commandcode_file(&path).is_empty());
+    }
+
+    #[test]
+    fn test_commandcode_skips_contentless_assistant_turns() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-empty",
+            None,
+            &[
+                r#"{"type":"session","version":3,"id":"sess-empty","timestamp":"2026-09-10T03:10:55Z"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[]},"usage":{"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":0,"costUsd":0.0},"model":"org/m"}"#,
+            ],
+        );
+
+        assert!(parse_commandcode_file(&path).is_empty());
+    }
+}

--- a/cli/tokens-core/src/sessions/commandcode.rs
+++ b/cli/tokens-core/src/sessions/commandcode.rs
@@ -4,8 +4,9 @@
 //!
 //! Assistant entries persist the real per-request token usage and cost on the
 //! line itself (`usage` with `inputTokens`/`outputTokens`/`cacheReadTokens`/
-//! `cacheWriteTokens`/`costUsd`, plus `model`); when present, they are used
-//! verbatim and the cost is marked authoritative. Transcripts without `usage`
+//! `cacheWriteTokens`/`costUsd`, plus `model`); when present, the token counts
+//! are used verbatim, and a reported `costUsd` is marked authoritative so local
+//! pricing does not overwrite it. Transcripts without `usage`
 //! (older versions or truncated turns) only contain message text, so token
 //! counts are ESTIMATED from message text at ~4 characters per token,
 //! consistent with this crate's other estimated sources (see Kiro).
@@ -54,14 +55,8 @@ struct CommandCodeEntry {
     entry_type: Option<String>,
     id: Option<String>,
     timestamp: Option<String>,
-    /// Flat (legacy) shape: one JSON object per line with the message fields
-    /// at the top level.
-    role: Option<String>,
-    content: Option<serde_json::Value>,
-    #[serde(rename = "sessionId")]
-    session_id: Option<String>,
-    /// v3 tree shape: the message is wrapped in a `message` object, and
-    /// assistant entries carry real usage and the model on the line itself.
+    /// The message is wrapped in a `message` object; assistant entries carry
+    /// the real usage and the model on the line itself.
     message: Option<CommandCodeMessage>,
     usage: Option<CommandCodeUsage>,
     model: Option<String>,
@@ -160,26 +155,18 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
             continue;
         }
 
-        if session_id.is_none() {
-            if let Some(id) = entry.session_id.as_deref().filter(|id| !id.is_empty()) {
-                session_id = Some(id.to_string());
-            }
-        }
+        let (role, content) = match entry.message.as_ref() {
+            Some(message) => (message.role.as_deref(), message.content.as_ref()),
+            None => continue,
+        };
+        let chars = content.map(content_chars).unwrap_or(0);
 
-        // Resolve role/content from whichever shape the entry uses.
-        let role = entry
-            .role
-            .clone()
-            .or_else(|| entry.message.as_ref().and_then(|m| m.role.clone()));
-        let content = entry
-            .content
-            .clone()
-            .or_else(|| entry.message.as_ref().and_then(|m| m.content.clone()));
-        let chars = content.as_ref().map(content_chars).unwrap_or(0);
-
-        match role.as_deref() {
+        match role {
             Some("assistant") => {
-                let (tokens, cost, has_real_usage) = match entry.usage.as_ref() {
+                // `costUsd` present (even as 0.0, which free models really do
+                // cost) means the provider priced the request; absent means
+                // local pricing should still fill it in from the real tokens.
+                let (tokens, cost, cost_is_authoritative) = match entry.usage.as_ref() {
                     Some(usage) => (
                         TokenBreakdown {
                             input: usage.input_tokens.unwrap_or(0),
@@ -189,7 +176,7 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
                             reasoning: 0,
                         },
                         usage.cost_usd.unwrap_or(0.0),
-                        true,
+                        usage.cost_usd.is_some(),
                     ),
                     None => (
                         TokenBreakdown {
@@ -256,7 +243,7 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
                     cost,
                     Some(dedup_key),
                 );
-                if has_real_usage {
+                if cost_is_authoritative {
                     // The provider reported both the tokens and the cost;
                     // local pricing must not overwrite either.
                     message.mark_provider_reported_cost();
@@ -592,31 +579,6 @@ mod tests {
         let messages = parse_commandcode_file(&path);
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].session_id, "path-fallback");
-    }
-
-    #[test]
-    fn test_commandcode_flat_legacy_shape_still_parses() {
-        let dir = tempfile::tempdir().unwrap();
-        let user_content = serde_json::json!([{"type": "text", "text": "hello there world"}]);
-        let expected = estimate_tokens(content_chars(&user_content));
-        let path = fixture(
-            dir.path(),
-            "users-alice-repo",
-            "sess-legacy",
-            Some("org/Legacy-Model"),
-            &[
-                r#"{"role":"user","content":[{"type":"text","text":"hello there world"}],"timestamp":"2026-09-10T03:10:56Z","sessionId":"legacy-id"}"#,
-                r#"{"role":"assistant","content":[{"type":"text","text":"hi there"}],"timestamp":"2026-09-10T03:11:06Z","sessionId":"legacy-id"}"#,
-            ],
-        );
-
-        let messages = parse_commandcode_file(&path);
-        assert_eq!(messages.len(), 1);
-        let msg = &messages[0];
-        assert_eq!(msg.session_id, "legacy-id");
-        assert_eq!(msg.model_id, "Legacy-Model");
-        assert_eq!(msg.tokens.input, expected);
-        assert_eq!(msg.cost_source, CostSource::Unknown);
     }
 
     #[test]

--- a/cli/tokens-core/src/sessions/commandcode.rs
+++ b/cli/tokens-core/src/sessions/commandcode.rs
@@ -176,10 +176,10 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
                             .filter(|cost| cost.is_finite() && *cost >= 0.0);
                         (
                             TokenBreakdown {
-                                input: usage.input_tokens.unwrap_or(0),
-                                output: usage.output_tokens.unwrap_or(0),
-                                cache_read: usage.cache_read_tokens.unwrap_or(0),
-                                cache_write: usage.cache_write_tokens.unwrap_or(0),
+                                input: usage.input_tokens.unwrap_or(0).max(0),
+                                output: usage.output_tokens.unwrap_or(0).max(0),
+                                cache_read: usage.cache_read_tokens.unwrap_or(0).max(0),
+                                cache_write: usage.cache_write_tokens.unwrap_or(0).max(0),
                                 reasoning: 0,
                             },
                             reported_cost.unwrap_or(0.0),

--- a/cli/tokens-core/src/sessions/commandcode.rs
+++ b/cli/tokens-core/src/sessions/commandcode.rs
@@ -483,13 +483,10 @@ mod tests {
     }
 
     #[test]
-    fn test_commandcode_normalizes_inclusive_input_boundaries() {
-        // The first row is real usage captured from Command Code 1.52.0.
-        // Clamp each bucket before subtraction and avoid overflowing when
-        // corrupt cache counts exceed the inclusive input or i64::MAX in sum.
+    fn test_commandcode_clamps_invalid_token_counts_without_overflow() {
+        // Valid cached requests are covered through pricing and reporting in
+        // lib.rs. Here, preserve the parser's safety contract for corrupt counts.
         for (input, output, cache_read, cache_write, expected_input, expected_total) in [
-            (11988, 48, 64, 0, 11924, 12036),
-            (1000, 100, 800, 100, 100, 1100),
             (100, 10, 0, 0, 100, 110),
             (100, 10, 80, 70, 0, 160),
             (100, 10, -80, -70, 100, 110),
@@ -640,54 +637,6 @@ mod tests {
         let messages = parse_commandcode_file(&path);
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].session_id, "path-fallback");
-    }
-
-    #[test]
-    fn test_commandcode_missing_cost_usd_is_not_authoritative() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = fixture(
-            dir.path(),
-            "users-alice-repo",
-            "sess-nocost",
-            None,
-            &[
-                r#"{"type":"session","version":3,"id":"sess-nocost","timestamp":"2026-09-10T03:10:55Z"}"#,
-                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
-                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":100,"outputTokens":10,"cacheReadTokens":50,"cacheWriteTokens":0},"model":"org/m"}"#,
-            ],
-        );
-
-        let messages = parse_commandcode_file(&path);
-        assert_eq!(messages.len(), 1);
-        // Local pricing must receive non-cached input, and an absent costUsd
-        // must not mark the cost authoritative or pricing would never fill it in.
-        assert_eq!(messages[0].tokens.input, 50);
-        assert_eq!(messages[0].tokens.output, 10);
-        assert_eq!(messages[0].cost, 0.0);
-        assert_eq!(messages[0].cost_source, CostSource::Unknown);
-    }
-
-    #[test]
-    fn test_commandcode_reported_zero_cost_stays_authoritative() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = fixture(
-            dir.path(),
-            "users-alice-repo",
-            "sess-free",
-            None,
-            &[
-                r#"{"type":"session","version":3,"id":"sess-free","timestamp":"2026-09-10T03:10:55Z"}"#,
-                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
-                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":100,"outputTokens":10,"cacheReadTokens":0,"cacheWriteTokens":0,"costUsd":0.0},"model":"org/free-model"}"#,
-            ],
-        );
-
-        let messages = parse_commandcode_file(&path);
-        assert_eq!(messages.len(), 1);
-        // A reported 0.0 (free model) is real pricing; local pricing must not
-        // overwrite it.
-        assert_eq!(messages[0].cost, 0.0);
-        assert_eq!(messages[0].cost_source, CostSource::ProviderReported);
     }
 
     #[test]

--- a/cli/tokens-core/src/sessions/commandcode.rs
+++ b/cli/tokens-core/src/sessions/commandcode.rs
@@ -5,8 +5,9 @@
 //! Assistant entries persist the real per-request token usage and cost on the
 //! line itself (`usage` with `inputTokens`/`outputTokens`/`cacheReadTokens`/
 //! `cacheWriteTokens`/`costUsd`, plus `model`); when present, the token counts
-//! are used verbatim, and a reported `costUsd` is marked authoritative so local
-//! pricing does not overwrite it. Transcripts without `usage`
+//! are used verbatim, and a valid reported `costUsd` (finite, non-negative —
+//! the same bar cline and gjc apply) is marked authoritative so local pricing
+//! does not overwrite it. Transcripts without `usage`
 //! (older versions or truncated turns) only contain message text, so token
 //! counts are ESTIMATED from message text at ~4 characters per token,
 //! consistent with this crate's other estimated sources (see Kiro).
@@ -163,21 +164,28 @@ pub fn parse_commandcode_file(path: &Path) -> Vec<UnifiedMessage> {
 
         match role {
             Some("assistant") => {
-                // `costUsd` present (even as 0.0, which free models really do
-                // cost) means the provider priced the request; absent means
-                // local pricing should still fill it in from the real tokens.
+                // A valid reported `costUsd` (finite, non-negative — the same
+                // validity bar cline and gjc apply to embedded costs) means
+                // the provider priced the request, including a real 0.0 for
+                // free models; absent or invalid means local pricing should
+                // still fill it in from the real tokens.
                 let (tokens, cost, cost_is_authoritative) = match entry.usage.as_ref() {
-                    Some(usage) => (
-                        TokenBreakdown {
-                            input: usage.input_tokens.unwrap_or(0),
-                            output: usage.output_tokens.unwrap_or(0),
-                            cache_read: usage.cache_read_tokens.unwrap_or(0),
-                            cache_write: usage.cache_write_tokens.unwrap_or(0),
-                            reasoning: 0,
-                        },
-                        usage.cost_usd.unwrap_or(0.0),
-                        usage.cost_usd.is_some(),
-                    ),
+                    Some(usage) => {
+                        let reported_cost = usage
+                            .cost_usd
+                            .filter(|cost| cost.is_finite() && *cost >= 0.0);
+                        (
+                            TokenBreakdown {
+                                input: usage.input_tokens.unwrap_or(0),
+                                output: usage.output_tokens.unwrap_or(0),
+                                cache_read: usage.cache_read_tokens.unwrap_or(0),
+                                cache_write: usage.cache_write_tokens.unwrap_or(0),
+                                reasoning: 0,
+                            },
+                            reported_cost.unwrap_or(0.0),
+                            reported_cost.is_some(),
+                        )
+                    }
                     None => (
                         TokenBreakdown {
                             input: estimate_tokens(turn_input_chars),
@@ -627,6 +635,29 @@ mod tests {
         // overwrite it.
         assert_eq!(messages[0].cost, 0.0);
         assert_eq!(messages[0].cost_source, CostSource::ProviderReported);
+    }
+
+    #[test]
+    fn test_commandcode_invalid_cost_usd_is_not_authoritative() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = fixture(
+            dir.path(),
+            "users-alice-repo",
+            "sess-badcost",
+            None,
+            &[
+                r#"{"type":"session","version":3,"id":"sess-badcost","timestamp":"2026-09-10T03:10:55Z"}"#,
+                r#"{"type":"message","id":"m1","parentId":null,"timestamp":"2026-09-10T03:10:56Z","message":{"role":"user","content":[{"type":"text","text":"hi"}]}}"#,
+                r#"{"type":"message","id":"m2","parentId":"m1","timestamp":"2026-09-10T03:11:06Z","message":{"role":"assistant","content":[{"type":"text","text":"hello"}]},"usage":{"inputTokens":100,"outputTokens":10,"cacheReadTokens":0,"cacheWriteTokens":0,"costUsd":-1.0},"model":"org/m"}"#,
+            ],
+        );
+
+        let messages = parse_commandcode_file(&path);
+        assert_eq!(messages.len(), 1);
+        // A negative costUsd is not a valid provider price (same validity bar
+        // as cline/gjc embedded costs); local pricing should fill it in.
+        assert_eq!(messages[0].cost, 0.0);
+        assert_eq!(messages[0].cost_source, CostSource::Unknown);
     }
 
     #[test]

--- a/cli/tokens-core/tests/fixtures/commandcode/0.17.18.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/0.17.18.jsonl
@@ -1,0 +1,2 @@
+{"id":"legacy-1","timestamp":"2026-07-20T12:00:00.000Z","sessionId":"native-v2","parentId":null,"role":"user","content":[{"type":"text","text":"Synthetic legacy prompt."}],"gitBranch":"synthetic","metadata":{"timestamp":"2026-07-20T12:00:00.000Z","source":"cli"}}
+{"id":"legacy-2","timestamp":"2026-07-20T12:00:00.000Z","sessionId":"native-v2","parentId":"legacy-1","role":"assistant","content":[{"type":"text","text":"Synthetic legacy answer."}],"gitBranch":"synthetic","metadata":{"timestamp":"2026-07-20T12:00:00.000Z","source":"cli"}}

--- a/cli/tokens-core/tests/fixtures/commandcode/0.50.0.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/0.50.0.jsonl
@@ -1,0 +1,2 @@
+{"id":"legacy-1","timestamp":"2026-07-20T12:00:00.000Z","sessionId":"native-v2","parentId":null,"role":"user","content":[{"type":"text","text":"Synthetic legacy prompt."}],"gitBranch":"synthetic","metadata":{"timestamp":"2026-07-20T12:00:00.000Z","source":"cli","version":2}}
+{"id":"legacy-2","timestamp":"2026-07-20T12:00:00.000Z","sessionId":"native-v2","parentId":"legacy-1","role":"assistant","content":[{"type":"text","text":"Synthetic legacy answer."}],"gitBranch":"synthetic","metadata":{"timestamp":"2026-07-20T12:00:00.000Z","source":"cli","version":2}}

--- a/cli/tokens-core/tests/fixtures/commandcode/0.52.5-migrated-by-1.0.0.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/0.52.5-migrated-by-1.0.0.jsonl
@@ -1,0 +1,3 @@
+{"type":"session","version":3,"id":"migrated-v2","timestamp":"2026-07-20T12:00:00.000Z","cwd":"/synthetic/commandcode-compatibility"}
+{"type":"message","id":"migrated-1","parentId":null,"timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Synthetic legacy prompt."}],"meta":{"source":"cli"}}}
+{"type":"message","id":"migrated-2","parentId":"migrated-1","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Synthetic legacy answer."}],"meta":{"source":"cli"}},"model":"anthropic/claude-sonnet-4-6"}

--- a/cli/tokens-core/tests/fixtures/commandcode/0.52.5.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/0.52.5.jsonl
@@ -1,0 +1,2 @@
+{"id":"legacy-1","timestamp":"2026-07-20T12:00:00.000Z","sessionId":"native-v2","parentId":null,"role":"user","content":[{"type":"text","text":"Synthetic legacy prompt."}],"gitBranch":"synthetic","metadata":{"timestamp":"2026-07-20T12:00:00.000Z","source":"cli","version":2}}
+{"id":"legacy-2","timestamp":"2026-07-20T12:00:00.000Z","sessionId":"native-v2","parentId":"legacy-1","role":"assistant","content":[{"type":"text","text":"Synthetic legacy answer."}],"gitBranch":"synthetic","metadata":{"timestamp":"2026-07-20T12:00:00.000Z","source":"cli","version":2}}

--- a/cli/tokens-core/tests/fixtures/commandcode/1.0.0.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/1.0.0.jsonl
@@ -1,0 +1,9 @@
+{"type":"session","version":3,"id":"native-v3","timestamp":"2026-07-20T12:00:00.000Z","cwd":"/synthetic/commandcode-compatibility"}
+{"type":"model_change","id":"entry-1","parentId":null,"timestamp":"2026-07-20T12:00:00.000Z","model":"anthropic/claude-sonnet-4-6"}
+{"type":"message","id":"entry-2","parentId":"entry-1","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"First synthetic prompt."}]}}
+{"type":"message","id":"entry-3","parentId":"entry-2","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Synthetic answer with measured usage."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"costUsd":0.25},"model":"anthropic/claude-sonnet-4-6"}
+{"type":"model_change","id":"entry-4","parentId":"entry-3","timestamp":"2026-07-20T12:00:00.000Z","model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-5","parentId":"entry-4","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Free-model synthetic prompt."}]}}
+{"type":"message","id":"entry-6","parentId":"entry-5","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Free synthetic answer."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"costUsd":0},"model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-7","parentId":"entry-6","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Synthetic prompt without a usage event."}]}}
+{"type":"message","id":"entry-8","parentId":"entry-7","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Usage-missing synthetic answer."}]}}

--- a/cli/tokens-core/tests/fixtures/commandcode/1.20.0.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/1.20.0.jsonl
@@ -1,0 +1,9 @@
+{"type":"session","version":3,"id":"native-v3","timestamp":"2026-07-20T12:00:00.000Z","cwd":"/synthetic/commandcode-compatibility"}
+{"type":"model_change","id":"entry-1","parentId":null,"timestamp":"2026-07-20T12:00:00.000Z","model":"anthropic/claude-sonnet-4-6"}
+{"type":"message","id":"entry-2","parentId":"entry-1","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"First synthetic prompt."}]}}
+{"type":"message","id":"entry-3","parentId":"entry-2","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Synthetic answer with measured usage."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"costUsd":0.25},"model":"anthropic/claude-sonnet-4-6"}
+{"type":"model_change","id":"entry-4","parentId":"entry-3","timestamp":"2026-07-20T12:00:00.000Z","model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-5","parentId":"entry-4","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Free-model synthetic prompt."}]}}
+{"type":"message","id":"entry-6","parentId":"entry-5","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Free synthetic answer."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"costUsd":0},"model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-7","parentId":"entry-6","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Synthetic prompt without a usage event."}]}}
+{"type":"message","id":"entry-8","parentId":"entry-7","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Usage-missing synthetic answer."}]}}

--- a/cli/tokens-core/tests/fixtures/commandcode/1.50.0.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/1.50.0.jsonl
@@ -1,0 +1,9 @@
+{"type":"session","version":3,"id":"native-v3","timestamp":"2026-07-20T12:00:00.000Z","cwd":"/synthetic/commandcode-compatibility"}
+{"type":"model_change","id":"entry-1","parentId":null,"timestamp":"2026-07-20T12:00:00.000Z","model":"anthropic/claude-sonnet-4-6"}
+{"type":"message","id":"entry-2","parentId":"entry-1","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"First synthetic prompt."}]}}
+{"type":"message","id":"entry-3","parentId":"entry-2","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Synthetic answer with measured usage."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"costUsd":0.25},"model":"anthropic/claude-sonnet-4-6"}
+{"type":"model_change","id":"entry-4","parentId":"entry-3","timestamp":"2026-07-20T12:00:00.000Z","model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-5","parentId":"entry-4","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Free-model synthetic prompt."}]}}
+{"type":"message","id":"entry-6","parentId":"entry-5","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Free synthetic answer."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"cacheWriteTokens1h":100,"costUsd":0},"model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-7","parentId":"entry-6","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Synthetic prompt without a usage event."}]}}
+{"type":"message","id":"entry-8","parentId":"entry-7","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Usage-missing synthetic answer."}]}}

--- a/cli/tokens-core/tests/fixtures/commandcode/1.52.0.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/1.52.0.jsonl
@@ -1,0 +1,9 @@
+{"type":"session","version":3,"id":"native-v3","timestamp":"2026-07-20T12:00:00.000Z","cwd":"/synthetic/commandcode-compatibility"}
+{"type":"model_change","id":"entry-1","parentId":null,"timestamp":"2026-07-20T12:00:00.000Z","model":"anthropic/claude-sonnet-4-6"}
+{"type":"message","id":"entry-2","parentId":"entry-1","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"First synthetic prompt."}]}}
+{"type":"message","id":"entry-3","parentId":"entry-2","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Synthetic answer with measured usage."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"costUsd":0.25},"model":"anthropic/claude-sonnet-4-6"}
+{"type":"model_change","id":"entry-4","parentId":"entry-3","timestamp":"2026-07-20T12:00:00.000Z","model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-5","parentId":"entry-4","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Free-model synthetic prompt."}]}}
+{"type":"message","id":"entry-6","parentId":"entry-5","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Free synthetic answer."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"cacheWriteTokens1h":100,"costUsd":0},"model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-7","parentId":"entry-6","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Synthetic prompt without a usage event."}]}}
+{"type":"message","id":"entry-8","parentId":"entry-7","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Usage-missing synthetic answer."}]}}

--- a/cli/tokens-core/tests/fixtures/commandcode/1.53.0.jsonl
+++ b/cli/tokens-core/tests/fixtures/commandcode/1.53.0.jsonl
@@ -1,0 +1,9 @@
+{"type":"session","version":3,"id":"native-v3","timestamp":"2026-07-20T12:00:00.000Z","cwd":"/synthetic/commandcode-compatibility"}
+{"type":"model_change","id":"entry-1","parentId":null,"timestamp":"2026-07-20T12:00:00.000Z","model":"anthropic/claude-sonnet-4-6"}
+{"type":"message","id":"entry-2","parentId":"entry-1","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"First synthetic prompt."}]}}
+{"type":"message","id":"entry-3","parentId":"entry-2","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Synthetic answer with measured usage."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"costUsd":0.25},"model":"anthropic/claude-sonnet-4-6"}
+{"type":"model_change","id":"entry-4","parentId":"entry-3","timestamp":"2026-07-20T12:00:00.000Z","model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-5","parentId":"entry-4","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Free-model synthetic prompt."}]}}
+{"type":"message","id":"entry-6","parentId":"entry-5","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Free synthetic answer."}]},"usage":{"inputTokens":2000,"outputTokens":50,"cacheReadTokens":700,"cacheWriteTokens":200,"cacheWriteTokens1h":100,"costUsd":0},"model":"MiniMaxAI/MiniMax-M3-Free"}
+{"type":"message","id":"entry-7","parentId":"entry-6","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"user","content":[{"type":"text","text":"Synthetic prompt without a usage event."}]}}
+{"type":"message","id":"entry-8","parentId":"entry-7","timestamp":"2026-07-20T12:00:00.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Usage-missing synthetic answer."}]}}

--- a/cli/tokens-core/tests/fixtures/commandcode/README.md
+++ b/cli/tokens-core/tests/fixtures/commandcode/README.md
@@ -1,0 +1,71 @@
+# Command Code transcript compatibility
+
+The parser supports native **v1, v2, and v3** transcripts. v1/v2 flat records
+retain per-turn text estimation; v3 wrapped messages use recorded usage when
+available. v3 was introduced in stable Command Code 1.0.0, immediately after
+0.52.5's v2 format. CLI package versions and transcript schema versions are
+different: `version:3` is not Command Code 3.x.
+
+| Released writer | Fixture | Parser expectation |
+| --- | --- | --- |
+| 1.0.0, 1.20.0 | `<version>.jsonl` | Recorded usage/model/cost; estimate only messages lacking usage |
+| 1.50.0, 1.52.0, 1.53.0 | `<version>.jsonl` | Same, with `cacheWriteTokens1h` already included in total cache writes |
+| 0.17.18 | `0.17.18.jsonl` | Native v1: estimated tokens, config model fallback, original session ID |
+| 0.50.0, 0.52.5 | `<version>.jsonl` | Native v2: same behavior; metadata.version = 2 |
+| 0.52.5 migrated by 1.0.0 | `0.52.5-migrated-by-1.0.0.jsonl` | Content/model retained; absent historical usage is estimated |
+
+These are sampled release **writer/reader compatibility tests**, not live API
+runs for every version or a guarantee about future releases. Only 1.52.0 was
+also exercised with a live model request; its captured usage is tested in the
+report-level test in `src/lib.rs`. That print-mode run left an empty transcript,
+so the live request did not verify persistence.
+
+## Fixture provenance
+
+Synthetic messages were passed to functions extracted from the published npm
+bundles. No personal transcripts are included. Historical packages were
+unpacked, not installed or started as CLIs. Sources are the versioned npm
+archives at:
+
+`https://registry.npmjs.org/command-code/-/command-code-<version>.tgz`
+
+For v3, the executed functions were `createSessionStoreV3`,
+`createSessionRecorder`, and `toSessionUsage`. Only their dependencies were
+injected: a fixed clock and IDs, filesystem writes to the fixture directory,
+an empty initial session context, and a fixed cost estimator ($0.25 or $0).
+The writer/recorder performed message wrapping, usage association, model-change
+serialization, and flushing. Model names are synthetic test inputs, not claims
+about historical model availability. `cacheWriteTokens1h:100` was supplied to
+all v3 writers; older writers omit it and newer writers preserve it as a subset
+of `cacheWriteTokens:200`, not an additional token bucket.
+
+Legacy fixtures execute `SessionManager.saveMessages` (0.17.18) or
+`SessionManager.writeMessages` (0.50.0/0.52.5), with synthetic state and an
+already-created output directory. The migrated fixture executes 1.0.0's
+migration functions on the 0.52.5 fixture, with a synthetic sidecar model.
+Migration does not recover token usage that the original writer never stored.
+Tokens reads both native legacy and migrated transcripts without migrating or
+rewriting them. The report test includes native v1/v2 and v3 files together to
+verify historical estimates are not dropped and are priced using config.
+Unknown version markers and malformed v3 records are not reinterpreted as
+legacy messages.
+
+The 1.0.0 and 1.20.0 embedded cost estimators differ from 1.50.0 onward: the
+older implementations do not subtract cache buckets before pricing input.
+These fixtures deliberately do not validate historical API billing or those
+estimators; they test serialization and preservation of supplied cost. The
+parser preserves existing embedded estimates rather than retroactively
+recalculating historical costs.
+
+Bundle SHA-256 (`dist/cli.mjs`, except `dist/index.mjs` for 0.17.18):
+
+| Version | SHA-256 |
+| --- | --- |
+| 0.17.18 | `33bde5a79bd7d0faf45aa4a72802e82735df560d4dc4710ce36045ef5c90fcc4` |
+| 0.50.0 | `076b958907fe0763c7cc91337d5503e917c7af908a35a40943b31ae9d1510cc6` |
+| 0.52.5 | `27f87ce11f4f29e3284307b7e1bb2afcad6c49ed7d6ee2f7b155a28b9d2e0802` |
+| 1.0.0 | `5f15c81c2547606f2ec51cbaca992ff49323cd35f9d379e1f2ff680cc9a132e4` |
+| 1.20.0 | `aa5f3e9e32072499018c76c0c71a1162f91e1efb059546e042f381708a508051` |
+| 1.50.0 | `429e94e9c9a2548526a352ac551cf7ca74f58d3068009c8a01b96d8dd1a7c11f` |
+| 1.52.0 | `9cc35f147b3b845a48e0d1f5b93d663e4fabc30db4f8a0e2ccd0ee578bacf395` |
+| 1.53.0 | `b4f5398190f2912d90cecb3c558017f9e0c2c97d55ccf6b66848eed910642859` |


### PR DESCRIPTION
Add support for Command Code's **v3 session format**, introduced in CLI 1.0.0, while preserving existing v1/v2 text-based usage estimation. The previous parser reads flat legacy messages; v3 wraps messages and records per-request usage/model on the enclosing entry. This lets v3 sessions contribute recorded usage to reports and `tokens submit` without requiring old sessions to be migrated.

### v3 accounting

Assistant entries supply token counts and model identity. Because `inputTokens` includes cache reads and writes, both are subtracted from the non-cached input bucket. For example, 1,000 input + 100 output with 800 cache-read and 100 cache-write tokens totals **1,100**, not 2,000. All-cache requests are retained.

Valid embedded `costUsd` estimates are preserved, including **$0**; missing or invalid costs use local pricing on normalized tokens. Entries without usage retain per-turn text estimation. Embedded costs are Command Code's estimates, not necessarily invoiced charges.

Session identity comes from the header, with a filename fallback. Models resolve from the entry, the latest `model_change`, or config. Checkpoint sidecars remain excluded, and the existing source-cache bypass remains necessary for config-dependent pricing.

### Backward compatibility

| Session format | Released writers checked | Behavior |
| --- | --- | --- |
| v1: flat messages, no version marker | 0.17.18 | Existing per-turn estimation and config model fallback |
| v2: flat messages, `metadata.version = 2` | 0.50.0, 0.52.5 | Existing estimation, no migration required |
| v3: versioned header and wrapped messages | 1.0.0, 1.20.0, 1.50.0, 1.52.0, 1.53.0 | Recorded usage; estimation only when usage is absent |
| v2 migrated to v3 | 0.52.5 migrated by 1.0.0 | Preserves content/model; unavailable historical usage remains estimated |

Schema versions are distinct from CLI versions. These are sampled release compatibility checks, not guarantees for every later release. Tokens does not rewrite or migrate transcripts. Unknown version markers and malformed v3 entries are not reinterpreted as legacy messages.

### Regression coverage

Released-writer fixtures and provenance are included in `cli/tokens-core/tests/fixtures/commandcode/`. The report test exercises **scan → parse → price → aggregate** with native v1/v2 and v3 files together, isolated storage, and fixed prices. It verifies historical usage remains present, token totals stay additive, and missing/positive/zero costs are handled correctly. Deliberately disabling legacy parsing, removing cache subtraction, skipping pricing, or breaking cost preservation causes the test to fail.

A live CLI 1.52.0 request supplied usage values for the report test. Other versions were checked through extracted writers with synthetic inputs, not live API requests. The live print-mode run left an empty transcript, so live persistence remains unverified.
