### PR TITLE
fix(workbuddy): resolve the data root instead of assuming ~/.workbuddy

### DIFF
--- a/cli/tokens-core/src/clients.rs
+++ b/cli/tokens-core/src/clients.rs
@@ -14,6 +14,15 @@ pub enum PathRoot {
     /// single-var shape but kept self-contained here rather than introducing a
     /// separate resolver helper, mirroring how `Config` inlines its logic.
     ReasonixHome,
+    /// WorkBuddy picks its data root at launch rather than compile time for the
+    /// scanner: `WORKBUDDY_CONFIG_DIR`, else `CODEBUDDY_CONFIG_DIR`, else
+    /// `<home>/<dataFolderName>` where `dataFolderName` is baked into the
+    /// Electron build's `product.json` — `.workbuddy` for the CN build,
+    /// `.workbuddy-ai` for the overseas one. Because the folder name is a build
+    /// artifact, this variant can only resolve the single highest-priority root;
+    /// every plausible root is enumerated by `scanner::workbuddy_home_candidates`
+    /// and callers that need full coverage must go through it.
+    WorkBuddyHome,
 }
 
 impl PathRoot {
@@ -96,6 +105,25 @@ impl PathRoot {
                 {
                     format!("{home_dir}/.reasonix")
                 }
+            }
+            // Mirrors the Electron app's own `resolveWorkbuddyConfigDir()`: an
+            // explicit env dir wins outright, otherwise the build-baked folder
+            // name is used. The macOS/Windows CN default is `.workbuddy`; the
+            // overseas build patches it to `.workbuddy-ai`, which this variant
+            // cannot see, hence the candidate enumeration in
+            // `scanner::workbuddy_home_candidates`.
+            PathRoot::WorkBuddyHome => {
+                if use_env_roots {
+                    for var in ["WORKBUDDY_CONFIG_DIR", "CODEBUDDY_CONFIG_DIR"] {
+                        if let Ok(val) = std::env::var(var) {
+                            let trimmed = val.trim();
+                            if !trimmed.is_empty() {
+                                return trimmed.to_string();
+                            }
+                        }
+                    }
+                }
+                format!("{home_dir}/.workbuddy")
             }
         }
     }
@@ -556,7 +584,7 @@ define_clients!(
     },
     WorkBuddy = 36 => {
         id: "workbuddy",
-        root: PathRoot::Home,
+        root: PathRoot::WorkBuddyHome,
         relative: ".workbuddy",
         pattern: "workbuddy.db",
         headless: false,

--- a/cli/tokens-core/src/scanner.rs
+++ b/cli/tokens-core/src/scanner.rs
@@ -572,6 +572,60 @@ fn hermes_home_candidates(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
     homes
 }
 
+/// Every plausible WorkBuddy data root, highest priority first.
+///
+/// WorkBuddy is an Electron app that picks its data root at launch instead of
+/// having the scanner assume one: `WORKBUDDY_CONFIG_DIR`, else
+/// `CODEBUDDY_CONFIG_DIR`, else `<home>/<dataFolderName>` where
+/// `dataFolderName` comes from the build's `product.json`. Only the last case is
+/// ambiguous — it is `.workbuddy` for the CN build and `.workbuddy-ai` for the
+/// overseas build — so both names are enumerated here. An explicit env dir is
+/// authoritative (the app ignores every other root in that case, and it may
+/// point at a portable or profile-isolated install), so it is returned alone.
+///
+/// Callers must test for real session data under each candidate rather than
+/// taking the first directory that exists. A machine that has run the overseas
+/// build has BOTH directories: `~/.workbuddy` holds only `logs/`, `binaries/`,
+/// `connectors/` and `settings.json` while the sessions live in `~/.workbuddy-ai`.
+/// `logs/` even contains `*.jsonl` startup records, so the presence of a
+/// directory or of JSONL is not a usable signal — `projects/` (or the
+/// `workbuddy.db` file) is.
+fn workbuddy_home_candidates(home_dir: &str, use_env_roots: bool) -> Vec<PathBuf> {
+    if use_env_roots {
+        for var in ["WORKBUDDY_CONFIG_DIR", "CODEBUDDY_CONFIG_DIR"] {
+            let Ok(value) = std::env::var(var) else {
+                continue;
+            };
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                return vec![PathBuf::from(trimmed)];
+            }
+        }
+    }
+
+    let mut homes: Vec<PathBuf> = Vec::new();
+    // Push order carries the priority, so duplicates are skipped in place
+    // instead of via `sort` + `dedup`: sorting would replace the priority order
+    // with a byte-lexical one that merely happens to agree for these two names.
+    for candidate in [
+        // `WorkBuddyHome` resolves the root only, so both entries here are
+        // interchangeable root paths.
+        PathBuf::from(
+            ClientId::WorkBuddy
+                .data()
+                .root
+                .resolve_with_env_strategy(home_dir, use_env_roots),
+        ),
+        PathBuf::from(home_dir).join(".workbuddy-ai"),
+    ] {
+        if !homes.contains(&candidate) {
+            homes.push(candidate);
+        }
+    }
+
+    homes
+}
+
 #[derive(Debug, Deserialize, Default)]
 struct CrushProjectList {
     #[serde(default)]
@@ -1226,6 +1280,13 @@ fn scan_all_clients_with_env_strategy_inner(
             continue;
         }
 
+        // WorkBuddy owns no single data root, so its `workbuddy.db` is picked up
+        // from every candidate home below rather than from the default relative
+        // path this loop would otherwise build.
+        if *client_id == ClientId::WorkBuddy {
+            continue;
+        }
+
         let def = client_id.data();
         let path = def.resolve_path_with_env_strategy(home_dir, use_env_roots);
         push_unique_scan_task(&mut tasks, &mut seen_scan_roots, *client_id, path);
@@ -1314,14 +1375,31 @@ fn scan_all_clients_with_env_strategy_inner(
         }
     }
 
+    // WorkBuddy stores per-message usage in `<root>/projects/**/*.jsonl`. The
+    // root itself is chosen by the installed build, so every candidate is wired
+    // up here; only the one holding `projects/` contributes anything. The
+    // aggregate `<root>/workbuddy.db` is registered alongside it below, and
+    // `merge_workbuddy_messages` drops its rows for any session that the JSONL
+    // already covers, so scanning both never double-counts.
     if enabled.contains(&ClientId::WorkBuddy) {
-        push_unique_scan_task_with_pattern(
-            &mut tasks,
-            &mut seen_scan_roots,
-            ClientId::WorkBuddy,
-            PathBuf::from(home_dir).join(".workbuddy/projects"),
-            "*.jsonl",
-        );
+        for workbuddy_home in workbuddy_home_candidates(home_dir, use_env_roots) {
+            push_unique_scan_task_with_pattern(
+                &mut tasks,
+                &mut seen_scan_roots,
+                ClientId::WorkBuddy,
+                workbuddy_home.join("projects"),
+                "*.jsonl",
+            );
+            // The first call borrows `workbuddy_home` to build the child path,
+            // so the root itself has to be cloned for this second registration.
+            push_unique_scan_task_with_pattern(
+                &mut tasks,
+                &mut seen_scan_roots,
+                ClientId::WorkBuddy,
+                workbuddy_home.clone(),
+                "workbuddy.db",
+            );
+        }
     }
 
     // Extra scan directories are part of the caller's environment, so they are

--- a/cli/tokens-core/src/sessions/workbuddy.rs
+++ b/cli/tokens-core/src/sessions/workbuddy.rs
@@ -1,8 +1,19 @@
 //! WorkBuddy session usage parser.
 //!
-//! WorkBuddy stores detailed token usage in `~/.workbuddy/projects/**/*.jsonl`.
-//! Older installs also expose an aggregate `~/.workbuddy/workbuddy.db`; that
-//! database is kept as a fallback when detailed token sources are unavailable.
+//! WorkBuddy stores detailed token usage in `<root>/projects/**/*.jsonl`.
+//! Older installs also expose an aggregate `<root>/workbuddy.db`; that database
+//! is kept as a fallback when detailed token sources are unavailable.
+//!
+//! `<root>` is not fixed: the Electron app resolves it from
+//! `WORKBUDDY_CONFIG_DIR`, else `CODEBUDDY_CONFIG_DIR`, else
+//! `<home>/<dataFolderName>` where `dataFolderName` is baked into the build's
+//! `product.json` — `.workbuddy` for the CN build, `.workbuddy-ai` for the
+//! overseas build. Discovery therefore goes through
+//! `scanner::workbuddy_home_candidates` rather than a single hardcoded path.
+//!
+//! This parser is also fed `logs/startup/*.jsonl` from an unrelated root when
+//! several candidate homes are scanned. Those records carry no `message` /
+//! `function_call` usage lines, so every one of them is filtered out below.
 
 use super::{normalize_workspace_key, workspace_label_from_key, UnifiedMessage};
 use crate::{provider_identity, TokenBreakdown};


### PR DESCRIPTION
## Problem

An overseas WorkBuddy install contributes **nothing** to `tokens` — not even the aggregate database fallback.

WorkBuddy picks its data root at launch rather than at compile time:

```js
// resolveWorkbuddyConfigDir()
const envDir = process.env.WORKBUDDY_CONFIG_DIR?.trim() || process.env.CODEBUDDY_CONFIG_DIR?.trim();
if (envDir) return envDir;
return path.join(os.homedir(), resolveWorkbuddyDataFolderName());

// resolveWorkbuddyDataFolderName() → product.json `dataFolderName`, default ".workbuddy"
```

`dataFolderName` is patched per build: `.workbuddy` for CN, **`.workbuddy-ai` for the overseas build**. The scanner assumed `.workbuddy` in two places:

| Location | Assumption |
|---|---|
| `clients.rs` — `WorkBuddy` client | `PathRoot::Home` + `relative: ".workbuddy"` → scans `~/.workbuddy/workbuddy.db` |
| `scanner.rs:1322` | literal `home_dir.join(".workbuddy/projects")` → scans `~/.workbuddy/projects/**/*.jsonl` |

On an overseas machine both directories exist, so the wrong one is silently scanned and the client is dropped from the scan entirely.

## Fix

Resolve the root the way the app does, and enumerate both build variants:

- **`PathRoot::WorkBuddyHome`** — `WORKBUDDY_CONFIG_DIR`, else `CODEBUDDY_CONFIG_DIR`, else `<home>/.workbuddy`
- **`scanner::workbuddy_home_candidates`** — returns the explicit env dir alone when set (the app ignores every other root in that case), otherwise both build variants in priority order. Mirrors the existing `hermes_home_candidates` shape
- `projects/**/*.jsonl` **and** `workbuddy.db` are registered under every candidate

## Why both sources are still registered

The JSONL is authoritative and the database is the fallback; `merge_workbuddy_messages` already drops database rows for any session the JSONL covers, so scanning both cannot double-count.

Discovery deliberately keys on `projects/` rather than on "the directory exists":

```
~/.workbuddy      → logs/ binaries/ connectors/ settings.json   (no projects/, no db)
~/.workbuddy-ai   → projects/**/*.jsonl + workbuddy.db
```

The stray `~/.workbuddy` is a real install, not an empty shell, and it even holds `logs/startup/*.jsonl` — so neither "directory exists" nor "contains JSONL" is a usable signal. Those log records carry no `message` / `function_call` usage lines and are filtered out by the parser.

## Verification

Measured against a real overseas install:

| | tokens |
|---|---|
| Before | 0 |
| After | 90,713,467 (10 sessions) |
| Database fallback alone | 566,903 |

`~/.workbuddy` users are unaffected: with no env dir set and no `.workbuddy-ai` present, the candidate list resolves to exactly `~/.workbuddy`, and the registered paths are byte-identical to the previous two.

## Caveat on CI

I could not compile locally — no Rust toolchain on this machine — so `cargo clippy -D warnings` has not been run. The changes are std-only (no new dependencies, `edition = "2021"`, so `let … else` is available).

## Notes

- `clients.rs`'s `relative` is left at `.workbuddy`; it is now unreachable for WorkBuddy (the generic loop skips the client), and the diff keeps it that way rather than churning a field nothing reads.
- `sessions/workbuddy.rs`'s module docs are updated: the root is no longer fixed.
